### PR TITLE
KineticForces - BUG FIX - Coulomb logarithm uses natural log, not log10

### DIFF
--- a/src/Equilibrium/KineticProfiles.jl
+++ b/src/Equilibrium/KineticProfiles.jl
@@ -267,7 +267,8 @@ function load_kinetic_profiles(kinetic_file::AbstractString;
         z = n_e > 0 ? zimp - (n_i / n_e) * zi * (zimp - zi) : Float64(zimp)
         zpitch = 1.0 + (1.0 + mimp) / (2.0 * mimp) * zimp * (z - 1.0) / (zimp - z)
 
-        ll = 17.3 - 0.5 * log10(n_e / 1.0e20) + 1.5 * log10(T_e / 1.602e-16)
+        # Coulomb logarithm (NRL formulary form), natural log; n_e in 1e20 m^-3, T_e in keV.
+        ll = 17.3 - 0.5 * log(n_e / 1.0e20) + 1.5 * log(T_e / 1.602e-16)
         loglam[i] = ll
 
         nui[i] = T_i > 0 ?


### PR DESCRIPTION
## Summary

The Coulomb logarithm in the kinetic-profile collisionality (`src/Equilibrium/KineticProfiles.jl`) was computed with **`log10`** where it must use **natural log**:

```julia
# before
ll = 17.3 - 0.5*log10(n_e/1.0e20) + 1.5*log10(T_e/1.602e-16)
# after
ll = 17.3 - 0.5*log(n_e/1.0e20)   + 1.5*log(T_e/1.602e-16)
```

The `17.3 / -0.5 / +1.5` coefficients are calibrated for natural log — they are the **NRL Plasma Formulary** electron-ion Coulomb logarithm

  λ_ei = 23 − ln(nₑ^{1/2} · Tₑ^{−3/2})   (nₑ in cm⁻³, Tₑ in eV)

re-normalized to GPEC units (nₑ / 10²⁰ m⁻³, Tₑ / 1 keV = 1.602e-16 J): the constant becomes **17.24 ≈ 17.3**, and the +1.5 coefficient on ln(Tₑ) is the signature of the Tₑ^{−3/2} regime (impossible with log₁₀). This also matches the Fortran reference `pentrc/inputs.f90:238`, which uses `log()` (natural log in Fortran).

## Impact

lnΛ, and the collision frequencies `nue`/`nui` that scale linearly with it, ran **~13% low at a 20 keV core** (19.2 vs the correct 21.7). The error vanishes near the reference point (nₑ=10²⁰, Tₑ=1 keV) and grows with temperature.

## Verification

- **Formulary + reference**: derivation above; matches NRL and Fortran PENTRC.
- **Regression** (`diiid_n1`): `NTV torque FGAR` and `NTV kinetic energy dW FGAR` shift +0.06% / +0.22% — within tolerance, correct direction, small because that case sits near the log reference point. No other quantity is attributable to the change (the touched code is the collision frequency; the delta-prime/resonant-field scatter is pre-existing threaded-reduction non-determinism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsLUydP2gJbE1tGoaHDiS1