### PR TITLE
EQUIL - IMPROVEMENT - Scope custom-Jacobian knobs to jac_custom_power_*

### DIFF
--- a/docs/src/conventions.md
+++ b/docs/src/conventions.md
@@ -84,8 +84,9 @@ field magnitude, ``B`` is the total field magnitude, ``R`` is the major radius, 
 
 The powers are set automatically from `jac_type` (`EquilibriumConfig` in
 `src/Equilibrium/EquilibriumTypes.jl`) and applied in the field-line Jacobian
-(`direct_fieldline_der!` in `src/Equilibrium/DirectEquilibrium.jl`). Setting `jac_type = "other"`
-lets you specify the four exponents manually.
+(`direct_fieldline_der!` in `src/Equilibrium/DirectEquilibrium.jl`). Setting `jac_type = "custom"`
+lets you specify the four exponents manually via `jac_custom_power_bp`, `jac_custom_power_b`,
+`jac_custom_power_r`, and `jac_custom_power_rc`.
 
 ## Helicity and Handedness
 

--- a/examples/DIIID-like_gal_resistive_example/gpec.toml
+++ b/examples/DIIID-like_gal_resistive_example/gpec.toml
@@ -1,10 +1,7 @@
 [Equilibrium]
 eq_filename = "TkMkr_D3Dlike_Hmode.geqdsk" # Path to equilibrium file
 eq_type = "efit"               # Type of the input 2D equilibrium file
-jac_type = "hamada"            # Coordinate system (hamada, pest, boozer, equal_arc)
-power_bp = 0                   # Poloidal field power exponent for Jacobian
-power_b = 0                    # Toroidal field power exponent for Jacobian
-power_r = 0                    # Major radius power exponent for Jacobian
+jac_type = "hamada"            # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"              # Radial grid packing type (ldp = linear-derivative packing toward rationals)
 psilow = 1e-4                  # Lower limit of normalized flux coordinate
 psihigh = 0.993                # Upper limit of normalized flux coordinate (0.993 stays clear of the separatrix; truncating at ≳0.998 is numerically unreasonable here)

--- a/examples/DIIID-like_gal_resistive_pe_example/gpec.toml
+++ b/examples/DIIID-like_gal_resistive_pe_example/gpec.toml
@@ -1,10 +1,7 @@
 [Equilibrium]
 eq_filename = "TkMkr_D3Dlike_Hmode.geqdsk" # Path to equilibrium file
 eq_type = "efit"               # Type of the input 2D equilibrium file
-jac_type = "hamada"            # Coordinate system (hamada, pest, boozer, equal_arc)
-power_bp = 0                   # Poloidal field power exponent for Jacobian
-power_b = 0                    # Toroidal field power exponent for Jacobian
-power_r = 0                    # Major radius power exponent for Jacobian
+jac_type = "hamada"            # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"              # Radial grid packing type (ldp = linear-derivative packing toward rationals)
 psilow = 1e-4                  # Lower limit of normalized flux coordinate
 psihigh = 0.993                # Upper limit of normalized flux coordinate (0.993 stays clear of the separatrix; truncating at ≳0.998 is numerically unreasonable here)

--- a/examples/DIIID-like_ideal_example/gpec.toml
+++ b/examples/DIIID-like_ideal_example/gpec.toml
@@ -6,7 +6,7 @@
 [Equilibrium]
 eq_filename = "TkMkr_D3Dlike_Hmode.geqdsk" # Path to equilibrium file
 eq_type = "efit"               # Type of the input 2D equilibrium file
-jac_type = "hamada"            # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "hamada"            # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "log_asymptotic"   # Radial grid packing type
 psilow = 1e-4                  # Lower limit of normalized poloidal flux
 psihigh = 0.9995               # Upper limit of normalized poloidal flux

--- a/examples/DIIID-like_ideal_example_IMAS/gpec.toml
+++ b/examples/DIIID-like_ideal_example_IMAS/gpec.toml
@@ -10,7 +10,7 @@
 [Equilibrium]
 eq_type      = "imas"          # Type of the input 2D equilibrium file
 eq_filename  = "from_dd"       # Path to equilibrium file (placeholder: equilibrium comes from the runtime dd argument)
-jac_type     = "boozer"        # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type     = "boozer"        # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 psilow       = 0.01            # Lower limit of normalized poloidal flux
 psihigh      = 0.9995          # Upper limit of normalized poloidal flux
 mpsi         = 128             # Number of radial grid points (0 = auto-compute from psi_accuracy)

--- a/examples/LAR_beta_scan/gpec.toml
+++ b/examples/LAR_beta_scan/gpec.toml
@@ -9,7 +9,7 @@
 
 [Equilibrium]
 eq_type   = "tj_analytic"      # TJ-analytic model (inverse pipeline; Fitzpatrick https://github.com/rfitzp/TJ)
-jac_type  = "hamada"           # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type  = "hamada"           # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"              # Radial grid packing type
 psilow    = 0.01               # Lower limit of normalized poloidal flux
 psihigh   = 0.995              # Upper limit of normalized poloidal flux

--- a/examples/LAR_epsilon_scan/gpec.toml
+++ b/examples/LAR_epsilon_scan/gpec.toml
@@ -9,7 +9,7 @@
 
 [Equilibrium]
 eq_type   = "tj_analytic"      # TJ-analytic model (inverse pipeline; overridden to "tj_analytic_direct" by run_scan.jl)
-jac_type  = "hamada"           # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type  = "hamada"           # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"              # Radial grid packing type
 psilow    = 0.01               # Lower limit of normalized poloidal flux
 psihigh   = 0.995              # Upper limit of normalized poloidal flux

--- a/examples/Solovev_ideal_example/gpec.toml
+++ b/examples/Solovev_ideal_example/gpec.toml
@@ -5,7 +5,7 @@
 
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized poloidal flux
 psihigh = 0.9995                        # Upper limit of normalized poloidal flux

--- a/examples/Solovev_ideal_example_3D/gpec.toml
+++ b/examples/Solovev_ideal_example_3D/gpec.toml
@@ -4,7 +4,7 @@
 
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized poloidal flux
 psihigh = 0.9995                        # Upper limit of normalized poloidal flux

--- a/examples/Solovev_ideal_example_multi_n/gpec.toml
+++ b/examples/Solovev_ideal_example_multi_n/gpec.toml
@@ -5,7 +5,7 @@
 
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized poloidal flux
 psihigh = 0.9995                        # Upper limit of normalized poloidal flux

--- a/examples/Solovev_ideal_example_multi_n/single_n_1/gpec.toml
+++ b/examples/Solovev_ideal_example_multi_n/single_n_1/gpec.toml
@@ -4,7 +4,7 @@
 
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized poloidal flux
 psihigh = 0.9995                        # Upper limit of normalized poloidal flux

--- a/examples/Solovev_ideal_example_multi_n/single_n_2/gpec.toml
+++ b/examples/Solovev_ideal_example_multi_n/single_n_2/gpec.toml
@@ -4,7 +4,7 @@
 
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized poloidal flux
 psihigh = 0.9995                        # Upper limit of normalized poloidal flux

--- a/examples/Solovev_kinetic_calculated_example/gpec.toml
+++ b/examples/Solovev_kinetic_calculated_example/gpec.toml
@@ -1,10 +1,7 @@
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
 eq_filename = "sol.toml"                # Path to equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc)
-power_bp = 0                            # Poloidal field power exponent for Jacobian
-power_b = 0                             # Toroidal field power exponent for Jacobian
-power_r = 0                             # Major radius power exponent for Jacobian
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized flux coordinate
 psihigh = 0.9995                        # Upper limit of normalized flux coordinate

--- a/examples/a10_kinetic_example/gpec.toml
+++ b/examples/a10_kinetic_example/gpec.toml
@@ -9,7 +9,7 @@
 [Equilibrium]
 eq_filename = "fix_a100_k10_q2_bn010_prof1"  # Path to equilibrium file
 eq_type = "efit"               # Type of the input 2D equilibrium file
-jac_type = "hamada"            # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "hamada"            # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"              # Radial grid packing type
 psilow = 1e-3                  # Lower limit of normalized poloidal flux
 psihigh = 0.99                 # Upper limit of normalized poloidal flux

--- a/src/Equilibrium/EquilibriumTypes.jl
+++ b/src/Equilibrium/EquilibriumTypes.jl
@@ -12,11 +12,15 @@ Bundles all necessary settings originally specified in the equil fortran namelis
 
   - `eq_type::String` - Type of equilibrium file ("efit", "solovev", "lar", etc.)
   - `eq_filename::String` - Path to equilibrium input file
-  - `jac_type::String` - Jacobian coordinate type ("hamada", "pest", "equal_arc", "boozer", "park", "other")
-  - `power_bp::Int` - Poloidal field power exponent for Jacobian
-  - `power_b::Int` - Total field power exponent for Jacobian
-  - `power_r::Int` - Major radius power exponent for Jacobian
-  - `power_rc::Int` - Minor radius (rfac = √((R-R₀)²+(Z-Z₀)²)) power exponent for Jacobian
+  - `jac_type::String` - Jacobian coordinate type ("hamada", "pest", "equal_arc", "boozer", "park", "custom")
+  - `power_bp::Int` - Poloidal field power exponent for Jacobian (internal, derived from `jac_type`; deprecated as a TOML input key)
+  - `power_b::Int` - Total field power exponent for Jacobian (internal, derived from `jac_type`; deprecated as a TOML input key)
+  - `power_r::Int` - Major radius power exponent for Jacobian (internal, derived from `jac_type`; deprecated as a TOML input key)
+  - `power_rc::Int` - Minor radius (rfac = √((R-R₀)²+(Z-Z₀)²)) power exponent for Jacobian (internal, derived from `jac_type`; deprecated as a TOML input key)
+  - `jac_custom_power_bp::Int` - Poloidal-field exponent for a custom Jacobian `J = Bp^bp · B^b / (R^r · rfac^rc)`; read only when `jac_type = "custom"`, ignored for named types
+  - `jac_custom_power_b::Int` - Total-field exponent for a custom Jacobian; read only when `jac_type = "custom"`, ignored for named types
+  - `jac_custom_power_r::Int` - Major-radius exponent for a custom Jacobian; read only when `jac_type = "custom"`, ignored for named types
+  - `jac_custom_power_rc::Int` - Minor-radius (rfac) exponent for a custom Jacobian; read only when `jac_type = "custom"`, ignored for named types
   - `r0exp::Float64` - Major radius normalization for CHEASE/EQDSK [m]
   - `b0exp::Float64` - On-axis toroidal field normalization for CHEASE/EQDSK [T]
   - `grid_type::String` - Grid type for flux surface discretization ("log_asymptotic", "ldp", "pow1")
@@ -42,6 +46,11 @@ Bundles all necessary settings originally specified in the equil fortran namelis
     power_r::Int = 0
     power_rc::Int = 0
 
+    jac_custom_power_bp::Int = 0
+    jac_custom_power_b::Int = 0
+    jac_custom_power_r::Int = 0
+    jac_custom_power_rc::Int = 0
+
     grid_type::String = "log_asymptotic"
     psilow::Float64 = 1e-2
     psihigh::Float64 = 0.9995
@@ -61,7 +70,11 @@ Bundles all necessary settings originally specified in the equil fortran namelis
     """
     Modified internal constructor that enforces self consistency within the inputs
     """
-    function EquilibriumConfig(eq_type, eq_filename, r0exp, b0exp, jac_type, power_bp, power_b, power_r, power_rc,
+    # The four `_` slots are the `power_bp/power_b/power_r/power_rc` struct fields, which @kwdef
+    # forwards positionally. They are always derived below from `jac_type` (or `jac_custom_power_*`),
+    # so their incoming values are ignored (hence `_`).
+    function EquilibriumConfig(eq_type, eq_filename, r0exp, b0exp, jac_type, _, _, _, _,
+        jac_custom_power_bp, jac_custom_power_b, jac_custom_power_r, jac_custom_power_rc,
         grid_type, psilow, psihigh, mpsi, psi_accuracy, mtheta, newq0, etol,
         force_termination, use_galgrid, imas_cocos)
         if jac_type == "hamada"
@@ -94,7 +107,12 @@ Bundles all necessary settings originally specified in the equil fortran namelis
             power_bp = 0
             power_r = 0
             power_rc = 0
-        elseif jac_type == "other"
+        elseif jac_type == "custom"
+            # Custom Jacobian: the user-facing knobs define the exponents.
+            power_bp = jac_custom_power_bp
+            power_b = jac_custom_power_b
+            power_r = jac_custom_power_r
+            power_rc = jac_custom_power_rc
             # Normalize to a named type when the powers match, so fast paths are taken.
             if power_b == 0 && power_bp == 0 && power_r == 0 && power_rc == 0
                 jac_type = "hamada"
@@ -122,6 +140,7 @@ Bundles all necessary settings originally specified in the equil fortran namelis
         end
         psihigh = min(psihigh, 1.0)
         return new(eq_type, eq_filename, r0exp, b0exp, jac_type, power_bp, power_b, power_r, power_rc,
+            jac_custom_power_bp, jac_custom_power_b, jac_custom_power_r, jac_custom_power_rc,
             grid_type, psilow, psihigh, mpsi, psi_accuracy, mtheta, newq0, etol,
             force_termination, use_galgrid, imas_cocos)
     end

--- a/src/GeneralizedPerturbedEquilibrium.jl
+++ b/src/GeneralizedPerturbedEquilibrium.jl
@@ -59,14 +59,15 @@ using .ForceFreeStates: find_kinetic_singular_surfaces!
 using .ForceFreeStates: eulerlagrange_integration, free_run!
 using .ForceFreeStates: galerkin_solve, write_galerkin!, GalerkinResult, gal_matched_odestate
 
-const _DEPRECATED_FFS_KEYS = ("mer_flag")
+const _DEPRECATED_FFS_KEYS = ("mer_flag",)
+const _DEPRECATED_EQUIL_KEYS = ("power_bp", "power_b", "power_r", "power_rc")
 
-# Drop deprecated [ForceFreeStates] keys so legacy gpec.toml files
-# keep parsing instead of throwing an unknown-keyword error.
-function _drop_deprecated_ffs_keys!(table)
-    for k in _DEPRECATED_FFS_KEYS
+# Drop deprecated keys from a parsed gpec.toml section so legacy files keep parsing
+# instead of throwing an unknown-keyword error; warn so the removal is not silent.
+function _drop_deprecated_keys!(table, deprecated_keys, section::String)
+    for k in deprecated_keys
         if haskey(table, k)
-            @warn "`$k` in [ForceFreeStates] is deprecated and ignored please remove it from gpec.toml."
+            @warn "`$k` in [$section] is deprecated and ignored; please remove it from gpec.toml."
             delete!(table, k)
         end
     end
@@ -111,6 +112,7 @@ function build_inputs_from_toml(path::String; dd::Union{IMASdd.dd,Nothing}=nothi
     inputs = TOML.parsefile(joinpath(path, "gpec.toml"))
 
     haskey(inputs, "Equilibrium") || error("No [Equilibrium] section in gpec.toml")
+    _drop_deprecated_keys!(inputs["Equilibrium"], _DEPRECATED_EQUIL_KEYS, "Equilibrium")
     eq_config = Equilibrium.EquilibriumConfig(inputs["Equilibrium"], path)
 
     # An equilibrium is analytic (sol/lar/tj, parameters from its embedded section),
@@ -169,7 +171,7 @@ function main_from_inputs(
     # Build data structures from inputs
     intr = ForceFreeStatesInternal(; dir_path=path)
     ffs_table = inputs["ForceFreeStates"]
-    _drop_deprecated_ffs_keys!(ffs_table)
+    _drop_deprecated_keys!(ffs_table, _DEPRECATED_FFS_KEYS, "ForceFreeStates")
     ctrl = ForceFreeStatesControl(; (Symbol(k) => v for (k, v) in ffs_table)...)
     equil = Equilibrium.setup_equilibrium(eq_config, additional_input)
 

--- a/src/Rerun.jl
+++ b/src/Rerun.jl
@@ -266,6 +266,7 @@ function build_inputs_from_h5(args::Vector{String})
           "  source: $(abspath(source_h5))\n" *
           "  output: $(abspath(joinpath(output_dir, output_name)))\n$_BANNER"
 
+    _drop_deprecated_keys!(inputs["Equilibrium"], _DEPRECATED_EQUIL_KEYS, "Equilibrium")
     eq_config = Equilibrium.EquilibriumConfig(inputs["Equilibrium"], output_dir)
     # Clear eq_filename: unused on replay, and a stale absolute path could mislead downstream code.
     eq_config.eq_filename = ""

--- a/test/test_data/regression_solovev_ideal_example/gpec.toml
+++ b/test/test_data/regression_solovev_ideal_example/gpec.toml
@@ -4,7 +4,7 @@
 
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized poloidal flux
 psihigh = 0.9995                        # Upper limit of normalized poloidal flux

--- a/test/test_data/regression_solovev_ideal_example_multi_n/gpec.toml
+++ b/test/test_data/regression_solovev_ideal_example_multi_n/gpec.toml
@@ -4,7 +4,7 @@
 
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized poloidal flux
 psihigh = 0.9995                        # Upper limit of normalized poloidal flux

--- a/test/test_data/regression_solovev_kinetic_calculated/gpec.toml
+++ b/test/test_data/regression_solovev_kinetic_calculated/gpec.toml
@@ -4,7 +4,7 @@
 
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized poloidal flux
 psihigh = 0.9995                        # Upper limit of normalized poloidal flux

--- a/test/test_data/regression_solovev_kinetic_example/gpec.toml
+++ b/test/test_data/regression_solovev_kinetic_example/gpec.toml
@@ -4,7 +4,7 @@
 
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized poloidal flux
 psihigh = 0.9995                        # Upper limit of normalized poloidal flux

--- a/test/test_data/regression_solovev_kinetic_multi_n/gpec.toml
+++ b/test/test_data/regression_solovev_kinetic_multi_n/gpec.toml
@@ -4,7 +4,7 @@
 
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, other)
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized poloidal flux
 psihigh = 0.9995                        # Upper limit of normalized poloidal flux

--- a/test/test_data/regression_solovev_kinetic_nuzero/gpec.toml
+++ b/test/test_data/regression_solovev_kinetic_nuzero/gpec.toml
@@ -1,9 +1,6 @@
 [Equilibrium]
 eq_type = "sol"                         # Type of the input 2D equilibrium file
-jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc)
-power_bp = 0                            # Poloidal field power exponent for Jacobian
-power_b = 0                             # Toroidal field power exponent for Jacobian
-power_r = 0                             # Major radius power exponent for Jacobian
+jac_type = "pest"                       # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
 grid_type = "ldp"                       # Radial grid packing type
 psilow = 1e-4                           # Lower limit of normalized flux coordinate
 psihigh = 0.9995                        # Upper limit of normalized flux coordinate


### PR DESCRIPTION
Closes #288.

## Problem

In `[Equilibrium]`, the Jacobian coordinate system is chosen with `jac_type`. For named systems (`hamada`, `pest`, `boozer`, `equal_arc`, `park`) the constructor *forces* a fixed set of exponents, yet the raw `power_bp/power_b/power_r/power_rc` were exposed as top-level keys that *look* universal but only mattered when `jac_type = "other"`. Listing them (as `0`) in every example implied false relevance, and setting one on a named-type run was silently ignored.

## Changes

**Custom-Jacobian knobs (`src/Equilibrium/EquilibriumTypes.jl`)**
- Rename `jac_type = "other"` → `jac_type = "custom"` (clearer intent; no shim — no stable API pre-2.0.0).
- Add user-facing `jac_custom_power_bp/b/r/rc` (default 0), read *only* at construction when `jac_type = "custom"`, then copied into the internal `power_*`. The existing "recognize a named type from the exponents" normalization is retained (fast paths still taken).
- Named types are unchanged: they force `power_*` and ignore the custom knobs.
- Downstream is untouched — `FieldLineDerivParams` and every Jacobian formula (`DirectEquilibrium.jl`, `DirectEquilibriumArcLength.jl`, `InverseEquilibrium.jl`) keep reading the internal `power_*` fields as the single source of truth. The four now derived-only constructor slots are marked `_`.

**Deprecate `power_*` as TOML input keys (reusing the centralized mechanism)**
- Generalize `_drop_deprecated_ffs_keys!(table)` → `_drop_deprecated_keys!(table, deprecated_keys, section)` in `src/GeneralizedPerturbedEquilibrium.jl`.
- Add `_DEPRECATED_EQUIL_KEYS = ("power_bp", "power_b", "power_r", "power_rc")`, applied on both the `gpec.toml` (`build_inputs_from_toml`) and h5-replay (`src/Rerun.jl`) input paths. A stale `power_*` key now **warns loudly and is dropped** instead of silently overriding the coordinate system.
- Fix a latent bug: `_DEPRECATED_FFS_KEYS = ("mer_flag")` was a *string* (not a 1-tuple), so `for k in …` iterated its characters and the FFS deprecation never fired. Now `("mer_flag",)`.

**Docs & examples**
- Update the `EquilibriumConfig` docstring (surfaced via `@autodocs`) and `docs/src/conventions.md` to document `custom` and the `jac_custom_power_*` fields with `J = Bp^bp · B^b / (R^r · rfac^rc)`.
- Standardize the `jac_type` option-list comment to `(hamada, pest, boozer, equal_arc, park, custom)` and remove the now-inactive `power_*` lines from the example/test `gpec.toml` files (safe — named types force the exponents regardless of file contents).

## Verification

- Unit checks: `custom` copies knobs → internal exponents and normalizes to the named fast path when they match; a non-standard set stays `custom` with manual exponents; named types force exponents and ignore custom knobs; the deprecation warns + drops and the config still builds from `jac_type`; all 19 example/test `gpec.toml` files parse.
- **Regression harness (`diiid_n1`, `solovev_n1`, `solovev_multi_n`, local vs develop): every quantity 0.0e+00 diff** — the change is numerically inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)