### PR TITLE
Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+# Pre-commit hooks for JPEC repository
+# Install: pip install pre-commit
+# Setup: pre-commit install
+# Run manually: pre-commit run --all-files
+
+default_language_version:
+  python: python3.10
+
+repos:
+  # Jupyter notebook cleaning - removes outputs, execution counts, metadata
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.7.1
+    hooks:
+      - id: nbstripout
+        name: Strip notebook outputs
+        args:
+          - --extra-keys
+          - |
+            metadata.kernelspec metadata.language_info.version
+            cell.metadata.executionInfo cell.metadata.colab
+            cell.metadata.id cell.metadata.scrolled
+
+  # General file cleanup
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+        name: Trim trailing whitespace
+      - id: end-of-file-fixer
+        name: Fix end of files
+      - id: check-yaml
+        name: Check YAML syntax
+      - id: check-toml
+        name: Check TOML syntax
+      - id: check-added-large-files
+        name: Prevent large files
+        args: ['--maxkb=5000']
+      - id: mixed-line-ending
+        name: Fix line endings
+        args: ['--fix=lf']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,10 @@ repos:
       - id: mixed-line-ending
         name: Fix line endings
         args: ['--fix=lf']
+
+  # Julia code formatting
+  - repo: https://github.com/domluna/JuliaFormatter.jl
+    rev: v1.0.62
+    hooks:
+      - id: julia-formatter
+        name: Format Julia code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,3 +143,4 @@ This format is used for compiling release notes, so tags should be human-readabl
 - The Vacuum module is actively being converted from Fortran to Julia (see `vacuum_julia` branch)
 - When modifying equilibrium code, remember to update diagnostic outputs (gsec.h5, gse.h5, gsei.h5)
 - The codebase uses 0-based indexing in many places to match Fortran conventions, then converts to 1-based Julia indexing
+- Pre-commit hooks are configured for notebook cleaning and Julia formatting (see `docs/src/set_up.md` for developer setup)

--- a/docs/src/set_up.md
+++ b/docs/src/set_up.md
@@ -190,6 +190,9 @@ Pre-commit hooks automatically:
 # Install pre-commit (requires Python/pip)
 pip install pre-commit
 
+# Install JuliaFormatter globally (required for Julia code formatting hook)
+julia -e 'using Pkg; Pkg.add("JuliaFormatter")'
+
 # Install the git hooks in your local repository
 cd /path/to/JPEC
 pre-commit install

--- a/docs/src/set_up.md
+++ b/docs/src/set_up.md
@@ -1,13 +1,14 @@
-# Setting up JPEC 
+# Setting up JPEC
 
 - [Setting up JPEC](#setting-up-jpec)
   - [On Windows via WSL (Ubuntu)](#on-windows-via-wsl-ubuntu)
   - [On macOS](#on-macos)
+  - [Pre-commit Hooks (Optional Developer Tools)](#pre-commit-hooks-optional-developer-tools)
 
 ## On Windows via WSL (Ubuntu)
 1. Install WSL and Ubuntu
    If you don't already have WSL and Ubuntu installed, set this up. [This page](https://learn.microsoft.com/en-us/windows/wsl/install) gives detailed instructions on how to complete the installation. In the Windows Powershell,
-   
+
    1. Make sure WSL is installed:
         ```PowerShell
         wsl --install
@@ -32,9 +33,9 @@
     `cmake` → sometimes needed by dependencies
 
 3. Install Julia in WSL
-   
+
     1. Download the latest Linux tarball from the official site [Julia downloads](https://julialang.org/downloads/). It will look like
-        ```shell 
+        ```shell
         wget https://julialang-s3.julialang.org/bin/linux/x64/1.11/julia-1.11.3-linux-x86_64.tar.gz
         ```
 
@@ -46,12 +47,12 @@
         tar -xvzf julia-1.11.3-linux-x86_64.tar.gz
         sudo mv julia-1.11.3 /opt/
         ```
-        
+
         ☆ Ensure these commands match the tarball you installed. These commands match the above tarball and might need to be modified for you installation.
-    
+
     3. Add Julia to PATH:
 
-        ```shell 
+        ```shell
         echo 'export PATH=/opt/julia-1.11.3/bin:$PATH' >> ~/.bashrc
         source ~/.bashrc
         ```
@@ -59,12 +60,12 @@
     4. Test it is properly installed
 
         ```shell
-        julia --version 
+        julia --version
         ```
 
-4. Install Python/Jupyter in WSL 
-   
-   This step is only really required if you want to run the `.ipynb` test notebooks. You do not necessarily need Python3 installed, but Jupyter runs on a Python server. 
+4. Install Python/Jupyter in WSL
+
+   This step is only really required if you want to run the `.ipynb` test notebooks. You do not necessarily need Python3 installed, but Jupyter runs on a Python server.
    If you do not want to install Python3 and Jupyter, you can install the "IJulia" package to your Julia environment instead and run the command 'notebook()' in the terminal.
    1. To install Python3 and Jupyter notebooks, use these commands
         ```shell
@@ -130,7 +131,7 @@ Clone it from GitHub directly to your virtual machine.
         Pkg.instantiate()       # install recorded dependencies
         Pkg.add("Preferences")  # install missing dependency if needed
         Pkg.build("IJulia")     # rebuild kernel
-        Pkg.precompile()        # precompile all packages - probably unnecessary 
+        Pkg.precompile()        # precompile all packages - probably unnecessary
         ```
 
 8. At this point, you should be able to run the code, open a `.ipynb` notebook, or connect VS Code to your WSL session.
@@ -147,9 +148,9 @@ Clone it from GitHub directly to your virtual machine.
         1. Install **Remote - WSL** extension in VS Code.
         2. Open VS Code → Connect To → Connect to WSL.
         3. Click Open Folder and then navigate to the JPEC folder on your VM. Open your JPEC folder from WSL: ~/JPEC.
-   
+
         If this is not working, you can launch vscode from the WSL shell you have using the command `code .`
-        
+
         4. Open a terminal inside VS Code — it will automatically use WSL/Ubuntu.
         5. You can now run:
             ```shell
@@ -167,3 +168,66 @@ Clone it from GitHub directly to your virtual machine.
             ```
 
 ## On macOS
+
+(Setup instructions to be added)
+
+## Pre-commit Hooks (Optional Developer Tools)
+
+The repository uses pre-commit hooks to maintain code quality and prevent noisy commits from Jupyter notebook metadata and outputs.
+
+### Why Use Pre-commit Hooks?
+
+Pre-commit hooks automatically:
+- Strip Jupyter notebook outputs, execution counts, and metadata (prevents merge conflicts and noisy diffs)
+- Format Julia code according to `.JuliaFormatter.toml` settings
+- Remove trailing whitespace and fix line endings
+- Validate YAML/TOML syntax
+- Prevent accidentally committing large files (>5MB)
+
+### Installation
+
+```bash
+# Install pre-commit (requires Python/pip)
+pip install pre-commit
+
+# Install the git hooks in your local repository
+cd /path/to/JPEC
+pre-commit install
+```
+
+### Usage
+
+Once installed, the hooks run automatically on `git commit`. You can also run them manually:
+
+```bash
+# Run on all files in the repository
+pre-commit run --all-files
+
+# Run only on currently staged files
+pre-commit run
+```
+
+### Bypassing Hooks (Not Recommended)
+
+In rare cases where you need to bypass the hooks:
+
+```bash
+git commit --no-verify
+```
+
+However, this is discouraged as it may introduce notebook clutter or formatting inconsistencies.
+
+### Optional: Standalone nbstripout Filter
+
+For additional protection beyond pre-commit, you can install nbstripout as a git filter:
+
+```bash
+# Install nbstripout globally
+pip install nbstripout
+
+# Install filter for this repository
+cd /path/to/JPEC
+nbstripout --install
+```
+
+This ensures notebooks are cleaned even if pre-commit is bypassed with `--no-verify`. However, this is **optional** and not required for normal development - the pre-commit hook is sufficient for most workflows.


### PR DESCRIPTION
This branch adds a pre-commit yml file that cleans up the notebook meta data and outputs so we stop recording silly changes whenever anyone runs a notebook. 

I made it a pre-commit so developers have to opt in by installing the pre-commit functionality and initializing it for their local repo. The alternative is to make it a hook, which would then be forced on anyone making any commit... I am open to thoughts on wether we should switch to this strict approach.

I also added a Julia Formatter. I think it would be valuable to enforce a standard of formatting, which makes the code more coherent and readable. I don't want to be overly prescriptive, but some consistent basics are good imo. I am also open to thoughts on this: should we add more prescriptions? Make it less prescriptive? Not use it? 