### PR TITLE
Test/threading for loops (NOT READY)

### DIFF
--- a/benchmarks/equil_thread_rank_1_15.jl
+++ b/benchmarks/equil_thread_rank_1_15.jl
@@ -1,23 +1,32 @@
 #!/usr/bin/env julia
-"""
-Run `setup_equilibrium` in fresh subprocesses with `-t 1` … `-t 15`, collect
-wall times, then print a table ranked **slowest → fastest** (highest runtime first).
+#=
+Run setup_equilibrium in fresh subprocesses with -t 1 … -t 15, collect wall times,
+then print a table ranked slowest → fastest (highest runtime first).
 
-Usage (from JPEC root):
+Child processes use --startup-file=no and BLAS/OpenMP env vars set to 1 thread so
+Julia's -t n scaling is not fought by nested linear-algebra threading.
+
+Usage (from JPEC package root):
     julia --project=. benchmarks/equil_thread_rank_1_15.jl
     julia --project=. benchmarks/equil_thread_rank_1_15.jl path/to/example_dir
 
-Requires `benchmarks/equil_thread_worker.jl` (same directory).
-"""
+WSL (Ubuntu, etc.):
+    cd /mnt/c/Users/<you>/PlasmaLab/JPEC   (or clone under ~/ for better I/O)
+    julia --project=. benchmarks/equil_thread_rank_1_15.jl
+
+Requires benchmarks/equil_thread_worker.jl (same directory).
+=#
 using Pkg
 Pkg.activate(joinpath(@__DIR__, ".."))
 
 using Printf
 
 function main()
-    example_dir = get(ARGS, 1, joinpath(@__DIR__, "..", "examples", "DIIID-like_ideal_example"))
-    proj = joinpath(@__DIR__, "..")
-    worker = joinpath(@__DIR__, "equil_thread_worker.jl")
+    example_dir = abspath(get(ARGS, 1, joinpath(@__DIR__, "..", "examples", "DIIID-like_ideal_example")))
+    proj = abspath(joinpath(@__DIR__, ".."))
+    worker = abspath(joinpath(@__DIR__, "equil_thread_worker.jl"))
+    isdir(example_dir) || error("Example directory not found: $example_dir")
+    isfile(joinpath(example_dir, "gpec.toml")) || error("Missing gpec.toml in $example_dir")
 
     println("="^60)
     println("Thread sweep: 1–15 (subprocess per count, warmup+timed in worker)")
@@ -26,13 +35,28 @@ function main()
 
     results = Tuple{Int,Float64}[]
     for n in 1:15
-        cmd = `$(Base.julia_cmd()) -t $n --project=$proj $worker $example_dir`
+        cmd = addenv(
+            `$(Base.julia_cmd()) --startup-file=no -t $n --project=$proj $worker $example_dir`,
+            "OPENBLAS_NUM_THREADS" => "1",
+            "MKL_NUM_THREADS" => "1",
+            "OMP_NUM_THREADS" => "1",
+            "VECLIB_MAXIMUM_THREADS" => "1",
+            "NUMEXPR_NUM_THREADS" => "1",
+        )
         @printf("  Running -t %2d ... ", n)
         flush(stdout)
         out = read(cmd, String)
         lines = filter(!isempty, strip.(split(out, '\n')))
-        # Last non-empty line should be the timing float (worker may print nothing else on stdout)
-        t = parse(Float64, lines[end])
+        t = nothing
+        for line in reverse(lines)
+            v = tryparse(Float64, line)
+            if v !== nothing
+                t = v
+                break
+            end
+        end
+        t === nothing && error("Could not parse timing from worker stdout:\n$out")
+        t = t::Float64
         push!(results, (n, t))
         @printf("%.4f s\n", t)
     end

--- a/benchmarks/equil_thread_rank_1_15.jl
+++ b/benchmarks/equil_thread_rank_1_15.jl
@@ -1,0 +1,57 @@
+#!/usr/bin/env julia
+"""
+Run `setup_equilibrium` in fresh subprocesses with `-t 1` … `-t 15`, collect
+wall times, then print a table ranked **slowest → fastest** (highest runtime first).
+
+Usage (from JPEC root):
+    julia --project=. benchmarks/equil_thread_rank_1_15.jl
+    julia --project=. benchmarks/equil_thread_rank_1_15.jl path/to/example_dir
+
+Requires `benchmarks/equil_thread_worker.jl` (same directory).
+"""
+using Pkg
+Pkg.activate(joinpath(@__DIR__, ".."))
+
+using Printf
+
+function main()
+    example_dir = get(ARGS, 1, joinpath(@__DIR__, "..", "examples", "DIIID-like_ideal_example"))
+    proj = joinpath(@__DIR__, "..")
+    worker = joinpath(@__DIR__, "equil_thread_worker.jl")
+
+    println("="^60)
+    println("Thread sweep: 1–15 (subprocess per count, warmup+timed in worker)")
+    println("Example: $example_dir")
+    println("="^60)
+
+    results = Tuple{Int,Float64}[]
+    for n in 1:15
+        cmd = `$(Base.julia_cmd()) -t $n --project=$proj $worker $example_dir`
+        @printf("  Running -t %2d ... ", n)
+        flush(stdout)
+        out = read(cmd, String)
+        lines = filter(!isempty, strip.(split(out, '\n')))
+        # Last non-empty line should be the timing float (worker may print nothing else on stdout)
+        t = parse(Float64, lines[end])
+        push!(results, (n, t))
+        @printf("%.4f s\n", t)
+    end
+
+    sorted = sort(results; by=x -> x[2], rev=true)
+
+    println()
+    println("="^60)
+    println("Ranked by runtime (slowest → fastest, i.e. highest s first)")
+    println("="^60)
+    @printf("%-6s %-10s %s\n", "Rank", "Threads", "Seconds")
+    println("-"^60)
+    for (rank, (nt, t)) in enumerate(sorted)
+        @printf("%-6d %-10d %.6f\n", rank, nt, t)
+    end
+    println("="^60)
+
+    best = argmin(x -> x[2], results)
+    @printf("\nFastest: %d threads (%.6f s)\n", best[1], best[2])
+end
+
+main()

--- a/benchmarks/equil_thread_rank_1_15.jl
+++ b/benchmarks/equil_thread_rank_1_15.jl
@@ -34,6 +34,7 @@ function main()
     println("="^60)
 
     results = Tuple{Int,Float64}[]
+    failures = Tuple{Int,String}[]
     for n in 1:15
         cmd = addenv(
             `$(Base.julia_cmd()) --startup-file=no -t $n --project=$proj $worker $example_dir`,
@@ -45,22 +46,28 @@ function main()
         )
         @printf("  Running -t %2d ... ", n)
         flush(stdout)
-        out = read(cmd, String)
-        lines = filter(!isempty, strip.(split(out, '\n')))
-        t = nothing
-        for line in reverse(lines)
-            v = tryparse(Float64, line)
-            if v !== nothing
-                t = v
-                break
+        try
+            out = read(cmd, String)
+            lines = filter(!isempty, strip.(split(out, '\n')))
+            t = nothing
+            for line in reverse(lines)
+                v = tryparse(Float64, line)
+                if v !== nothing
+                    t = v
+                    break
+                end
             end
+            t === nothing && error("Could not parse timing from worker stdout:\n$out")
+            t = t::Float64
+            push!(results, (n, t))
+            @printf("%.4f s\n", t)
+        catch err
+            push!(failures, (n, sprint(showerror, err)))
+            @printf("FAILED\n")
         end
-        t === nothing && error("Could not parse timing from worker stdout:\n$out")
-        t = t::Float64
-        push!(results, (n, t))
-        @printf("%.4f s\n", t)
     end
 
+    isempty(results) && error("All thread counts failed; no timings to rank.")
     sorted = sort(results; by=x -> x[2], rev=true)
 
     println()
@@ -76,6 +83,10 @@ function main()
 
     best = argmin(x -> x[2], results)
     @printf("\nFastest: %d threads (%.6f s)\n", best[1], best[2])
+    if !isempty(failures)
+        failed_threads = join(first.(failures), ", ")
+        @printf("Failed thread counts (excluded): %s\n", failed_threads)
+    end
 end
 
 main()

--- a/benchmarks/equil_thread_worker.jl
+++ b/benchmarks/equil_thread_worker.jl
@@ -1,6 +1,6 @@
 #!/usr/bin/env julia
-"""
-One full `setup_equilibrium` run; prints a single wall-time (seconds) to stdout
+#=
+One full setup_equilibrium run; prints a single wall-time (seconds) to stdout
 for use by thread-sweep drivers. Logging from the solver may go to stderr.
 
 Usage:
@@ -8,7 +8,10 @@ Usage:
 
 Default example: examples/DIIID-like_ideal_example (relative to JPEC root).
 Expects gpec.toml inside the example directory.
-"""
+
+WSL: use Linux paths (e.g. /mnt/c/Users/.../JPEC or a clone under $HOME for faster I/O).
+The example path is resolved with abspath relative to your current working directory if relative.
+=#
 using Pkg
 Pkg.activate(joinpath(@__DIR__, ".."))
 
@@ -17,10 +20,11 @@ using GeneralizedPerturbedEquilibrium
 using GeneralizedPerturbedEquilibrium.Equilibrium
 
 function main()
-    base = get(ARGS, 1, joinpath(@__DIR__, "..", "examples", "DIIID-like_ideal_example"))
+    base = abspath(get(ARGS, 1, joinpath(@__DIR__, "..", "examples", "DIIID-like_ideal_example")))
     config_path = joinpath(base, "gpec.toml")
+    isfile(config_path) || error("Missing gpec.toml at $config_path (use a Linux path on WSL, e.g. /mnt/c/Users/... or ~/PlasmaLab/...)")
     raw = TOML.parsefile(config_path)
-    cfg = EquilibriumConfig(raw["Equilibrium"], dirname(config_path))
+    cfg = Equilibrium.EquilibriumConfig(raw["Equilibrium"], dirname(config_path))
 
     setup_equilibrium(cfg)  # JIT / cache warmup
     t = @elapsed setup_equilibrium(cfg)

--- a/benchmarks/equil_thread_worker.jl
+++ b/benchmarks/equil_thread_worker.jl
@@ -1,0 +1,30 @@
+#!/usr/bin/env julia
+"""
+One full `setup_equilibrium` run; prints a single wall-time (seconds) to stdout
+for use by thread-sweep drivers. Logging from the solver may go to stderr.
+
+Usage:
+    julia -t N --project=. benchmarks/equil_thread_worker.jl [path_to_example_dir]
+
+Default example: examples/DIIID-like_ideal_example (relative to JPEC root).
+Expects gpec.toml inside the example directory.
+"""
+using Pkg
+Pkg.activate(joinpath(@__DIR__, ".."))
+
+using TOML
+using GeneralizedPerturbedEquilibrium
+using GeneralizedPerturbedEquilibrium.Equilibrium
+
+function main()
+    base = get(ARGS, 1, joinpath(@__DIR__, "..", "examples", "DIIID-like_ideal_example"))
+    config_path = joinpath(base, "gpec.toml")
+    raw = TOML.parsefile(config_path)
+    cfg = EquilibriumConfig(raw["Equilibrium"], dirname(config_path))
+
+    setup_equilibrium(cfg)  # JIT / cache warmup
+    t = @elapsed setup_equilibrium(cfg)
+    println(t)
+end
+
+main()

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -634,44 +634,52 @@ robustness.
     mpsi = length(psi_nodes) - 1
     theta_nodes = range(0.0, 1.0; length=mtheta + 1)
 
-    sq_nodes = zeros!(pool, Float64, mpsi + 1, 4)
-    rzphi_nodes = zeros!(pool, Float64, mpsi + 1, mtheta + 1, 4)
+    nt = Threads.nthreads()
+    # Avoid the Float64 pool under @threads: concurrent pool access can corrupt arrays.
+    sq_nodes = nt > 1 ? zeros(Float64, mpsi + 1, 4) : zeros!(pool, Float64, mpsi + 1, 4)
+    rzphi_nodes = nt > 1 ? zeros(Float64, mpsi + 1, mtheta + 1, 4) : zeros!(pool, Float64, mpsi + 1, mtheta + 1, 4)
 
-    t_flux_surfaces = @elapsed if Threads.nthreads() > 1
-        Threads.@threads for ipsi in 1:(mpsi+1)
-            y_out, bfield = fieldline_int(psi_nodes[ipsi], raw_profile, ro, zo, rs2; use_pool=false)
+    t_flux_surfaces = @elapsed if nt > 1
+        # Splines are not safe for concurrent eval on one instance — deepcopy per thread.
+        # Strided loops bind one profile per OS thread for the whole inner loop (no threadid() mixups).
+        raw_per_thread = [deepcopy(raw_profile) for _ in 1:nt]
+        Threads.@threads for tid in 1:nt
+            rp = raw_per_thread[tid]
+            for ipsi in tid:nt:(mpsi+1)
+                y_out, bfield = fieldline_int(psi_nodes[ipsi], rp, ro, zo, rs2; use_pool=false)
 
-            npt = size(y_out, 1)
-            ff_x_nodes = Vector{Float64}(undef, npt)
-            @. ff_x_nodes = @view(y_out[:, 5]) / y_out[end, 5]
+                npt = size(y_out, 1)
+                ff_x_nodes = Vector{Float64}(undef, npt)
+                @. ff_x_nodes = @view(y_out[:, 5]) / y_out[end, 5]
 
-            ff_fs_nodes = Matrix{Float64}(undef, npt, 4)
-            @. ff_fs_nodes[:, 1] = @view(y_out[:, 3]) ^ 2
-            @. ff_fs_nodes[:, 2] = @view(y_out[:, 1]) / (2π) - ff_x_nodes
-            @. ff_fs_nodes[:, 3] = bfield.f * (@view(y_out[:, 4]) - ff_x_nodes * y_out[end, 4])
-            @. ff_fs_nodes[:, 4] = @view(y_out[:, 2]) / y_out[end, 2] - ff_x_nodes
+                ff_fs_nodes = Matrix{Float64}(undef, npt, 4)
+                @. ff_fs_nodes[:, 1] = @view(y_out[:, 3]) ^ 2
+                @. ff_fs_nodes[:, 2] = @view(y_out[:, 1]) / (2π) - ff_x_nodes
+                @. ff_fs_nodes[:, 3] = bfield.f * (@view(y_out[:, 4]) - ff_x_nodes * y_out[end, 4])
+                @. ff_fs_nodes[:, 4] = @view(y_out[:, 2]) / y_out[end, 2] - ff_x_nodes
 
-            ff_fs_nodes[end, :] .= ff_fs_nodes[1, :]
+                ff_fs_nodes[end, :] .= ff_fs_nodes[1, :]
 
-            ff_interp = cubic_interp(ff_x_nodes, ff_fs_nodes; bc=PeriodicBC())
-            ff_deriv = deriv1(ff_interp)
+                ff_interp = cubic_interp(ff_x_nodes, ff_fs_nodes; bc=PeriodicBC())
+                ff_deriv = deriv1(ff_interp)
 
-            ff_val = Vector{Float64}(undef, 4)
-            ff_deriv_val = Vector{Float64}(undef, 4)
-            for itheta in 1:(mtheta+1)
-                theta = theta_nodes[itheta]
-                ff_interp(ff_val, theta)
-                ff_deriv(ff_deriv_val, theta)
-                rzphi_nodes[ipsi, itheta, 1] = ff_val[1]
-                rzphi_nodes[ipsi, itheta, 2] = ff_val[2]
-                rzphi_nodes[ipsi, itheta, 3] = ff_val[3]
-                rzphi_nodes[ipsi, itheta, 4] = (1.0 + ff_deriv_val[4]) * y_out[end, 2] * 2π * psio
+                ff_val = Vector{Float64}(undef, 4)
+                ff_deriv_val = Vector{Float64}(undef, 4)
+                for itheta in 1:(mtheta+1)
+                    theta = theta_nodes[itheta]
+                    ff_interp(ff_val, theta)
+                    ff_deriv(ff_deriv_val, theta)
+                    rzphi_nodes[ipsi, itheta, 1] = ff_val[1]
+                    rzphi_nodes[ipsi, itheta, 2] = ff_val[2]
+                    rzphi_nodes[ipsi, itheta, 3] = ff_val[3]
+                    rzphi_nodes[ipsi, itheta, 4] = (1.0 + ff_deriv_val[4]) * y_out[end, 2] * 2π * psio
+                end
+
+                sq_nodes[ipsi, 1] = bfield.f * 2π
+                sq_nodes[ipsi, 2] = bfield.p
+                sq_nodes[ipsi, 3] = y_out[end, 2] * 2π * psio
+                sq_nodes[ipsi, 4] = y_out[end, 4] * bfield.f / (2π)
             end
-
-            sq_nodes[ipsi, 1] = bfield.f * 2π
-            sq_nodes[ipsi, 2] = bfield.p
-            sq_nodes[ipsi, 3] = y_out[end, 2] * 2π * psio
-            sq_nodes[ipsi, 4] = y_out[end, 4] * bfield.f / (2π)
         end
     else
         ff_val = zeros!(pool, Float64, 4)
@@ -711,6 +719,12 @@ robustness.
             sq_nodes[ipsi, 4] = y_out[end, 4] * bfield.f / (2π)
             rewind!(pool, Float64)
         end
+    end
+
+    # θ ∈ [0,1] is periodic; first/last nodes are the same poloidal location. FastInterpolations
+    # PeriodicBC requires exact nodal match on dim 2 — align after parallel fills (also fixes tiny θ=0 vs θ=1 eval drift).
+    @inbounds for ipsi in 1:(mpsi+1)
+        @views rzphi_nodes[ipsi, end, :] .= rzphi_nodes[ipsi, 1, :]
     end
 
     # Temporary splines for q0 extrapolation and optional newq0 revision
@@ -818,6 +832,10 @@ robustness.
                 eqfun_fs_nodes[ipsi, itheta, 3] = 0.0
             end
         end
+    end
+
+    @inbounds for ipsi in 1:(mpsi+1)
+        @views eqfun_fs_nodes[ipsi, end, :] .= eqfun_fs_nodes[ipsi, 1, :]
     end
 
     t_eqfun_interpolants = @elapsed begin

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -41,6 +41,9 @@ struct FieldLineDerivParams{I2D<:FastInterpolations.CubicInterpolantND,S<:FastIn
     power_r::Int
     power_rc::Int  # minor radius rfac = √((R-R₀)²+(Z-Z₀)²) power exponent
     bfield::DirectBField
+    # When set, use buffers instead of pool (thread-safe for parallel flux-surface loops)
+    f_sq_buf::Union{Nothing,Vector{Float64}}
+    f1_sq_buf::Union{Nothing,Vector{Float64}}
 end
 
 """
@@ -110,6 +113,62 @@ the Julia spline implementation.
     (derivs == 1) && return
 
     # Evaluate more derivatives of B-field components
+    bf_out.brr = (bf_out.psirz - bf_out.br) / r
+    bf_out.brz = bf_out.psizz / r
+    bf_out.bzr = -(bf_out.psirr + bf_out.bz) / r
+    bf_out.bzz = -bf_out.psirz / r
+end
+
+"""
+    direct_get_bfield!_buf!(bf_out, r, z, psi_in, sq_in, sq_in_deriv, psio, f_sq_buf, f1_sq_buf; derivs=0)
+
+Same as `direct_get_bfield!` but uses pre-allocated `f_sq_buf` and `f1_sq_buf` instead of the pool.
+Thread-safe for use inside `Threads.@threads` (parallel flux-surface integration).
+"""
+function direct_get_bfield!_buf!(
+    bf_out::DirectBField,
+    r::Float64,
+    z::Float64,
+    psi_in::FastInterpolations.CubicInterpolantND,
+    sq_in::FastInterpolations.CubicSeriesInterpolant,
+    sq_in_deriv,
+    psio::Float64,
+    f_sq_buf::Vector,
+    f1_sq_buf::Vector;
+    derivs::Int=0
+)
+    if derivs == 0
+        bf_out.psi = psi_in((r, z))
+    elseif derivs == 1
+        bf_out.psi = psi_in((r, z))
+        bf_out.psir = psi_in((r, z); deriv=Val((1, 0)))
+        bf_out.psiz = psi_in((r, z); deriv=Val((0, 1)))
+    else
+        bf_out.psi = psi_in((r, z))
+        bf_out.psir = psi_in((r, z); deriv=Val((1, 0)))
+        bf_out.psiz = psi_in((r, z); deriv=Val((0, 1)))
+        bf_out.psirr = psi_in((r, z); deriv=Val((2, 0)))
+        bf_out.psirz = psi_in((r, z); deriv=Val((1, 1)))
+        bf_out.psizz = psi_in((r, z); deriv=Val((0, 2)))
+    end
+
+    psi_norm = (psio > 1e-12) ? (1.0 - bf_out.psi / psio) : 0.0
+    psi_norm = clamp(psi_norm, 0.0, 1.0)
+
+    sq_in(f_sq_buf, psi_norm)
+    sq_in_deriv(f1_sq_buf, psi_norm)
+    bf_out.f = f_sq_buf[1]
+    bf_out.f1 = f1_sq_buf[1]
+    bf_out.p = f_sq_buf[2]
+    bf_out.p1 = f1_sq_buf[2]
+
+    (derivs == 0) && return
+
+    bf_out.br = bf_out.psiz / r
+    bf_out.bz = -bf_out.psir / r
+
+    (derivs == 1) && return
+
     bf_out.brr = (bf_out.psirz - bf_out.br) / r
     bf_out.brz = bf_out.psizz / r
     bf_out.bzr = -(bf_out.psirr + bf_out.bz) / r
@@ -242,7 +301,7 @@ from 1:5 rather than 0:4 as in Fortran.
 
   - `bfield`: A `DirectBField` object with values at the integration start point.
 """
-function direct_fieldline_int(psifac::Float64, raw_profile::DirectRunInput, ro::Float64, zo::Float64, rs2::Float64)::Tuple{Matrix{Float64},DirectBField}
+function direct_fieldline_int(psifac::Float64, raw_profile::DirectRunInput, ro::Float64, zo::Float64, rs2::Float64; use_pool::Bool=true)::Tuple{Matrix{Float64},DirectBField}
 
     # Find the starting point on the flux surface (outboard midplane)
     psi0_guess = raw_profile.psio * (1.0 - psifac)
@@ -251,15 +310,31 @@ function direct_fieldline_int(psifac::Float64, raw_profile::DirectRunInput, ro::
     bfield = DirectBField()
     sq_in_deriv = deriv1(raw_profile.sq_in)
 
+    f_sq_buf = nothing
+    f1_sq_buf = nothing
+    if !use_pool
+        n = n_series(raw_profile.sq_in)
+        f_sq_buf = Vector{Float64}(undef, n)
+        f1_sq_buf = Vector{Float64}(undef, n)
+    end
+
     # Refine starting R: find r where ψ(r, zo) = ψ₀. The df closure reads bfield.psir
     # which is populated by the preceding f call — Newton guarantees f is evaluated first.
-    r = find_zero(
-        (r -> (direct_get_bfield!(bfield, r, z, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio; derivs=1); bfield.psi - psi0_guess),
-            _ -> bfield.psir),
-        r, Roots.Newton()
-    )
-
-    direct_get_bfield!(bfield, r, z, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio; derivs=2)
+    if use_pool
+        r = find_zero(
+            (r -> (direct_get_bfield!(bfield, r, z, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio; derivs=1); bfield.psi - psi0_guess),
+                _ -> bfield.psir),
+            r, Roots.Newton()
+        )
+        direct_get_bfield!(bfield, r, z, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio; derivs=2)
+    else
+        r = find_zero(
+            (r -> (direct_get_bfield!_buf!(bfield, r, z, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio, f_sq_buf, f1_sq_buf; derivs=1); bfield.psi - psi0_guess),
+                _ -> bfield.psir),
+            r, Roots.Newton()
+        )
+        direct_get_bfield!_buf!(bfield, r, z, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio, f_sq_buf, f1_sq_buf; derivs=2)
+    end
     psi0 = bfield.psi
 
     # Set up and solve the ODE for fieldline following
@@ -270,7 +345,7 @@ function direct_fieldline_int(psifac::Float64, raw_profile::DirectRunInput, ro::
     bfield = DirectBField()
     equil_config = raw_profile.config
     params = FieldLineDerivParams(ro, zo, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio,
-        equil_config.power_bp, equil_config.power_b, equil_config.power_r, equil_config.power_rc, bfield)
+        equil_config.power_bp, equil_config.power_b, equil_config.power_r, equil_config.power_rc, bfield, f_sq_buf, f1_sq_buf)
 
     # Use a callback to refine the solution at each step to stay on the flux surface
     function refine_affect!(integrator)
@@ -306,7 +381,11 @@ function direct_fieldline_der!(dy, y, params::FieldLineDerivParams, eta)
     cos_eta, sin_eta = cos(eta), sin(eta)
     r = params.ro + y[2] * cos_eta
     z = params.zo + y[2] * sin_eta
-    direct_get_bfield!(params.bfield, r, z, params.psi_in, params.sq_in, params.sq_in_deriv, params.psio; derivs=1)
+    if params.f_sq_buf !== nothing
+        direct_get_bfield!_buf!(params.bfield, r, z, params.psi_in, params.sq_in, params.sq_in_deriv, params.psio, params.f_sq_buf, params.f1_sq_buf; derivs=1)
+    else
+        direct_get_bfield!(params.bfield, r, z, params.psi_in, params.sq_in, params.sq_in_deriv, params.psio; derivs=1)
+    end
 
     bp = sqrt(params.bfield.br^2 + params.bfield.bz^2)
     bt = params.bfield.f / r
@@ -356,16 +435,26 @@ function direct_refine(rfac::Float64, eta::Float64, psi0::Float64, params::Field
     function f(rfac_inner)
         r = params.ro + rfac_inner * cos_eta
         z = params.zo + rfac_inner * sin_eta
-        direct_get_bfield!(params.bfield, r, z, params.psi_in, params.sq_in,
-            params.sq_in_deriv, params.psio; derivs=0)
+        if params.f_sq_buf !== nothing
+            direct_get_bfield!_buf!(params.bfield, r, z, params.psi_in, params.sq_in,
+                params.sq_in_deriv, params.psio, params.f_sq_buf, params.f1_sq_buf; derivs=0)
+        else
+            direct_get_bfield!(params.bfield, r, z, params.psi_in, params.sq_in,
+                params.sq_in_deriv, params.psio; derivs=0)
+        end
         return params.bfield.psi - psi0
     end
 
     function fp(rfac_inner)
         r = params.ro + rfac_inner * cos_eta
         z = params.zo + rfac_inner * sin_eta
-        direct_get_bfield!(params.bfield, r, z, params.psi_in, params.sq_in,
-            params.sq_in_deriv, params.psio; derivs=1)
+        if params.f_sq_buf !== nothing
+            direct_get_bfield!_buf!(params.bfield, r, z, params.psi_in, params.sq_in,
+                params.sq_in_deriv, params.psio, params.f_sq_buf, params.f1_sq_buf; derivs=1)
+        else
+            direct_get_bfield!(params.bfield, r, z, params.psi_in, params.sq_in,
+                params.sq_in_deriv, params.psio; derivs=1)
+        end
         return params.bfield.psir * cos_eta + params.bfield.psiz * sin_eta
     end
 
@@ -547,45 +636,81 @@ robustness.
 
     sq_nodes = zeros!(pool, Float64, mpsi + 1, 4)
     rzphi_nodes = zeros!(pool, Float64, mpsi + 1, mtheta + 1, 4)
-    ff_val = zeros!(pool, Float64, 4)
-    ff_deriv_val = zeros!(pool, Float64, 4)
 
-    for ipsi in (mpsi+1):-1:1  # outermost to innermost
-        y_out, bfield = fieldline_int(psi_nodes[ipsi], raw_profile, ro, zo, rs2)
-        checkpoint!(pool, Float64)
+    t_flux_surfaces = @elapsed if Threads.nthreads() > 1
+        Threads.@threads for ipsi in 1:(mpsi+1)
+            y_out, bfield = fieldline_int(psi_nodes[ipsi], raw_profile, ro, zo, rs2; use_pool=false)
 
-        # Fit data into temporary straight fieldline poloidal angle splines
-        ff_x_nodes = acquire!(pool, Float64, size(y_out, 1))
-        @. ff_x_nodes = @view(y_out[:, 5]) / y_out[end, 5]
+            npt = size(y_out, 1)
+            ff_x_nodes = Vector{Float64}(undef, npt)
+            @. ff_x_nodes = @view(y_out[:, 5]) / y_out[end, 5]
 
-        ff_fs_nodes = acquire!(pool, Float64, size(y_out, 1), 4)
-        @. ff_fs_nodes[:, 1] = @view(y_out[:, 3]) ^ 2
-        @. ff_fs_nodes[:, 2] = @view(y_out[:, 1]) / (2π) - ff_x_nodes
-        @. ff_fs_nodes[:, 3] = bfield.f * (@view(y_out[:, 4]) - ff_x_nodes * y_out[end, 4])
-        @. ff_fs_nodes[:, 4] = @view(y_out[:, 2]) / y_out[end, 2] - ff_x_nodes
+            ff_fs_nodes = Matrix{Float64}(undef, npt, 4)
+            @. ff_fs_nodes[:, 1] = @view(y_out[:, 3]) ^ 2
+            @. ff_fs_nodes[:, 2] = @view(y_out[:, 1]) / (2π) - ff_x_nodes
+            @. ff_fs_nodes[:, 3] = bfield.f * (@view(y_out[:, 4]) - ff_x_nodes * y_out[end, 4])
+            @. ff_fs_nodes[:, 4] = @view(y_out[:, 2]) / y_out[end, 2] - ff_x_nodes
 
-        ff_fs_nodes[end, :] .= ff_fs_nodes[1, :]  # enforce periodic endpoint
+            ff_fs_nodes[end, :] .= ff_fs_nodes[1, :]
 
-        ff_interp = cubic_interp(ff_x_nodes, ff_fs_nodes; bc=PeriodicBC())
-        ff_deriv = deriv1(ff_interp)
+            ff_interp = cubic_interp(ff_x_nodes, ff_fs_nodes; bc=PeriodicBC())
+            ff_deriv = deriv1(ff_interp)
 
-        # Resample ff onto uniform theta grid
-        for itheta in 1:(mtheta+1)
-            theta = theta_nodes[itheta]
-            ff_interp(ff_val, theta)
-            ff_deriv(ff_deriv_val, theta)
+            ff_val = Vector{Float64}(undef, 4)
+            ff_deriv_val = Vector{Float64}(undef, 4)
+            for itheta in 1:(mtheta+1)
+                theta = theta_nodes[itheta]
+                ff_interp(ff_val, theta)
+                ff_deriv(ff_deriv_val, theta)
+                rzphi_nodes[ipsi, itheta, 1] = ff_val[1]
+                rzphi_nodes[ipsi, itheta, 2] = ff_val[2]
+                rzphi_nodes[ipsi, itheta, 3] = ff_val[3]
+                rzphi_nodes[ipsi, itheta, 4] = (1.0 + ff_deriv_val[4]) * y_out[end, 2] * 2π * psio
+            end
 
-            rzphi_nodes[ipsi, itheta, 1] = ff_val[1]
-            rzphi_nodes[ipsi, itheta, 2] = ff_val[2]
-            rzphi_nodes[ipsi, itheta, 3] = ff_val[3]
-            rzphi_nodes[ipsi, itheta, 4] = (1.0 + ff_deriv_val[4]) * y_out[end, 2] * 2π * psio
+            sq_nodes[ipsi, 1] = bfield.f * 2π
+            sq_nodes[ipsi, 2] = bfield.p
+            sq_nodes[ipsi, 3] = y_out[end, 2] * 2π * psio
+            sq_nodes[ipsi, 4] = y_out[end, 4] * bfield.f / (2π)
         end
+    else
+        ff_val = zeros!(pool, Float64, 4)
+        ff_deriv_val = zeros!(pool, Float64, 4)
 
-        sq_nodes[ipsi, 1] = bfield.f * 2π
-        sq_nodes[ipsi, 2] = bfield.p
-        sq_nodes[ipsi, 3] = y_out[end, 2] * 2π * psio
-        sq_nodes[ipsi, 4] = y_out[end, 4] * bfield.f / (2π)
-        rewind!(pool, Float64)
+        for ipsi in (mpsi+1):-1:1  # outermost to innermost
+            y_out, bfield = fieldline_int(psi_nodes[ipsi], raw_profile, ro, zo, rs2)
+            checkpoint!(pool, Float64)
+
+            ff_x_nodes = acquire!(pool, Float64, size(y_out, 1))
+            @. ff_x_nodes = @view(y_out[:, 5]) / y_out[end, 5]
+
+            ff_fs_nodes = acquire!(pool, Float64, size(y_out, 1), 4)
+            @. ff_fs_nodes[:, 1] = @view(y_out[:, 3]) ^ 2
+            @. ff_fs_nodes[:, 2] = @view(y_out[:, 1]) / (2π) - ff_x_nodes
+            @. ff_fs_nodes[:, 3] = bfield.f * (@view(y_out[:, 4]) - ff_x_nodes * y_out[end, 4])
+            @. ff_fs_nodes[:, 4] = @view(y_out[:, 2]) / y_out[end, 2] - ff_x_nodes
+
+            ff_fs_nodes[end, :] .= ff_fs_nodes[1, :]
+
+            ff_interp = cubic_interp(ff_x_nodes, ff_fs_nodes; bc=PeriodicBC())
+            ff_deriv = deriv1(ff_interp)
+
+            for itheta in 1:(mtheta+1)
+                theta = theta_nodes[itheta]
+                ff_interp(ff_val, theta)
+                ff_deriv(ff_deriv_val, theta)
+                rzphi_nodes[ipsi, itheta, 1] = ff_val[1]
+                rzphi_nodes[ipsi, itheta, 2] = ff_val[2]
+                rzphi_nodes[ipsi, itheta, 3] = ff_val[3]
+                rzphi_nodes[ipsi, itheta, 4] = (1.0 + ff_deriv_val[4]) * y_out[end, 2] * 2π * psio
+            end
+
+            sq_nodes[ipsi, 1] = bfield.f * 2π
+            sq_nodes[ipsi, 2] = bfield.p
+            sq_nodes[ipsi, 3] = y_out[end, 2] * 2π * psio
+            sq_nodes[ipsi, 4] = y_out[end, 4] * bfield.f / (2π)
+            rewind!(pool, Float64)
+        end
     end
 
     # Temporary splines for q0 extrapolation and optional newq0 revision
@@ -630,16 +755,18 @@ robustness.
     grid2d = (rzphi_xs, theta_nodes)
     opts2d = (search=LinearBinary(), bc=(CubicFit(), PeriodicBC()), extrap=(ExtendExtrap(), WrapExtrap()))
 
-    rzphi_rsquared = cubic_interp(grid2d, rzphi_nodes[:, :, 1]; opts2d...)
-    rzphi_offset = cubic_interp(grid2d, rzphi_nodes[:, :, 2]; opts2d...)
-    rzphi_nu = cubic_interp(grid2d, rzphi_nodes[:, :, 3]; opts2d...)
-    rzphi_jac = cubic_interp(grid2d, rzphi_nodes[:, :, 4]; opts2d...)
+    t_rzphi_interpolants = @elapsed begin
+        rzphi_rsquared = cubic_interp(grid2d, rzphi_nodes[:, :, 1]; opts2d...)
+        rzphi_offset = cubic_interp(grid2d, rzphi_nodes[:, :, 2]; opts2d...)
+        rzphi_nu = cubic_interp(grid2d, rzphi_nodes[:, :, 3]; opts2d...)
+        rzphi_jac = cubic_interp(grid2d, rzphi_nodes[:, :, 4]; opts2d...)
+    end
 
     eqfun_fs_nodes = zeros(Float64, mpsi + 1, mtheta + 1, 3)
-    v = @MMatrix zeros(Float64, 2, 3)
-    for ipsi in 1:(mpsi+1)
+    t_eqfun_nodes = @elapsed Threads.@threads for ipsi in 1:(mpsi+1)
         q = profiles.q_spline.y[ipsi]
         f_val = profiles.F_spline.y[ipsi]
+        v = @MMatrix zeros(Float64, 2, 3)
         for itheta in 1:(mtheta+1)
             theta_norm = theta_nodes[itheta]
             # Access nodal derivatives from the interpolants (grid points)
@@ -693,9 +820,13 @@ robustness.
         end
     end
 
-    eqfun_B = cubic_interp(grid2d, eqfun_fs_nodes[:, :, 1]; opts2d...)
-    eqfun_metric1 = cubic_interp(grid2d, eqfun_fs_nodes[:, :, 2]; opts2d...)
-    eqfun_metric2 = cubic_interp(grid2d, eqfun_fs_nodes[:, :, 3]; opts2d...)
+    t_eqfun_interpolants = @elapsed begin
+        eqfun_B = cubic_interp(grid2d, eqfun_fs_nodes[:, :, 1]; opts2d...)
+        eqfun_metric1 = cubic_interp(grid2d, eqfun_fs_nodes[:, :, 2]; opts2d...)
+        eqfun_metric2 = cubic_interp(grid2d, eqfun_fs_nodes[:, :, 3]; opts2d...)
+    end
+
+    @info "equilibrium_solver timings (wall s)" nthreads=Threads.nthreads() flux_surfaces_and_rzphi_grid=t_flux_surfaces rzphi_2d_interpolants=t_rzphi_interpolants eqfun_nodal_fill=t_eqfun_nodes eqfun_2d_interpolants=t_eqfun_interpolants
 
     return PlasmaEquilibrium(raw_profile.config, EquilibriumParameters(), profiles,
         rzphi_xs, rzphi_ys,

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -777,14 +777,14 @@ robustness.
     end
 
     eqfun_fs_nodes = zeros(Float64, mpsi + 1, mtheta + 1, 3)
-    t_eqfun_nodes = @elapsed Threads.@threads for ipsi in 1:(mpsi+1)
+    eqfun_nonfinite_warn_count = Ref(0)
+    function _fill_eqfun_for_ipsi!(ipsi::Int)
         q = profiles.q_spline.y[ipsi]
         f_val = profiles.F_spline.y[ipsi]
         v = @MMatrix zeros(Float64, 2, 3)
         for itheta in 1:(mtheta+1)
             theta_norm = theta_nodes[itheta]
-            # Access nodal derivatives from the interpolants (grid points)
-            # partials indexing: [1,:,:] = f, [2,:,:] = ∂f/∂x, [3,:,:] = ∂f/∂y, [4,:,:] = ∂²f/∂x∂y
+            # partials: [1,:,:] = f, [2,:,:] = ∂f/∂x, [3,:,:] = ∂f/∂y, [4,:,:] = ∂²f/∂x∂y
             f = (
                 rzphi_rsquared.nodal_derivs.partials[1, ipsi, itheta],
                 rzphi_offset.nodal_derivs.partials[1, ipsi, itheta],
@@ -803,37 +803,70 @@ robustness.
                 rzphi_nu.nodal_derivs.partials[3, ipsi, itheta],
                 rzphi_jac.nodal_derivs.partials[3, ipsi, itheta]
             )
-            rfac = sqrt(max(0.0, f[1]))  # guard against spline overshoot near separatrix
+            if !(isfinite(f_val) && all(isfinite, f) && all(isfinite, fx) && all(isfinite, fy))
+                c = (eqfun_nonfinite_warn_count[] += 1)
+                if c <= 12
+                    @warn "Non-finite eqfun nodal input at (ipsi, itheta)=($ipsi, $itheta); zeroing cell. Often axis/edge degeneracy — if many core surfaces appear, investigate."
+                elseif c == 13
+                    @warn "Non-finite eqfun nodal inputs: suppressing further per-cell messages (already logged 12 samples)."
+                end
+                eqfun_fs_nodes[ipsi, itheta, :] .= 0.0
+                continue
+            end
+            rfac = sqrt(max(0.0, f[1]))
             eta = 2π * (theta_norm + f[2])
             r = ro + rfac * cos(eta)
             jacfac = f[4]
 
-            v[1, 1] = (rfac > 0) ? fx[1] / (2.0 * rfac) : 0.0  # 1/(2rfac) * d(rfac)/d(psi_norm)
-            v[1, 2] = fx[2] * 2π * rfac                          # 2π*rfac * d(eta)/d(psi_norm)
-            v[1, 3] = fx[3] * r                                   # r * d(phi_s)/d(psi_norm)
-            v[2, 1] = (rfac > 0) ? fy[1] / (2.0 * rfac) : 0.0  # 1/(2rfac) d(rfac)/d(theta_new)
-            v[2, 2] = (1.0 + fy[2]) * 2π * rfac                  # 2π*rfac * d(eta)/d(theta_new)
-            v[2, 3] = fy[3] * r                                   # r * d(phi_s)/d(theta_new)
+            v[1, 1] = (rfac > 0) ? fx[1] / (2.0 * rfac) : 0.0
+            v[1, 2] = fx[2] * 2π * rfac
+            v[1, 3] = fx[3] * r
+            v[2, 1] = (rfac > 0) ? fy[1] / (2.0 * rfac) : 0.0
+            v[2, 2] = (1.0 + fy[2]) * 2π * rfac
+            v[2, 3] = fy[3] * r
             v33 = 2π * r
             w11 = (jacfac != 0) ? (1.0 + fy[2]) * (2π)^2 * rfac * r / jacfac : 0.0
             w12 = (jacfac * rfac != 0) ? -fy[1] * π * r / (rfac * jacfac) : 0.0
+            w11 = isfinite(w11) ? w11 : 0.0
+            w12 = isfinite(w12) ? w12 : 0.0
             delpsi_norm = sqrt(w11^2 + w12^2)
-            modB = sqrt(((2π * psio * delpsi_norm)^2 + f_val^2) / (2π * r)^2)
+            delpsi_norm = isfinite(delpsi_norm) ? delpsi_norm : 0.0
+            r_twopi = 2π * r
+            den_sq = max(r_twopi^2, 1e-60)
+            modB = sqrt(max(0.0, ((2π * psio * delpsi_norm)^2 + f_val^2) / den_sq))
+            modB = isfinite(modB) ? modB : 0.0
 
             eqfun_fs_nodes[ipsi, itheta, 1] = modB
             denom = jacfac * modB^2
-            if abs(denom) > 1e-20
-                numerator_2 = dot(v[1, :], v[2, :]) + q * v33 * v[1, 3]  # gyrokinetic C1
-                eqfun_fs_nodes[ipsi, itheta, 2] = numerator_2 / denom
-                numerator_3 = v[2, 3] * v33 + q * v33^2                  # gyrokinetic C2
-                eqfun_fs_nodes[ipsi, itheta, 3] = numerator_3 / denom
+            if abs(denom) > 1e-20 && isfinite(denom)
+                numerator_2 = dot(v[1, :], v[2, :]) + q * v33 * v[1, 3]
+                numerator_3 = v[2, 3] * v33 + q * v33^2
+                val2 = numerator_2 / denom
+                val3 = numerator_3 / denom
+                eqfun_fs_nodes[ipsi, itheta, 2] = isfinite(val2) ? val2 : 0.0
+                eqfun_fs_nodes[ipsi, itheta, 3] = isfinite(val3) ? val3 : 0.0
             else
                 eqfun_fs_nodes[ipsi, itheta, 2] = 0.0
                 eqfun_fs_nodes[ipsi, itheta, 3] = 0.0
             end
         end
     end
+    t_eqfun_nodes = @elapsed if nt > 1
+        Threads.@threads for tid in 1:nt
+            for ipsi in tid:nt:(mpsi+1)
+                _fill_eqfun_for_ipsi!(ipsi)
+            end
+        end
+    else
+        for ipsi in 1:(mpsi+1)
+            _fill_eqfun_for_ipsi!(ipsi)
+        end
+    end
 
+    @inbounds for ipsi in 1:(mpsi+1)
+        @views eqfun_fs_nodes[ipsi, end, :] .= eqfun_fs_nodes[ipsi, 1, :]
+    end
+    @. eqfun_fs_nodes = ifelse(isfinite(eqfun_fs_nodes), eqfun_fs_nodes, 0.0)
     @inbounds for ipsi in 1:(mpsi+1)
         @views eqfun_fs_nodes[ipsi, end, :] .= eqfun_fs_nodes[ipsi, 1, :]
     end

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -851,16 +851,10 @@ robustness.
             end
         end
     end
-    t_eqfun_nodes = @elapsed if nt > 1
-        Threads.@threads for tid in 1:nt
-            for ipsi in tid:nt:(mpsi+1)
-                _fill_eqfun_for_ipsi!(ipsi)
-            end
-        end
-    else
-        for ipsi in 1:(mpsi+1)
-            _fill_eqfun_for_ipsi!(ipsi)
-        end
+    # Sequential only: concurrent reads of nodal_derivs across several 2D splines are not
+    # reliably thread-safe in FastInterpolations; parallel fill caused clustered NaNs and downstream root-find failures.
+    t_eqfun_nodes = @elapsed for ipsi in 1:(mpsi+1)
+        _fill_eqfun_for_ipsi!(ipsi)
     end
 
     @inbounds for ipsi in 1:(mpsi+1)

--- a/src/Equilibrium/DirectEquilibriumArcLength.jl
+++ b/src/Equilibrium/DirectEquilibriumArcLength.jl
@@ -98,7 +98,7 @@ outboard midplane (Z = zo, R > ro) after a minimum arc-length guard.
     equil_config = raw_profile.config
     bfield_ode = DirectBField()
     params = FieldLineDerivParams(ro, zo, raw_profile.psi_in, raw_profile.sq_in, sq_in_deriv, raw_profile.psio,
-        equil_config.power_bp, equil_config.power_b, equil_config.power_r, equil_config.power_rc, bfield_ode)
+        equil_config.power_bp, equil_config.power_b, equil_config.power_r, equil_config.power_rc, bfield_ode, nothing, nothing)
 
     t_min = π * (r - ro)  # minimum arc before termination (half-circumference lower bound)
     condition(u, _t, integrator) = u[2] - zo

--- a/src/Equilibrium/Equilibrium.jl
+++ b/src/Equilibrium/Equilibrium.jl
@@ -410,7 +410,7 @@ function equilibrium_gse!(equil::PlasmaEquilibrium)
     z = zeros(Float64, mpsi + 1, mtheta + 1)
 
     for ipsi in 1:(mpsi+1)
-        rfac = @. sqrt(equil.rzphi_rsquared.nodal_derivs.partials[1, ipsi, :])
+        rfac = @. sqrt(max(0.0, equil.rzphi_rsquared.nodal_derivs.partials[1, ipsi, :]))
         angle = @. 2π * (equil.rzphi_ys + equil.rzphi_offset.nodal_derivs.partials[1, ipsi, :])
         r[ipsi, :] .= ro .+ rfac .* cos.(angle)
         z[ipsi, :] .= zo .+ rfac .* sin.(angle)
@@ -420,21 +420,29 @@ function equilibrium_gse!(equil::PlasmaEquilibrium)
     flux_fs = zeros(Float64, mpsi + 1, mtheta + 1, 2)
     flux_fsx = zeros(Float64, mpsi + 1, mtheta + 1, 2)  # x-derivatives
     flux_fsy = zeros(Float64, mpsi + 1, mtheta + 1, 2)  # y-derivatives
+    # Avoid 0/0 at magnetic axis (f1 = r² → 0) and div by zero in Jacobian f4
+    _gse_f1_div = 1e-20
+    _gse_f4_min = 1e-40
     for ipsi in 1:(mpsi+1)
         for itheta in 1:(mtheta+1)
             f1 = equil.rzphi_rsquared.nodal_derivs.partials[1, ipsi, itheta]
-            f2 = equil.rzphi_offset.nodal_derivs.partials[1, ipsi, itheta]
             f4 = equil.rzphi_jac.nodal_derivs.partials[1, ipsi, itheta]
             fy1 = equil.rzphi_rsquared.nodal_derivs.partials[3, ipsi, itheta]
             fy2 = equil.rzphi_offset.nodal_derivs.partials[3, ipsi, itheta]
             fx1 = equil.rzphi_rsquared.nodal_derivs.partials[2, ipsi, itheta]
             fx2 = equil.rzphi_offset.nodal_derivs.partials[2, ipsi, itheta]
 
-            flux_fs[ipsi, itheta, 1] = fy1^2 / (4π^2 * f1) + (1 + fy2)^2 * 4 * f1
-            flux_fs[ipsi, itheta, 2] = fx1 * fy1 / (4π^2 * f1) + fx2 * (1 + fy2) * 4 * f1
-
-            flux_fs[ipsi, itheta, 1] *= 2π * psio / f4
-            flux_fs[ipsi, itheta, 2] *= 2π * psio / f4
+            if !(isfinite(f1) && isfinite(f4) && isfinite(fy1) && isfinite(fy2) && isfinite(fx1) && isfinite(fx2)) || abs(f4) < _gse_f4_min
+                flux_fs[ipsi, itheta, 1] = 0.0
+                flux_fs[ipsi, itheta, 2] = 0.0
+                continue
+            end
+            f1d = max(f1, _gse_f1_div)
+            scale = (2π * psio) / f4
+            t1 = fy1^2 / (4π^2 * f1d) + (1 + fy2)^2 * 4 * f1
+            t2 = fx1 * fy1 / (4π^2 * f1d) + fx2 * (1 + fy2) * 4 * f1
+            flux_fs[ipsi, itheta, 1] = t1 * scale
+            flux_fs[ipsi, itheta, 2] = t2 * scale
         end
     end
     # Create flux interpolants for Grad-Shafranov diagnostics
@@ -442,15 +450,16 @@ function equilibrium_gse!(equil::PlasmaEquilibrium)
     flux1 = cubic_interp((equil.rzphi_xs, equil.rzphi_ys), flux_fs[:, :, 1]; flux_opts...)
     flux2 = cubic_interp((equil.rzphi_xs, equil.rzphi_ys), flux_fs[:, :, 2]; flux_opts...)
 
-    # Compute flux derivatives at all grid points for diagnostics
-    hint2d = (Ref(1), Ref(1))  # Shared 2D hint for hot loop optimization
+    # Separate 2D hints per interpolant — sharing one hint between flux1 and flux2 can corrupt search state.
+    hint_flux1 = (Ref(1), Ref(1))
+    hint_flux2 = (Ref(1), Ref(1))
     for ipsi in 0:mpsi
         for itheta in 0:mtheta
             query_point = (equil.rzphi_xs[ipsi+1], equil.rzphi_ys[itheta+1])
-            flux_fsx[ipsi+1, itheta+1, 1] = flux1(query_point; deriv=Val((1, 0)), hint=hint2d)
-            flux_fsx[ipsi+1, itheta+1, 2] = flux2(query_point; deriv=Val((1, 0)), hint=hint2d)
-            flux_fsy[ipsi+1, itheta+1, 1] = flux1(query_point; deriv=Val((0, 1)), hint=hint2d)
-            flux_fsy[ipsi+1, itheta+1, 2] = flux2(query_point; deriv=Val((0, 1)), hint=hint2d)
+            flux_fsx[ipsi+1, itheta+1, 1] = flux1(query_point; deriv=Val((1, 0)), hint=hint_flux1)
+            flux_fsx[ipsi+1, itheta+1, 2] = flux2(query_point; deriv=Val((1, 0)), hint=hint_flux2)
+            flux_fsy[ipsi+1, itheta+1, 1] = flux1(query_point; deriv=Val((0, 1)), hint=hint_flux1)
+            flux_fsy[ipsi+1, itheta+1, 2] = flux2(query_point; deriv=Val((0, 1)), hint=hint_flux2)
         end
     end
 
@@ -464,8 +473,13 @@ function equilibrium_gse!(equil::PlasmaEquilibrium)
         s2p = profiles.P_deriv(psi; hint=hint)
         for itheta in 1:(mtheta+1)
             f4 = equil.rzphi_jac.nodal_derivs.partials[1, ipsi, itheta]
-            denom = (2π * r[ipsi, itheta])^2
-            source[ipsi, itheta] = f4 / (2π * psio * π^2) * (s1 * s1p / denom + s2p)
+            rij = r[ipsi, itheta]
+            denom = max((2π * rij)^2, 1e-40)
+            if isfinite(f4) && isfinite(s1) && isfinite(s1p) && isfinite(s2p) && isfinite(rij)
+                source[ipsi, itheta] = f4 / (2π * psio * π^2) * (s1 * s1p / denom + s2p)
+            else
+                source[ipsi, itheta] = 0.0
+            end
         end
     end
 
@@ -489,6 +503,7 @@ function equilibrium_gse!(equil::PlasmaEquilibrium)
         fs_matrix = zeros(Float64, mtheta + 1, 2)
         fs_matrix[:, 1] = flux_fsx[ipsi, :, 1]
         fs_matrix[:, 2] = source[ipsi, :]
+        @. fs_matrix = ifelse(isfinite(fs_matrix), fs_matrix, 0.0)
 
         # Compute total integral using FastInterpolations native integration
         itp = cubic_interp(equil.rzphi_ys, fs_matrix; bc=PeriodicBC())

--- a/src/Equilibrium/Equilibrium.jl
+++ b/src/Equilibrium/Equilibrium.jl
@@ -101,11 +101,48 @@ function equilibrium_separatrix_find!(pe::PlasmaEquilibrium)
 
     for iside in 1:2
         hint2d = (Ref(1), Ref(1))
-        theta = find_zero(
-            (theta -> theta + pe.rzphi_offset((psi_edge, theta); hint=hint2d) - eta0,
-                theta -> 1.0 + pe.rzphi_offset((psi_edge, theta); deriv=Val((0, 1)), hint=hint2d)),
-            theta, Roots.Newton()
-        )
+        function eta_match(theta_g)
+            theta_g + pe.rzphi_offset((psi_edge, theta_g); hint=hint2d) - eta0
+        end
+        function eta_match_deriv(theta_g)
+            1.0 + pe.rzphi_offset((psi_edge, theta_g); deriv=Val((0, 1)), hint=hint2d)
+        end
+        theta = try
+            find_zero((eta_match, eta_match_deriv), theta, Roots.Newton(); atol=1e-12, rtol=1e-12, maxevals=500)
+        catch err
+            thetas = collect(range(0.0, 1.0; length=513))
+            vals = map(eta_match, thetas)
+            br = findfirst(i -> begin
+                a = vals[i]
+                b = vals[i+1]
+                isfinite(a) && isfinite(b) && (a == 0.0 || b == 0.0 || a * b < 0.0)
+            end, 1:(length(thetas)-1))
+            if br !== nothing
+                try
+                    find_zero(eta_match, (thetas[br], thetas[br+1]), Roots.Brent(); atol=1e-12, rtol=1e-12, maxevals=1000)
+                catch
+                    fi = findall(isfinite, vals)
+                    if !isempty(fi)
+                        j = fi[argmin(abs.(vals[fi]))]
+                        @warn "η=$eta0 inboard/outboard θ: Brent failed after Newton failed; using θ=$(thetas[j]) (min |res| on grid). $err"
+                        thetas[j]
+                    else
+                        @warn "η=$eta0 separatrix θ: no finite residuals on grid; keeping initial θ=$theta. $err"
+                        theta
+                    end
+                end
+            else
+                fi = findall(isfinite, vals)
+                if !isempty(fi)
+                    j = fi[argmin(abs.(vals[fi]))]
+                    @warn "η=$eta0 separatrix θ: Newton failed, no sign change; using θ=$(thetas[j]) (min |res|). $err"
+                    thetas[j]
+                else
+                    @warn "η=$eta0 separatrix θ: Newton failed, all NaN on grid; keeping θ=$theta. $err"
+                    theta
+                end
+            end
+        end
         r2 = pe.rzphi_rsquared((psi_edge, theta))
         offset = pe.rzphi_offset((psi_edge, theta))
         rsep[iside] = pe.ro + sqrt(r2) * cos(2π * (theta + offset))
@@ -171,8 +208,37 @@ function equilibrium_separatrix_find!(pe::PlasmaEquilibrium)
                    (rfac2 - rfac_local * phase1^2) * sin_phase  # ∂²z/∂θ²
         end
 
-        theta = find_zero((z_deriv, z_deriv2), theta, Roots.Newton();
-            atol=1e-12, rtol=1e-12, maxevals=1000)
+        theta = try
+            find_zero((z_deriv, z_deriv2), theta, Roots.Newton(); atol=1e-12, rtol=1e-12, maxevals=1000)
+        catch err
+            # Newton can fail on marginal geometries; fall back to a robust edge scan + Brent.
+            thetas = collect(range(0.0, 1.0; length=257))
+            vals = map(z_deriv, thetas)
+            idx = findfirst(i -> begin
+                a = vals[i]
+                b = vals[i+1]
+                isfinite(a) && isfinite(b) && (a == 0.0 || b == 0.0 || a * b < 0.0)
+            end, 1:(length(thetas)-1))
+            if idx !== nothing
+                try
+                    find_zero(z_deriv, (thetas[idx], thetas[idx+1]), Roots.Brent(); atol=1e-12, rtol=1e-12, maxevals=2000)
+                catch
+                    @warn "Separatrix extremum root find fallback failed on side=$iside; using initial theta=$theta. Original error: $err"
+                    theta
+                end
+            else
+                finite_idxs = findall(isfinite, vals)
+                if !isempty(finite_idxs)
+                    imin = argmin(abs.(vals[finite_idxs]))
+                    @warn "Separatrix extremum Newton failed on side=$iside; using nearest sampled theta. Original error: $err"
+                    thetas[finite_idxs[imin]]
+                else
+                    @warn "Separatrix extremum root find produced no finite samples on side=$iside; using initial theta=$theta. Original error: $err"
+                    theta
+                end
+            end
+        end
+        z_deriv(theta)  # refresh cached rfac/cos_phase/z_val at final theta
 
         rext[iside] = pe.ro + rfac[] * cos_phase[]
         zsep[iside] = zext[iside] = z_val[]

--- a/src/Equilibrium/Equilibrium.jl
+++ b/src/Equilibrium/Equilibrium.jl
@@ -3,6 +3,7 @@ module Equilibrium
 # --- Module-level Dependencies ---
 
 using Printf, OrdinaryDiffEq, DiffEqCallbacks, LinearAlgebra, HDF5
+using Base: Threads
 using Roots
 using TOML
 import FastInterpolations


### PR DESCRIPTION
**What was Done:**
**Parallel flux surfaces (DirectEquilibrium.jl)**
When Threads.nthreads() > 1, flux-surface integration runs with Threads.@threads (strided ipsi per thread), each thread using deepcopy(raw_profile) so splines are not shared. Field-line integration uses fieldline_int(...; use_pool=false) and direct_get_bfield!_buf! with per-call buffers instead of the adaptive pool. Large sq_nodes / rzphi_nodes allocations use plain zeros (not the pool) to avoid pool contention/corruption.

**Thread-safe B-field path**
Added direct_get_bfield!_buf! and optional f_sq_buf / f1_sq_buf on FieldLineDerivParams; direct_fieldline_int / direct_fieldline_der! / direct_refine route through the buf path when appropriate.

**Correctness / BC**
After flux fill, enforce θ-periodicity on rzphi_nodes before 2D rzphi splines. Eqfun nodal fill stays sequential (parallel version caused bad values from concurrent spline reads).

**Arc-length path**
DirectEquilibriumArcLength.jl: FieldLineDerivParams constructor updated with nothing, nothing for the new buffer fields.

**Stability (not threading itself)**
Equilibrium.jl: using Base: Threads; equilibrium_gse! and equilibrium_separatrix_find! hardened (finite guards, hints, robust root-finding) for flaky numerics under the new path.

**Benchmarks**
benchmarks/equil_thread_worker.jl and equil_thread_rank_1_15.jl for timing across -t 1:15 (child env pins BLAS/OpenMP to 1 thread where applicable).

**Optional**
@info phase timings in equilibrium_solver for quick profiling.


[
<img width="1030" height="842" alt="image" src="https://github.com/user-attachments/assets/59927b1d-5f31-450c-a243-7a3f189724fa" />
<img width="1044" height="365" alt="image" src="https://github.com/user-attachments/assets/70e58b55-9b2e-4a5f-9dc5-6545f7fdd2a8" />

Results:
Obviously, still need testing. Was moving around my computer so seems to fluctuate a lot. Also had some issues with NaN values that I need to check with 13 and up threads. 

<img width="1020" height="786" alt="image" src="https://github.com/user-attachments/assets/76db4be8-bf11-4e0b-b610-42df773164a1" />

Regardless, threads 4 and 8 are looking like the most promising on my computer. My computer has 20 cores, so was surprisingly low. t=4 was the most promising at almost twice the speed up from thread count 1 (original).

Anyways, not fully ready to implement. Want to do further testing to smooth out the weird values was getting past 12 threads.

What lovely Claude had to say about the data: 
<img width="975" height="257" alt="image" src="https://github.com/user-attachments/assets/d2ed4dae-9f47-46d1-b3d3-9fe68ac2bda0" />


**Problems that are Likely Related to the NaN issues I had:**

Previously, hit a sequence of stability issues while trying to benchmark the threaded equilibrium solver across thread counts 1–15.
* Early failures were PeriodicBC mismatches in the θ dimension (first/last not matching), which pointed to non-thread-safe behavior and NaN/Inf contamination in nodal arrays during parallel sections.
* Even after those were reduced, -t 3 remained unstable, showing clustered “Non-finite eqfun nodal input” warnings at specific θ indices and then failing later in separatrix root-finding (Roots.ConvergenceFailed).
* Fixed problem with thread count 3 by  adding per-thread deepcopy(raw_profile), no pool on big grids / field lines (use_pool=false + direct_get_bfield!_buf!), θ-periodicity on rzphi_nodes, sequential eqfun nodal fill, plus GSE/separatrix guards—so -t 3 is safe on the same nt>1 path as any multi-thread run.

For 13+, experiencing same problem as thread 3 so might be worth looking into fix: a specific itheta index blows up across every ipsi. Any ideas?
