### PR TITLE
EXPERIMENT: Issue #376 mpsi investigation — handoff (do not merge)

### DIFF
--- a/handoff/issue376/HANDOFF.md
+++ b/handoff/issue376/HANDOFF.md
@@ -1,8 +1,10 @@
 # Handoff — issue #376 mpsi/ForceFreeStates performance investigation
 
-**Date:** 2026-08-14. **Base:** `performance/regression-harness-threading` @ e7bb7cb8.
-**Status:** investigation essentially complete; one discriminator run pending; issue comment not
-yet drafted/posted.
+**Date:** 2026-08-14, updated 2026-08-15. **Base:** §2–§5 measured on
+`performance/regression-harness-threading` @ e7bb7cb8; §6 onward on this branch's tree (post
+on-demand-solution-derivatives merge) — see the note at the end of RESULTS.md §6.
+**Status:** investigation complete. Tolerance sweep done (RESULTS.md §6). Issue comment drafted in
+`ISSUE_COMMENT.md` — **not posted**; awaiting the user's review.
 
 ## What was established (details + tables in RESULTS.md)
 
@@ -19,17 +21,16 @@ yet drafted/posted.
 
 ## Loose ends for the next session
 
-1. **Tolerance discriminator landed** (see RESULTS.md §5): tol 1e-8 at mpsi=512 → nstep
-   1629 vs 3010, identical et[1]. Both mechanisms confirmed: dψ ∝ knotΔ at fixed tol,
-   dψ ∝ tol^{1/9} at fixed grid. A tolerance-sweep (1e-6 … 1e-12) checking et[1]/Δ′ stability
-   would firm up a recommendation to relax the default `eulerlagrange_tolerance`.
-2. **Draft the issue #376 comment** (do not post without the user's review — user chose
-   draft-for-review). Content = RESULTS.md conclusion + tables + ranked follow-ups.
-3. Optional cheap experiment from the ranked list: swap Vern9 → Vern7/Tsit5 in
-   `integrate_el_region!` (`src/ForceFreeStates/EulerLagrange.jl:766`) and in the Riccati
-   chunk solves (`src/ForceFreeStates/Riccati.jl:1442,1454`), rerun the ladder point at
-   mpsi=1024, compare EL wall time at equal physics (et[1], Δ′). Regression harness required
-   for any such change: `regress --cases diiid_n1 --refs develop,local`.
+1. **Tolerance sweep — done** (RESULTS.md §6). et[1] is invariant across 1e-6…1e-12; Δ′ is the
+   discriminator; 1e-8 is the sweet spot. EL wall time is sub-linear in nstep at fixed grid.
+2. **Issue comment — drafted, not posted.** `ISSUE_COMMENT.md` holds the full text. Posting needs
+   the user's explicit go-ahead (`gh issue comment 376 --body-file handoff/issue376/ISSUE_COMMENT.md`).
+3. **Integrator-order experiment — done** (RESULTS.md §7). Result recorded there; the `src/` edits
+   were reverted, so this branch still touches no source. If it is worth pursuing, it lands on its
+   own branch with `regress --cases diiid_n1 --refs develop,local`.
+4. Remaining ranked follow-ups (smoothing splines for F/K/G, equilibrium `etol` noise floor, and
+   any per-deck `eulerlagrange_tolerance` change) are unstarted — each needs its own branch and a
+   regression-harness run.
 
 ## How to reproduce the runs
 
@@ -40,6 +41,10 @@ julia --project=. handoff/issue376/parse_ladder.jl        # expects mpsi_<N>.log
 julia --project=. handoff/issue376/step_regions.jl        # step distribution vs psi
 julia --project=. handoff/issue376/step_vs_knot.jl        # dpsi / knot-spacing ratios
 julia --project=. handoff/issue376/microbench_mpsi.jl     # standalone, no inputs needed
+
+# tolerance sweep: one run dir per tolerance (run_<tol>/ with mpsi=512 and that
+# eulerlagrange_tolerance) plus its tol_<tol>.log, then
+julia --project=. handoff/issue376/parse_tolsweep.jl <sweep_dir>
 ```
 
 The parse/step scripts look for logs and run dirs in their own directory (`@__DIR__`); either

--- a/handoff/issue376/HANDOFF.md
+++ b/handoff/issue376/HANDOFF.md
@@ -49,7 +49,18 @@ julia --project=. handoff/issue376/microbench_mpsi.jl     # standalone, no input
 # tolerance sweep: one run dir per tolerance (run_<tol>/ with mpsi=512 and that
 # eulerlagrange_tolerance) plus its tol_<tol>.log, then
 julia --project=. handoff/issue376/parse_tolsweep.jl <sweep_dir>
+
+# mechanism (RESULTS.md 8-9). Stripped decks run in ~31 s instead of ~220 s: drop the
+# [ForcingTerms]/[PerturbedEquilibrium]/[KineticForces] sections and set
+# local_stability_flag = false. Everything else stays as the example ships it.
+julia --project=. handoff/issue376/roughness.jl <rundir> [<rundir> ...]         # F/K/G
+GPEC_ROUGHNESS_MATS=A,D,C,E,H,F,K,G julia --project=. handoff/issue376/roughness.jl <rundir>
 ```
+
+Read the **mid-plasma (0.3-0.7)** rows for the clean diagnosis: near the axis the r1 statistic is
+unreliable on the strongly graded grid (A and D read r1 < -2/3 there despite a 2e-7 residual), and
+genuine psi->0 structure is mixed in with the noise. `PREDICTIONS.md` records what each hypothesis
+predicted, written before the runs.
 
 The parse/step scripts look for logs and run dirs in their own directory (`@__DIR__`); either
 run them from a scratch dir containing `mpsi_<N>.log` + `run_<N>/`, or adjust `LADDER_DIR`.

--- a/handoff/issue376/HANDOFF.md
+++ b/handoff/issue376/HANDOFF.md
@@ -28,9 +28,13 @@ on-demand-solution-derivatives merge) — see the note at the end of RESULTS.md 
 3. **Integrator-order experiment — done** (RESULTS.md §7). Result recorded there; the `src/` edits
    were reverted, so this branch still touches no source. If it is worth pursuing, it lands on its
    own branch with `regress --cases diiid_n1 --refs develop,local`.
-4. Remaining ranked follow-ups (smoothing splines for F/K/G, equilibrium `etol` noise floor, and
-   any per-deck `eulerlagrange_tolerance` change) are unstarted — each needs its own branch and a
-   regression-harness run.
+4. **Mechanism established** (RESULTS.md §8–§9, new `roughness.jl`): a ~1e-5 relative node-error
+   floor in the C/E/H coefficient matrices, amplified as ε/Δ² by spline interpolation. `etol`,
+   `mtheta` and the input equilibrium were each tested and ruled out as the source.
+5. **The one open follow-up that matters**: find what sets the ~1e-5 floor in C/E/H —
+   `Fourfit.jl:439-447`, the construction of `g31`, `jtheta`/`imat`, `q1` — given that A/B/D
+   (g22/g23/g33 only) are clean at 1e-8 and converging. Needs its own branch and a
+   regression-harness run. Do **not** re-test `etol`/`mtheta`/input resolution; §8 closed those.
 
 ## How to reproduce the runs
 

--- a/handoff/issue376/HANDOFF.md
+++ b/handoff/issue376/HANDOFF.md
@@ -19,12 +19,10 @@ yet drafted/posted.
 
 ## Loose ends for the next session
 
-1. **Pending run:** `eulerlagrange_tolerance=1e-8` at mpsi=512 (auto packing) was still running
-   at handoff on the previous machine (scratch dir `…/scratchpad/ladder/run_tol512`). Its output
-   did not make it into this branch. Re-run if needed: copy the DIIID example inputs, set
-   `mpsi=512`, `eulerlagrange_tolerance=1e-8`, and use `run_one.jl <dir>`; read
-   `integration/psi` from the produced `gpec.h5`. Prediction under the knot-slaving mechanism:
-   nstep barely drops vs 3010 despite 100× looser tolerance.
+1. **Tolerance discriminator landed** (see RESULTS.md §5): tol 1e-8 at mpsi=512 → nstep
+   1629 vs 3010, identical et[1]. Both mechanisms confirmed: dψ ∝ knotΔ at fixed tol,
+   dψ ∝ tol^{1/9} at fixed grid. A tolerance-sweep (1e-6 … 1e-12) checking et[1]/Δ′ stability
+   would firm up a recommendation to relax the default `eulerlagrange_tolerance`.
 2. **Draft the issue #376 comment** (do not post without the user's review — user chose
    draft-for-review). Content = RESULTS.md conclusion + tables + ranked follow-ups.
 3. Optional cheap experiment from the ranked list: swap Vern9 → Vern7/Tsit5 in

--- a/handoff/issue376/HANDOFF.md
+++ b/handoff/issue376/HANDOFF.md
@@ -1,0 +1,66 @@
+# Handoff — issue #376 mpsi/ForceFreeStates performance investigation
+
+**Date:** 2026-08-14. **Base:** `performance/regression-harness-threading` @ e7bb7cb8.
+**Status:** investigation essentially complete; one discriminator run pending; issue comment not
+yet drafted/posted.
+
+## What was established (details + tables in RESULTS.md)
+
+1. FastInterpolations series-spline eval is flat in knot count (~890 ns/eval, 676 series,
+   hinted, zero-alloc). Search/hints are not the problem.
+2. The EL slowdown at large mpsi is **step-count growth at flat per-step cost**: accepted step
+   size stays a constant fraction (~0.12 median) of the *local knot spacing*, so nstep tracks
+   knot count where knots pack (dominantly ψ<0.1 on log-family grids; edge secondarily).
+   Singular-surface step counts are mpsi-flat.
+3. Uniform-grid discriminator (mpsi=512): near-axis steps 1891→559, nstep 3010→2237 —
+   confirms knot-density slaving over axis physics.
+4. The two-pass auto grid (mpsi=0) reaches converged et[1]≈0.80 with 558 knots and ~half the
+   EL time of a fixed 1024 log grid.
+
+## Loose ends for the next session
+
+1. **Pending run:** `eulerlagrange_tolerance=1e-8` at mpsi=512 (auto packing) was still running
+   at handoff on the previous machine (scratch dir `…/scratchpad/ladder/run_tol512`). Its output
+   did not make it into this branch. Re-run if needed: copy the DIIID example inputs, set
+   `mpsi=512`, `eulerlagrange_tolerance=1e-8`, and use `run_one.jl <dir>`; read
+   `integration/psi` from the produced `gpec.h5`. Prediction under the knot-slaving mechanism:
+   nstep barely drops vs 3010 despite 100× looser tolerance.
+2. **Draft the issue #376 comment** (do not post without the user's review — user chose
+   draft-for-review). Content = RESULTS.md conclusion + tables + ranked follow-ups.
+3. Optional cheap experiment from the ranked list: swap Vern9 → Vern7/Tsit5 in
+   `integrate_el_region!` (`src/ForceFreeStates/EulerLagrange.jl:766`) and in the Riccati
+   chunk solves (`src/ForceFreeStates/Riccati.jl:1442,1454`), rerun the ladder point at
+   mpsi=1024, compare EL wall time at equal physics (et[1], Δ′). Regression harness required
+   for any such change: `regress --cases diiid_n1 --refs develop,local`.
+
+## How to reproduce the runs
+
+```bash
+# per mpsi: copy example inputs into a fresh dir, edit gpec.toml (mpsi = N), then
+julia --project=. handoff/issue376/run_one.jl <run_dir>   # cold+warm, TSMARK timestamps
+julia --project=. handoff/issue376/parse_ladder.jl        # expects mpsi_<N>.log + run_<N>/ in its dir
+julia --project=. handoff/issue376/step_regions.jl        # step distribution vs psi
+julia --project=. handoff/issue376/step_vs_knot.jl        # dpsi / knot-spacing ratios
+julia --project=. handoff/issue376/microbench_mpsi.jl     # standalone, no inputs needed
+```
+
+The parse/step scripts look for logs and run dirs in their own directory (`@__DIR__`); either
+run them from a scratch dir containing `mpsi_<N>.log` + `run_<N>/`, or adjust `LADDER_DIR`.
+Warm-run numbers (RUN2) are the meaningful ones. Note: run GPEC comparisons single-threaded or
+all with `-t auto`, consistently — the ladder above was single-threaded.
+
+## Remove this handoff directory when done
+
+This directory (`handoff/issue376/`) is a transfer vehicle, not repo content — per repo policy
+benchmark artifacts do not get committed. Once the investigation lands (issue comment posted,
+any follow-up implemented on its own branch):
+
+```bash
+git rm -r handoff/issue376
+git commit -m "FFS - CHORE - Remove issue #376 handoff artifacts"
+git push
+```
+
+Then close the associated PR **without merging** (it exists only for machine transfer), or if
+any part of the PR is to be kept, strip this directory from it first. Never merge the handoff
+directory into develop.

--- a/handoff/issue376/ISSUE_COMMENT.md
+++ b/handoff/issue376/ISSUE_COMMENT.md
@@ -75,10 +75,9 @@ Two discriminators confirm the mechanism at mpsi = 512:
   (100^(1/9) ≈ 1.7).
 
 So the step size is genuinely error-controlled — but the error *magnitude* per unit ψ is set by
-knot-scale roughness in the interpolated F/K/G coefficients. Hence dψ ∝ knotΔ at fixed tolerance
-and dψ ∝ tol^(1/9) at fixed grid. Physically this is (i) the C² knot discontinuities of a cubic
-spline, which a 9th-order error estimator cannot cheaply step across, plus (ii) node-noise
-amplification on fine grids (the h⁻⁴ effect already warned about in `GridRefinement.jl`).
+knot-scale roughness in the interpolated F/K/G coefficients, not by the physics. §6 is about where
+that roughness comes from, because "it's the same smooth function, just sampled more finely" is
+the natural expectation and it turns out to be false.
 
 ### 4. Tolerance sweep — how tight does `eulerlagrange_tolerance` actually need to be?
 
@@ -86,13 +85,16 @@ Five runs at mpsi = 512 (513 knots), everything but the tolerance held fixed. Δ
 relative to the 1e-12 point; `Δ'diag` is the worst per-surface relative error on the
 `singular/delta_prime_matrix` diagonal.
 
-| tol | nstep | attempted | ψ<0.1 steps | EL (s) | et[1] | Δ'diag rel |
-|---|---|---|---|---|---|---|
-| 1e-6  | 929  | 1159 | 591  | 10.1 | 0.78255904 | 1.7e-02 |
-| 1e-7  | 1240 | 1565 | 807  | 12.2 | 0.78255903 | 3.3e-03 |
-| 1e-8  | 1656 | 2116 | 1090 | 14.7 | 0.78255906 | 6.9e-04 |
-| 1e-10 | 3018 | 3977 | 1893 | 18.9 | 0.78255905 | 6.2e-06 |
-| 1e-12 | 7297 | 9620 | 3732 | 32.9 | 0.78255905 | 0 (ref)  |
+| tol | accepted steps | saved | EL (s) | et[1] | Δ'diag rel |
+|---|---|---|---|---|---|
+| 1e-6  | 1159 | 929  | 10.1 | 0.78255904 | 1.7e-02 |
+| 1e-7  | 1565 | 1240 | 12.2 | 0.78255903 | 3.3e-03 |
+| 1e-8  | 2116 | 1656 | 14.7 | 0.78255906 | 6.9e-04 |
+| 1e-10 | 3977 | 3018 | 18.9 | 0.78255905 | 6.2e-06 |
+| 1e-12 | 9620 | 7297 | 32.9 | 0.78255905 | 0 (ref)  |
+
+(`integration/nstep_total` is accepted steps; `integration/nstep` is saved snapshots at
+`save_interval = 3`. Rejected steps are not recorded anywhere.)
 
 Three things worth knowing:
 
@@ -101,11 +103,14 @@ Three things worth knowing:
   the q = 5 row: −1460 at 1e-6, −1332 at 1e-7, −1321 at 1e-8, −1319.5 at 1e-10). **1e-8 — the
   `ForceFreeStatesControl` default — is the sweet spot**: 1.8× fewer steps than 1e-10 for 7e-4
   relative Δ' error.
-- **Step count scales as tol^(−1/6.7)**, a little steeper than the ideal 9th-order tol^(−1/9),
-  exactly as expected when the error being controlled is knot-scale roughness rather than the
-  smooth truncation term. The rejected-step fraction is flat (0.20–0.24), so this is not a
-  step-control artefact.
-- **EL wall time is sub-linear in nstep**: 1e-10 → 1e-8 cuts accepted steps 1.82× but EL time only
+- **Vern9 never achieves its formal order.** Per-decade exponents of h ∝ tol^α: 0.130, 0.131,
+  0.137, then **0.192** for the last two decades. A 9th-order method on a smooth integrand should
+  give α = 1/(p+1) = 0.100, or 0.111 under error-per-unit-step. Measured α is outside both
+  everywhere and degrades sharply at tight tolerance — an error floor that is not truncation
+  error. Vern7 over the same range gives α = 0.131, comfortably inside its own formal band
+  (0.125–0.143): the 7th-order method behaves as advertised, the 9th-order one does not. §6
+  explains why.
+- **EL wall time is sub-linear in step count**: 1e-10 → 1e-8 cuts accepted steps 1.88× but EL time only
   1.29×. There is a ~7 s tolerance-independent floor in that phase on this deck. And the whole
   warm run is ~220 s regardless of tolerance — at mpsi = 512 with the NTV section active, EL
   integration is under 10% of the run. Tolerance relaxation is real but second-order here; it
@@ -117,12 +122,12 @@ If steps cannot span a knot interval anyway, Vern9's 16 stages per step are wast
 six `Vern9()` call sites inside `ForceFreeStates` for `Vern7()` (10 stages), left the
 equilibrium-side ones alone, and reran at mpsi = 512 (edits reverted afterwards):
 
-| method | tol | nstep | EL (s) | ms/step | et[1] | Δ'diag rel |
+| method | tol | accepted steps | EL (s) | ms/step | et[1] | Δ'diag rel |
 |---|---|---|---|---|---|---|
-| Vern9 | 1e-10 | 3018 | 18.9 | 6.26 | 0.782559048 | 6.2e-06 |
-| Vern7 | 1e-10 | 4163 | 15.3 | 3.67 | 0.782559048 | 2.5e-04 |
-| Vern9 | 1e-8  | 1656 | 14.7 | 8.85 | 0.782559057 | 6.9e-04 |
-| Vern7 | 1e-8  | 2317 | 10.9 | 4.70 | 0.782559050 | 2.5e-04 |
+| Vern9 | 1e-10 | 3977 | 18.9 | 4.75 | 0.782559048 | 6.2e-06 |
+| Vern7 | 1e-10 | 5355 | 15.3 | 2.86 | 0.782559048 | 2.5e-04 |
+| Vern9 | 1e-8  | 2116 | 14.7 | 6.95 | 0.782559057 | 6.9e-04 |
+| Vern7 | 1e-8  | 2927 | 10.9 | 3.72 | 0.782559050 | 2.5e-04 |
 
 Vern7 takes ~40% more steps but each step is 1.7× cheaper, so EL wall time drops ~20% at 1e-10 and
 ~26% at 1e-8. **Vern7 at 1e-8 dominates Vern9 at 1e-8 on both axes** — faster *and* closer to the
@@ -132,6 +137,76 @@ One caveat before anyone acts on this: Vern7's Δ' deviation is 2.47e-4 at 1e-10
 1e-8, i.e. **tolerance-independent**, so it is not step-truncation error. Something in the
 propagator/matching path carries a method-dependent offset that Vern9 does not. It is small, but
 it should be understood rather than absorbed.
+
+### 6. Why refining the grid makes the integrand *rougher* — the actual mechanism
+
+The integrand is the same smooth function only down to the accuracy of the node data. Below that,
+adding knots does not add information; it just interpolates the error more finely.
+
+Diagnostic: second divided differences of `matrices/ideal/F,K,G` (the actual EL integrand splines)
+at their own knots. Two statistics — `r1`, the knot-to-knot autocorrelation of f'' (**+1 = smooth,
+−2/3 = white noise**), and |f''|/|f|. `q(ψ)` on the same grid is the control.
+
+| region | quantity | mpsi=256 | mpsi=512 | mpsi=1024 |
+|---|---|---|---|---|
+| ψ<0.1 | K: r1 / \|f''\|/\|f\| | −0.42 / 1.01e7 | −0.45 / 4.53e7 | −0.56 / 1.62e8 |
+| ψ<0.1 | F: r1 / \|f''\|/\|f\| | +0.91 / 4.48e3 | +0.67 / 4.10e3 | −0.32 / 4.65e3 |
+| 0.3–0.7 | F: r1 / \|f''\|/\|f\| | +0.91 / 1.730 | +0.96 / 1.712 | +0.97 / 1.705 |
+| 0.3–0.7 | G: r1 / \|f''\|/\|f\| | +0.83 / 3.66 | +0.86 / 3.87 | −0.18 / 3.99 |
+| all | **q control r1** | **+0.88…+0.94** | **+0.94…+0.97** | **+0.97** |
+
+Near-axis K grows 4.5× then 3.6× per doubling — the Δ⁻² of a fixed-amplitude node error — while
+r1 marches toward the white-noise value. Meanwhile mid-plasma F converges beautifully
+(1.730 → 1.712 → 1.705): where the grid is still coarse relative to the noise, the physics
+dominates and your intuition holds exactly. The noise floor simply spreads outward with mpsi —
+axis first, then edge, then mid-plasma.
+
+**Three candidate sources tested and ruled out**, all at fixed mpsi = 512:
+
+| knob | range tested | effect on accepted steps |
+|---|---|---|
+| `etol` (field-line integration tolerance) | 1e-8 → 1e-12 | 4038 → 3930 (2.7%) |
+| `mtheta` (poloidal resolution) | 256 → 1024 | 3977 → 3983 (0.3%) |
+| input equilibrium | 257×257 EFIT vs analytic Solovev | Solovev diverges the same, or worse |
+
+So it is not the ODE tolerance, not the poloidal quadrature, and not the finite resolution of the
+input reconstruction. It is generated inside the equilibrium → coefficient pipeline.
+
+**Localised.** A local degree-4 fit residual over a 9-knot window measures the node-error amplitude
+directly (smooth data → falls like Δ⁵; a floor → flat). Mid-plasma:
+
+| matrix | built from | resid @512 | resid @1024 | r1 @512 | r1 @1024 |
+|---|---|---|---|---|---|
+| A, B, D | g22, g23, g33 | ~6e-08 | **~1.3e-08** | +0.972 | **+0.987** |
+| C | + g31, jtheta·imat | 8.90e-06 | 1.21e-05 | +0.694 | **−0.401** |
+| E | + g31, jtheta·imat, q1 | 8.74e-06 | 1.17e-05 | +0.547 | **−0.400** |
+| H | + g31, jtheta·imat | 1.11e-05 | 1.41e-05 | +0.837 | **+0.022** |
+| F = F̃ − D†A⁻¹D | clean inputs | 2.48e-07 | 1.96e-07 | +0.957 | +0.973 |
+| K = E − K†A⁻¹C | dirty inputs | 1.22e-05 | 1.56e-05 | +0.916 | +0.593 |
+| G = H − C†A⁻¹C | dirty inputs | 1.01e-05 | 1.70e-05 | +0.856 | −0.176 |
+
+**The floor enters at C, E, H at the ~1e-5 relative level.** A/B/D are clean at 1e-8 *and still
+converging*, exactly as smooth data should. The derived-matrix algebra is not the culprit either —
+F goes through the same `A⁻¹` path and stays clean at 2e-7 because its inputs are clean; K and G
+are dirty only because E, C and H are. Per `Fourfit.jl:439-447`, the three dirty matrices are
+precisely the ones involving **g31**, **jtheta·imat** and (for E) **q1 = dq/dψ**; the clean ones
+use only g22/g23/g33.
+
+### So, the answer to the question in the title
+
+1. C/E/H node values carry a relative error of ~1e-5 that **does not shrink with mpsi**.
+2. The cubic spline interpolates that error exactly, contributing ~ε/Δ² to f'' — growing 4× per
+   mpsi doubling.
+3. Once ε/Δ² exceeds the physical curvature, the integrand is dominated by knot-scale structure —
+   near axis first, spreading outward.
+4. The adaptive controller prices that structure, so the step collapses onto the knot scale:
+   dψ ∝ Δ, ~6 steps per knot interval, invariant in mpsi.
+5. Because the controlled error is not smooth truncation error, Vern9 cannot reach its formal
+   order — hence §4's exponents and §5's result that Vern7 loses nothing.
+
+The premise "same smooth function, just sampled more finely" is true of the physics and false of
+the data. Below the 1e-5 floor, refining the grid doesn't improve the integrand — it makes the
+interpolant measurably rougher in exactly the derivative norms the error estimator reads.
 
 ### Recommendations
 
@@ -146,11 +221,11 @@ it should be understood rather than absorbed.
 3. **Switch the ForceFreeStates integrator to Vern7** — measured in §5, ~20–26% off the EL phase,
    with better Δ' than Vern9 at the same tolerance. Gated on explaining the tolerance-independent
    2.5e-4 Δ' offset first; then its own branch and a regression-harness run.
-4. **Smoother coefficients** — fitting F/K/G with smoothing (or higher-continuity) splines instead
-   of pure interpolation would lift the knot-scale noise floor that currently pins the step size.
-   This is the only change that would actually decouple nstep from mpsi rather than rescale it.
-5. **Node-noise floor** — tightening the equilibrium field-line integration tolerance (`etol`)
-   reduces the noise that fine grids amplify; worth checking at high mpsi.
+4. **Fix the ~1e-5 node-error floor in C/E/H** — this is the root cause and the only change that
+   would genuinely decouple nstep from mpsi rather than rescale it. `Fourfit.jl:439-447` and the
+   construction of `g31`, `jtheta`/`imat` and `q1` are the place to start, since A/B/D are clean
+   at 1e-8 and converging. Failing that, fit C/E/H with smoothing rather than interpolating
+   splines so the floor is not differentiated.
 
 One bookkeeping note: the
 mpsi ladder (§2–§3) was measured a few merges earlier than the tolerance sweep (§4); the shared

--- a/handoff/issue376/ISSUE_COMMENT.md
+++ b/handoff/issue376/ISSUE_COMMENT.md
@@ -1,0 +1,136 @@
+# DRAFT — proposed comment for issue #376 (not posted; awaiting user review)
+
+---
+
+## Answer: spline evaluation is not the bottleneck — adaptive step count is
+
+I measured this end to end on `examples/DIIID-like_ideal_example` (ideal path, `kinetic_factor = 0`),
+single-threaded, Vern9, `eulerlagrange_tolerance = 1e-10` unless stated otherwise. Short version:
+
+**The hint-based spline lookup already does exactly what the issue hoped — evaluation cost is
+flat in knot count. There is nothing left to win there.** The mpsi slowdown is entirely
+**adaptive step-count growth**: the integrator's accepted step size is slaved to the *local knot
+spacing*, so `nstep` scales with the number of knots in the regions where steps concentrate.
+
+### 1. Spline evaluation is knot-count-independent
+
+`CubicSeriesInterpolant`, 676 `ComplexF64` series (mirrors `fmats`/`kmats`/`gmats` at `numpert = 26`),
+non-uniform `Vector` grid, in-place eval, persistent `Ref(1)` hint, 16k queries:
+
+| npts | mono ns/ev | stage ns/ev | no-hint mono | range grid | 3-sep stage | B/eval |
+|---|---|---|---|---|---|---|
+| 33   | 880 | 928 | 890 | 889 | 883 | 0 |
+| 129  | 898 | 913 | 915 | 925 | 893 | 0 |
+| 513  | 898 | 906 | 930 | 890 | 896 | 0 |
+| 1025 | 887 | 889 | 937 | 991 | 1020 | 0 |
+| 2049 | 892 | 909 | 948 | 901 | 935 | 0 |
+
+Flat from 33 to 2049 knots, zero allocations. The hint buys only ~5% here because the 676-series
+payload dominates the lookup entirely. A single-series control (the `q_spline` analogue) runs
+~2 ns/eval hinted and 5→13 ns unhinted across the same range — the expected O(log n), and
+negligible. So `precompute_transpose!`, extra hints, and merged `SeriesInterpolant`s were measured
+and **dropped**: there is no knot-length sensitivity left in the evaluation path to remove.
+
+### 2. What actually grows: the number of ODE steps
+
+mpsi ladder, warm runs (second `main()` call in one process, JIT excluded):
+
+| mpsi | knots | EL integration (s) | nstep | ms/step | ballooning (s) | et[1] |
+|---|---|---|---|---|---|---|
+| 128  | 129  | 9.3  | 1190 | 7.8 | 1.7  | 1.391 |
+| 256  | 257  | 10.0 | 1753 | 5.7 | 3.7  | 0.376 |
+| 512  | 513  | 18.5 | 3010 | 6.2 | 8.2  | 0.783 |
+| 1024 | 1025 | 32.4 | 5683 | 5.7 | 18.7 | 0.803 |
+| auto | 558  | 16.9 | 2542 | 6.6 | 17.4 | 0.801 |
+
+EL time ∝ nstep, and **ms/step is flat** — per-step cost is mpsi-independent (Npert-sized LAPACK
+dominates it, not interpolation). The whole slowdown is the step count.
+
+### 3. The steps pile up where the knots pack, not where the physics is
+
+Accepted steps binned by ψ:
+
+| region | 128 | 256 | 512 | 1024 | auto |
+|---|---|---|---|---|---|
+| ψ < 0.1 (axis packing)   | 553 | 964 | 1891 | 3806 | 581 |
+| 0.985–0.9935 (edge pack) | 117 | 157 | 217  | 418  | 227 |
+| q = 2 surface ±          | 63  | 62  | 64   | 67   | 112 |
+| q = 3 surface ±          | 59  | 60  | 58   | 59   | 87  |
+
+Singular-surface neighbourhoods are **mpsi-flat** — those steps are physics-controlled, as they
+should be. All the growth is in the near-axis region where the log-family grid packs hardest.
+
+Within ψ < 0.1, knot counts 73/145/289 (mpsi 128/256/512) give 553/964/1891 steps, and the ratio
+dψ/knotΔ has p25/median/p75 = 0.06/0.12/0.21 **at every mpsi** — about 6.5 accepted steps per knot
+interval, invariant. If steps were tolerance- or physics-limited, dψ would be mpsi-independent;
+instead it halves whenever the knot spacing halves.
+
+Two discriminators confirm the mechanism at mpsi = 512:
+
+- **`grid_type = "uniform"`** (un-packs the axis): near-axis steps 1891 → **559**, total nstep
+  3010 → **2237**. Steps follow knot density, not axis physics. (This is a mechanism probe, not a
+  config recommendation — the uniform grid is physically under-resolved near axis, et[1] = 0.993.)
+- **`eulerlagrange_tolerance = 1e-8`** (100× looser, same grid): nstep 3010 → **1629** with
+  identical physics (et[1] = 0.78286 at both). The 1.85× drop matches the 9th-order expectation
+  (100^(1/9) ≈ 1.7).
+
+So the step size is genuinely error-controlled — but the error *magnitude* per unit ψ is set by
+knot-scale roughness in the interpolated F/K/G coefficients. Hence dψ ∝ knotΔ at fixed tolerance
+and dψ ∝ tol^(1/9) at fixed grid. Physically this is (i) the C² knot discontinuities of a cubic
+spline, which a 9th-order error estimator cannot cheaply step across, plus (ii) node-noise
+amplification on fine grids (the h⁻⁴ effect already warned about in `GridRefinement.jl`).
+
+### 4. Tolerance sweep — how tight does `eulerlagrange_tolerance` actually need to be?
+
+Five runs at mpsi = 512 (513 knots), everything but the tolerance held fixed. Δ' deviations are
+relative to the 1e-12 point; `Δ'diag` is the worst per-surface relative error on the
+`singular/delta_prime_matrix` diagonal.
+
+| tol | nstep | attempted | ψ<0.1 steps | EL (s) | et[1] | Δ'diag rel |
+|---|---|---|---|---|---|---|
+| 1e-6  | 929  | 1159 | 591  | 10.1 | 0.78255904 | 1.7e-02 |
+| 1e-7  | 1240 | 1565 | 807  | 12.2 | 0.78255903 | 3.3e-03 |
+| 1e-8  | 1656 | 2116 | 1090 | 14.7 | 0.78255906 | 6.9e-04 |
+| 1e-10 | 3018 | 3977 | 1893 | 18.9 | 0.78255905 | 6.2e-06 |
+| 1e-12 | 7297 | 9620 | 3732 | 32.9 | 0.78255905 | 0 (ref)  |
+
+Three things worth knowing:
+
+- **et[1] is not a discriminator** — identical to 8 significant digits across six decades of
+  tolerance. Δ' is what actually degrades, and it degrades fast below 1e-8 (the worst surface is
+  the q = 5 row: −1460 at 1e-6, −1332 at 1e-7, −1321 at 1e-8, −1319.5 at 1e-10). **1e-8 — the
+  `ForceFreeStatesControl` default — is the sweet spot**: 1.8× fewer steps than 1e-10 for 7e-4
+  relative Δ' error.
+- **Step count scales as tol^(−1/6.7)**, a little steeper than the ideal 9th-order tol^(−1/9),
+  exactly as expected when the error being controlled is knot-scale roughness rather than the
+  smooth truncation term. The rejected-step fraction is flat (0.20–0.24), so this is not a
+  step-control artefact.
+- **EL wall time is sub-linear in nstep**: 1e-10 → 1e-8 cuts accepted steps 1.82× but EL time only
+  1.29×. There is a ~7 s tolerance-independent floor in that phase on this deck. And the whole
+  warm run is ~220 s regardless of tolerance — at mpsi = 512 with the NTV section active, EL
+  integration is under 10% of the run. Tolerance relaxation is real but second-order here; it
+  matters where EL dominates (large mpsi, no kinetic post-processing).
+
+### Recommendations
+
+1. **Use the two-pass auto grid** (`mpsi = 0` with `psi_accuracy`) — already the example default.
+   It reaches the converged et[1] ≈ 0.80 with 558 knots and about half the EL time of a fixed
+   1024-knot log grid. Minimising knots for a target accuracy is exactly what minimises EL time,
+   so the auto grid is the direct fix for the symptom in this issue.
+2. **Revisit the per-deck `eulerlagrange_tolerance`.** The struct default is `1e-8`; the DIII-D
+   decks pin `1e-10` and the LAR decks `1e-12`. On the evidence of §4 those tighter values buy
+   Δ' accuracy this case does not need, at 1.8–4× the step count. This is a per-deck edit on its
+   own branch with a regression-harness run, not a change to the struct default.
+3. **Integrator order** is worth one cheap experiment: Vern9's 16 stages/step buy nothing when a
+   step cannot span a knot interval anyway. A 5th–7th order method (Tsit5/Vern6/Vern7) may cut RHS
+   evaluations per accepted step ~2× at equal nstep, with no physics change.
+4. **Smoother coefficients** — fitting F/K/G with smoothing (or higher-continuity) splines instead
+   of pure interpolation would lift the knot-scale noise floor that currently pins the step size.
+   This is the only change that would actually decouple nstep from mpsi rather than rescale it.
+5. **Node-noise floor** — tightening the equilibrium field-line integration tolerance (`etol`)
+   reduces the noise that fine grids amplify; worth checking at high mpsi.
+
+Scripts and full tables are in the handoff branch (`handoff/issue376/`). One bookkeeping note: the
+mpsi ladder (§2–§3) was measured a few merges earlier than the tolerance sweep (§4); the shared
+mpsi = 512 / 1e-10 point agrees to 0.3% in nstep between the two, but the tables should not be
+mixed element-by-element.

--- a/handoff/issue376/ISSUE_COMMENT.md
+++ b/handoff/issue376/ISSUE_COMMENT.md
@@ -111,6 +111,28 @@ Three things worth knowing:
   integration is under 10% of the run. Tolerance relaxation is real but second-order here; it
   matters where EL dominates (large mpsi, no kinetic post-processing).
 
+### 5. Integrator order — Vern9 is the wrong tool here
+
+If steps cannot span a knot interval anyway, Vern9's 16 stages per step are wasted. I swapped all
+six `Vern9()` call sites inside `ForceFreeStates` for `Vern7()` (10 stages), left the
+equilibrium-side ones alone, and reran at mpsi = 512 (edits reverted afterwards):
+
+| method | tol | nstep | EL (s) | ms/step | et[1] | Δ'diag rel |
+|---|---|---|---|---|---|---|
+| Vern9 | 1e-10 | 3018 | 18.9 | 6.26 | 0.782559048 | 6.2e-06 |
+| Vern7 | 1e-10 | 4163 | 15.3 | 3.67 | 0.782559048 | 2.5e-04 |
+| Vern9 | 1e-8  | 1656 | 14.7 | 8.85 | 0.782559057 | 6.9e-04 |
+| Vern7 | 1e-8  | 2317 | 10.9 | 4.70 | 0.782559050 | 2.5e-04 |
+
+Vern7 takes ~40% more steps but each step is 1.7× cheaper, so EL wall time drops ~20% at 1e-10 and
+~26% at 1e-8. **Vern7 at 1e-8 dominates Vern9 at 1e-8 on both axes** — faster *and* closer to the
+converged Δ' — and is 42% faster than the deck's current Vern9 @ 1e-10.
+
+One caveat before anyone acts on this: Vern7's Δ' deviation is 2.47e-4 at 1e-10 and 2.50e-4 at
+1e-8, i.e. **tolerance-independent**, so it is not step-truncation error. Something in the
+propagator/matching path carries a method-dependent offset that Vern9 does not. It is small, but
+it should be understood rather than absorbed.
+
 ### Recommendations
 
 1. **Use the two-pass auto grid** (`mpsi = 0` with `psi_accuracy`) — already the example default.
@@ -121,9 +143,9 @@ Three things worth knowing:
    decks pin `1e-10` and the LAR decks `1e-12`. On the evidence of §4 those tighter values buy
    Δ' accuracy this case does not need, at 1.8–4× the step count. This is a per-deck edit on its
    own branch with a regression-harness run, not a change to the struct default.
-3. **Integrator order** is worth one cheap experiment: Vern9's 16 stages/step buy nothing when a
-   step cannot span a knot interval anyway. A 5th–7th order method (Tsit5/Vern6/Vern7) may cut RHS
-   evaluations per accepted step ~2× at equal nstep, with no physics change.
+3. **Switch the ForceFreeStates integrator to Vern7** — measured in §5, ~20–26% off the EL phase,
+   with better Δ' than Vern9 at the same tolerance. Gated on explaining the tolerance-independent
+   2.5e-4 Δ' offset first; then its own branch and a regression-harness run.
 4. **Smoother coefficients** — fitting F/K/G with smoothing (or higher-continuity) splines instead
    of pure interpolation would lift the knot-scale noise floor that currently pins the step size.
    This is the only change that would actually decouple nstep from mpsi rather than rescale it.

--- a/handoff/issue376/ISSUE_COMMENT.md
+++ b/handoff/issue376/ISSUE_COMMENT.md
@@ -152,7 +152,7 @@ it should be understood rather than absorbed.
 5. **Node-noise floor** — tightening the equilibrium field-line integration tolerance (`etol`)
    reduces the noise that fine grids amplify; worth checking at high mpsi.
 
-Scripts and full tables are in the handoff branch (`handoff/issue376/`). One bookkeeping note: the
+One bookkeeping note: the
 mpsi ladder (§2–§3) was measured a few merges earlier than the tolerance sweep (§4); the shared
 mpsi = 512 / 1e-10 point agrees to 0.3% in nstep between the two, but the tables should not be
 mixed element-by-element.

--- a/handoff/issue376/ISSUE_COMMENT.md
+++ b/handoff/issue376/ISSUE_COMMENT.md
@@ -70,9 +70,9 @@ Two discriminators confirm the mechanism at mpsi = 512:
 - **`grid_type = "uniform"`** (un-packs the axis): near-axis steps 1891 → **559**, total nstep
   3010 → **2237**. Steps follow knot density, not axis physics. (This is a mechanism probe, not a
   config recommendation — the uniform grid is physically under-resolved near axis, et[1] = 0.993.)
-- **`eulerlagrange_tolerance = 1e-8`** (100× looser, same grid): nstep 3010 → **1629** with
-  identical physics (et[1] = 0.78286 at both). The 1.85× drop matches the 9th-order expectation
-  (100^(1/9) ≈ 1.7).
+- **`eulerlagrange_tolerance = 1e-8`** (100× looser, same grid): accepted steps 3977 → **2116**
+  with identical physics (et[1] unchanged to 8 digits). The step size is genuinely error-controlled
+  — but at an effective order well short of Vern9's, see §4.
 
 So the step size is genuinely error-controlled — but the error *magnitude* per unit ψ is set by
 knot-scale roughness in the interpolated F/K/G coefficients, not by the physics. §6 is about where

--- a/handoff/issue376/PREDICTIONS.md
+++ b/handoff/issue376/PREDICTIONS.md
@@ -1,0 +1,13 @@
+Written BEFORE the runs, 2026-08-15.
+
+H1 "node-noise floor": each flux surface's coefficients are built by an independent field-line
+integration to tolerance etol, so node values carry an independent O(etol-ish) error. Refining the
+grid does not reduce that error, so the interpolant's derivatives pick it up amplified by 1/dpsi^k.
+  - etol A/B at fixed mpsi=512: nstep_total(1e-8) > nstep_total(1e-10) > nstep_total(1e-12).
+  - near-axis |f''|/|f| of K,G tracks etol; r1 moves toward -2/3 as etol loosens.
+  - ladder: near-axis |f''|/|f| grows ~4x per mpsi doubling (dpsi^-2); r1 stays negative.
+
+H2 "pure cubic-spline C2 structure with exact data": roughness comes only from interpolating an
+exactly-known smooth function, so
+  - etol A/B: nstep_total independent of etol.
+  - ladder: |f''|/|f| converges to the physical curvature; r1 stays positive at all mpsi.

--- a/handoff/issue376/RESULTS.md
+++ b/handoff/issue376/RESULTS.md
@@ -80,13 +80,52 @@ error estimator can't step across cheaply, and (ii) node-noise amplification on 
   The ~1.85× drop matches the 9th-order expectation (100^{1/9} ≈ 1.7): the step size is genuinely
   error-controlled, but the error *magnitude* per unit ψ is set by knot-scale roughness in the
   spline coefficients — so dψ ∝ knotΔ at fixed tolerance (§4) and ∝ tol^{1/9} at fixed grid.
-  Practical corollary: the default 1e-10 tolerance looks overly tight — 1e-8 halves EL cost on
-  this case with no change in et[1].
+  (The step count halves; §6 shows EL *wall time* does not — there is a step-independent floor.)
+
+## 6. Tolerance sweep (`parse_tolsweep.jl`, mpsi=512 fixed grid, 513 knots)
+
+Five warm runs, one process each, single-threaded, everything but `eulerlagrange_tolerance` fixed.
+Δ' deviations are relative to the 1e-12 point: `Δ'diag` = worst per-surface relative error on the
+`singular/delta_prime_matrix` diagonal, `Δ'mat` = max elementwise deviation over max|Δ'|.
+
+| tol | nstep | tried | ψ<0.1 | EL (s) | ms/step | run (s) | et[1] | Δ'diag rel | Δ'mat rel |
+|---|---|---|---|---|---|---|---|---|---|
+| 1e-6  | 929  | 1159 | 591  | 10.1 | 10.89 | 224.9 | 0.78255904 | 1.7e-02 | 7.5e-03 |
+| 1e-7  | 1240 | 1565 | 807  | 12.2 | 9.84  | 207.8 | 0.78255903 | 3.3e-03 | 6.5e-04 |
+| 1e-8  | 1656 | 2116 | 1090 | 14.7 | 8.85  | 216.0 | 0.78255906 | 6.9e-04 | 8.1e-05 |
+| 1e-10 | 3018 | 3977 | 1893 | 18.9 | 6.26  | 221.8 | 0.78255905 | 6.2e-06 | 4.3e-06 |
+| 1e-12 | 7297 | 9620 | 3732 | 32.9 | 4.51  | 234.6 | 0.78255905 | 0        | 0        |
+
+- **`et[1]` is not a discriminator**: identical to 8 significant digits across six decades of
+  tolerance. Any tolerance recommendation has to be made on Δ', not on the free-boundary energy.
+- **Δ' is the discriminator** and it degrades fast below 1e-8. The worst surface is the q=5 row
+  (|Δ'| ~ 1.3e3): −1460 at 1e-6, −1332 at 1e-7, −1321 at 1e-8, −1319.5 at 1e-10, converged at
+  1e-12. **1e-8 is the sweet spot** — 1.8× fewer steps than 1e-10 at 7e-4 relative Δ' error.
+- **Step count scales as tol^{−1/6.7}** over the full range (929 → 7297 for 10⁶ in tolerance),
+  slightly steeper than the ideal 9th-order tol^{−1/9}, as expected when the error being
+  controlled is knot-scale roughness rather than the smooth truncation term. The rejected-step
+  fraction is flat (0.20–0.24), so this is not a step-control artefact.
+- **EL wall time is sub-linear in nstep**: 1e-10 → 1e-8 cuts accepted steps 1.82× but EL time only
+  1.29× (18.9 → 14.7 s). A linear fit gives ~2.7 ms per attempted step plus a **~7 s
+  tolerance-independent floor** in the phase (which also contains the parallel-FM BVP setup and
+  the serial dense-ξ pass). The nstep → time proportionality of §2 holds across *grids*, not
+  across tolerances at fixed grid.
+- **Whole-run effect is small on this deck**: total warm run is ~220 s regardless of tolerance —
+  EL integration is under 10% of it at mpsi=512 (KineticForces/NTV and PE dominate). Tolerance
+  relaxation is worth ~4 s of ~220 s here; it matters where EL dominates (large mpsi, no NTV).
+
+Note: this sweep ran on the current branch tree, which has moved since the §2–§5 ladder
+(`e7bb7cb8`, before the on-demand-solution-derivatives merge). The 1e-10 point reproduces §5
+within 0.3% on nstep (3018 vs 3010) and 4e-4 relative on et[1] (0.782559 vs 0.78286); conclusions
+are unaffected, but do not mix numbers across the two tables.
 
 ## Implications / ranked follow-ups
 
 1. **Use the two-pass auto grid** (`mpsi=0`, `psi_accuracy`) — already the example default; it
    minimizes knots for a target accuracy, which this data shows is exactly what minimizes EL time.
+1b. **`eulerlagrange_tolerance = 1e-8`** (the struct default) is the right per-deck value on the
+   evidence of §6; the DIII-D decks' 1e-10 and the LAR decks' 1e-12 buy Δ' accuracy the case does
+   not need. Any such deck edit is a separate branch and needs the regression harness.
 2. **Integrator order**: Vern9's 16 stages/step buy nothing when steps can't span a knot
    interval. A 5–7th order method (Tsit5/Vern6/Vern7) may cut RHS evals per accepted step ~2×
    at equal nstep. Cheap experiment, no physics change.

--- a/handoff/issue376/RESULTS.md
+++ b/handoff/issue376/RESULTS.md
@@ -88,25 +88,42 @@ Five warm runs, one process each, single-threaded, everything but `eulerlagrange
 Δ' deviations are relative to the 1e-12 point: `Δ'diag` = worst per-surface relative error on the
 `singular/delta_prime_matrix` diagonal, `Δ'mat` = max elementwise deviation over max|Δ'|.
 
-| tol | nstep | tried | ψ<0.1 | EL (s) | ms/step | run (s) | et[1] | Δ'diag rel | Δ'mat rel |
+**Column semantics** (`GeneralizedPerturbedEquilibrium.jl:808-810`): `integration/nstep_total` is
+the number of **accepted solver steps** and is the physically meaningful count; `integration/nstep`
+and `integration/psi` are the **saved snapshots** (`save_interval = 3`, plus forced saves near
+rationals and in the edge band). Rejected steps are never recorded anywhere. The tables below and
+in §2–§4 originally conflated the two — "saved" is a proxy for step count, "accepted" is the count.
+
+| tol | accepted | saved | ψ<0.1 (saved) | EL (s) | ms/step | run (s) | et[1] | Δ'diag rel | Δ'mat rel |
 |---|---|---|---|---|---|---|---|---|---|
-| 1e-6  | 929  | 1159 | 591  | 10.1 | 10.89 | 224.9 | 0.78255904 | 1.7e-02 | 7.5e-03 |
-| 1e-7  | 1240 | 1565 | 807  | 12.2 | 9.84  | 207.8 | 0.78255903 | 3.3e-03 | 6.5e-04 |
-| 1e-8  | 1656 | 2116 | 1090 | 14.7 | 8.85  | 216.0 | 0.78255906 | 6.9e-04 | 8.1e-05 |
-| 1e-10 | 3018 | 3977 | 1893 | 18.9 | 6.26  | 221.8 | 0.78255905 | 6.2e-06 | 4.3e-06 |
-| 1e-12 | 7297 | 9620 | 3732 | 32.9 | 4.51  | 234.6 | 0.78255905 | 0        | 0        |
+| 1e-6  | 1159 | 929  | 591  | 10.1 | 8.72 | 224.9 | 0.78255904 | 1.7e-02 | 7.5e-03 |
+| 1e-7  | 1565 | 1240 | 807  | 12.2 | 7.80 | 207.8 | 0.78255903 | 3.3e-03 | 6.5e-04 |
+| 1e-8  | 2116 | 1656 | 1090 | 14.7 | 6.95 | 216.0 | 0.78255906 | 6.9e-04 | 8.1e-05 |
+| 1e-10 | 3977 | 3018 | 1893 | 18.9 | 4.75 | 221.8 | 0.78255905 | 6.2e-06 | 4.3e-06 |
+| 1e-12 | 9620 | 7297 | 3732 | 32.9 | 3.42 | 234.6 | 0.78255905 | 0        | 0        |
 
 - **`et[1]` is not a discriminator**: identical to 8 significant digits across six decades of
   tolerance. Any tolerance recommendation has to be made on Δ', not on the free-boundary energy.
 - **Δ' is the discriminator** and it degrades fast below 1e-8. The worst surface is the q=5 row
   (|Δ'| ~ 1.3e3): −1460 at 1e-6, −1332 at 1e-7, −1321 at 1e-8, −1319.5 at 1e-10, converged at
   1e-12. **1e-8 is the sweet spot** — 1.8× fewer steps than 1e-10 at 7e-4 relative Δ' error.
-- **Step count scales as tol^{−1/6.7}** over the full range (929 → 7297 for 10⁶ in tolerance),
-  slightly steeper than the ideal 9th-order tol^{−1/9}, as expected when the error being
-  controlled is knot-scale roughness rather than the smooth truncation term. The rejected-step
-  fraction is flat (0.20–0.24), so this is not a step-control artefact.
-- **EL wall time is sub-linear in nstep**: 1e-10 → 1e-8 cuts accepted steps 1.82× but EL time only
-  1.29× (18.9 → 14.7 s). A linear fit gives ~2.7 ms per attempted step plus a **~7 s
+- **Vern9 never achieves its formal order.** Local exponents of h ∝ tol^α from accepted steps:
+
+  | decade | α | effective 1/α |
+  |---|---|---|
+  | 1e-6 → 1e-7   | 0.130 | 7.7 |
+  | 1e-7 → 1e-8   | 0.131 | 7.6 |
+  | 1e-8 → 1e-10  | 0.137 | 7.3 |
+  | 1e-10 → 1e-12 | 0.192 | 5.2 |
+
+  A 9th-order method on a smooth integrand should give α = 1/(p+1) = 0.100 (error-per-step) or
+  1/p = 0.111 (error-per-unit-step). Measured α is outside both everywhere, and **degrades
+  sharply at tight tolerance** — the classic signature of an error floor that is not truncation
+  error. Vern7 over the same range gives α = 0.131, comfortably inside its own formal band
+  (0.125–0.143): the 7th-order method behaves as advertised, the 9th-order one does not. The
+  integrand's effective smoothness, not the method, is what caps the order at ≈ 7–8.
+- **EL wall time is sub-linear in step count**: 1e-10 → 1e-8 cuts accepted steps 1.88× but EL time
+  only 1.29× (18.9 → 14.7 s). A linear fit gives ~2.7 ms per accepted step plus a **~7 s
   tolerance-independent floor** in the phase (which also contains the parallel-FM BVP setup and
   the serial dense-ξ pass). The nstep → time proportionality of §2 holds across *grids*, not
   across tolerances at fixed grid.
@@ -126,12 +143,12 @@ and `Riccati.jl:1080,1443,1455,1515,1525`); the equilibrium-side Vern9 uses were
 EL phase is isolated. Δ' deviation is again relative to the Vern9 1e-12 point of §6. **The `src/`
 edits were reverted after measurement — this branch touches no source.**
 
-| method | tol | nstep | tried | EL (s) | ms/step | et[1] | Δ'diag rel |
+| method | tol | accepted | saved | EL (s) | ms/step | et[1] | Δ'diag rel |
 |---|---|---|---|---|---|---|---|
-| Vern9 | 1e-10 | 3018 | 3977 | 18.9 | 6.26 | 0.782559048 | 6.2e-06 |
-| Vern7 | 1e-10 | 4163 | 5355 | 15.3 | 3.67 | 0.782559048 | 2.5e-04 |
-| Vern9 | 1e-8  | 1656 | 2116 | 14.7 | 8.85 | 0.782559057 | 6.9e-04 |
-| Vern7 | 1e-8  | 2317 | 2927 | 10.9 | 4.70 | 0.782559050 | 2.5e-04 |
+| Vern9 | 1e-10 | 3977 | 3018 | 18.9 | 4.75 | 0.782559048 | 6.2e-06 |
+| Vern7 | 1e-10 | 5355 | 4163 | 15.3 | 2.86 | 0.782559048 | 2.5e-04 |
+| Vern9 | 1e-8  | 2116 | 1656 | 14.7 | 6.95 | 0.782559057 | 6.9e-04 |
+| Vern7 | 1e-8  | 2927 | 2317 | 10.9 | 3.72 | 0.782559050 | 2.5e-04 |
 
 - The §2 prediction holds: Vern7 takes ~40% more steps but each step is **1.7× cheaper**
   (10 stages vs 16), so EL wall time drops ~20% at 1e-10 and ~26% at 1e-8.
@@ -143,6 +160,153 @@ edits were reverted after measurement — this branch touches no source.**
   propagator/matching path carries a method-dependent offset that Vern9 does not have. That floor
   should be understood before Vern7 is adopted; it is small, but it is not a convergence error.
 
+## 8. Mechanism: why more knots means more steps (`roughness.jl`)
+
+§2–§7 established *that* dψ ∝ knot spacing. This section establishes *why*, because "the integrand
+is the same smooth function, just sampled more finely" is the natural expectation and it is wrong.
+
+Hypotheses written down before the runs (`PREDICTIONS.md` in the scratch dir):
+
+- **H1 node-noise floor** — every flux surface's coefficients are built independently, so node
+  values carry a fixed-amplitude error that does *not* shrink with mpsi. Interpolating it gives a
+  contribution to f'' of order ε/Δ², growing as the grid refines. Predicts: roughness grows ~4×
+  per mpsi doubling, and the knot-to-knot correlation of f'' goes negative.
+- **H2 pure cubic-spline C² structure with exact data** — roughness comes only from interpolating
+  an exactly-known function. Predicts: f'' converges to the physical curvature, correlation stays
+  positive.
+
+### The measurement
+
+`matrices/ideal/F,K,G` are `ffit.fmats_lower/kmats/gmats` — the actual EL integrand splines —
+evaluated at their own knots. Second divided differences approximate f''. Two statistics per
+region: `r1`, the lag-1 autocorrelation of f'' knot to knot (**+1 = smooth, −2/3 = white noise**),
+and median |f''|/|f|, the curvature per unit amplitude. `q(ψ)` on the same grid is the control.
+
+| region | quantity | mpsi=256 | mpsi=512 | mpsi=1024 |
+|---|---|---|---|---|
+| ψ<0.1  | K: r1 / \|f''\|/\|f\| | −0.42 / 1.01e7 | −0.45 / 4.53e7 | −0.56 / 1.62e8 |
+| ψ<0.1  | G: r1 / \|f''\|/\|f\| | +0.12 / 1.16e4 | −0.27 / 4.98e4 | −0.45 / 4.01e5 |
+| ψ<0.1  | F: r1 / \|f''\|/\|f\| | +0.91 / 4.48e3 | +0.67 / 4.10e3 | −0.32 / 4.65e3 |
+| 0.3–0.7 | F: r1 / \|f''\|/\|f\| | +0.91 / 1.730 | +0.96 / 1.712 | +0.97 / 1.705 |
+| 0.3–0.7 | G: r1 / \|f''\|/\|f\| | +0.83 / 3.66 | +0.86 / 3.87 | −0.18 / 3.99 |
+| ψ>0.95 | G: r1 / \|f''\|/\|f\| | +0.84 / 7.04e3 | +0.69 / 6.43e3 | −0.13 / 6.56e3 |
+| all | **q control r1** | **+0.88…+0.94** | **+0.94…+0.97** | **+0.97** |
+
+**H1 confirmed, H2 refuted.** Near-axis K grows 4.5× then 3.6× per doubling — the Δ⁻² of a
+fixed-amplitude node error — while its r1 marches to −0.56, approaching the −2/3 of pure noise.
+The q profile on the identical grid stays at r1 ≈ +0.95 throughout, so this is not an artefact of
+the estimator or of the graded grid.
+
+The two effects are cleanly separable in the table:
+
+- **Where the grid is still coarse relative to the noise, the physics dominates and converges** —
+  mid-plasma F is 1.730 → 1.712 → 1.705, textbook convergence. The user's intuition holds here.
+- **Where the grid is fine, the noise dominates and diverges.** The noise floor spreads outward
+  with mpsi: at 256 only K near axis is noise-dominated; at 512 G near axis has joined; at 1024
+  F near axis, G mid-plasma and everything at the edge have gone negative.
+
+Note the F row near axis: |f''|/|f| is *converged* at ~4.5e3 (that curvature is real, ψ→0 physics)
+yet r1 still collapses to −0.32. Magnitude convergence and smoothness are independent — the
+integrator responds to the second, which is why "the functions look the same" and "the integrator
+needs more steps" are both true at once.
+
+### Where the noise comes from — two knobs ruled out
+
+Both candidate *adjustable* sources were tested at fixed mpsi=512 and both are null.
+
+`etol`, the equilibrium field-line integration tolerance, over four decades:
+
+| etol | accepted steps | et[1] |
+|---|---|---|
+| 1e-8  | 4038 | 0.781859964 |
+| 1e-10 | 3977 | 0.782559048 |
+| 1e-12 | 3930 | 0.782601093 |
+
+**2.7% total across 10⁴ in tolerance** — monotonic in the predicted direction but negligible. This
+refutes ranked follow-up #4 as originally stated: the floor is not set by an adjustable integration
+tolerance, so tightening `etol` cannot buy back the step count.
+
+`mtheta`, the poloidal resolution each surface's metric integrals use:
+
+| mtheta | accepted steps | near-axis K \|f''\|/\|f\| | near-axis K r1 |
+|---|---|---|---|
+| 256  | 3977 | 4.525e7 | −0.450 |
+| 512  | 3966 | 4.502e7 | −0.450 |
+| 1024 | 3983 | 4.509e7 | −0.450 |
+
+**Completely flat** — 4× the poloidal resolution changes the roughness in the third significant
+figure and the step count by 0.3%. The noise is not poloidal quadrature error either.
+
+The obvious remaining suspect was the input equilibrium — `TkMkr_D3Dlike_Hmode.geqdsk` is a
+257×257 reconstruction of ψ(R,Z), a fixed-resolution source that no ψ refinement can resolve away.
+**That is also wrong**: the analytic Solovev equilibrium (`eq_type = "sol"`, exact ψ(R,Z), same
+stripped treatment, etol 1e-10) shows the same divergence, more strongly if anything —
+
+| mpsi | accepted steps | near-axis K \|f''\|/\|f\| | mid-plasma K \|f''\|/\|f\| | mid-plasma K r1 |
+|---|---|---|---|---|
+| 256  | 880  | 2.60e2 | 6.42e1 | −0.575 |
+| 512  | 1514 | 1.97e3 | 3.90e2 | −0.505 |
+| 1024 | 2776 | 1.34e4 | 3.22e3 | −0.581 |
+
+so the floor is generated *inside* the equilibrium → coefficient pipeline, not inherited from the
+input data. §9 finds where.
+
+## 9. Where the floor is generated (`roughness.jl` on the primitive matrices)
+
+The residual of a local degree-4 fit over a 9-knot window measures the node-error amplitude
+directly: smooth data leaves a residual falling like Δ⁵ (≈32× per mpsi doubling), data on a noise
+floor leaves a residual that is flat in Δ. Mid-plasma (ψ = 0.3–0.7), where the physics has no
+structure and the diagnosis is cleanest:
+
+| matrix | built from | resid @512 | resid @1024 | r1 @512 | r1 @1024 |
+|---|---|---|---|---|---|
+| A | g22, g23, g33          | 5.96e-08 | **1.32e-08** | +0.972 | **+0.987** |
+| B | g22, g23, g33          | 2.66e-08 | **1.96e-08** | —      | —      |
+| D | g23, g33               | 5.92e-08 | **1.28e-08** | +0.972 | **+0.987** |
+| C | + g31, jtheta·imat     | 8.90e-06 | 1.21e-05 | +0.694 | **−0.401** |
+| E | + g31, jtheta·imat, q1 | 8.74e-06 | 1.17e-05 | +0.547 | **−0.400** |
+| H | + g31, jtheta·imat     | 1.11e-05 | 1.41e-05 | +0.837 | **+0.022** |
+| F | = F̃ − D†A⁻¹D          | 2.48e-07 | 1.96e-07 | +0.957 | +0.973 |
+| K | = E − K†A⁻¹C           | 1.22e-05 | 1.56e-05 | +0.916 | +0.593 |
+| G | = H − C†A⁻¹C           | 1.01e-05 | 1.70e-05 | +0.856 | −0.176 |
+
+**The floor enters at C, E and H, at the ~1e-5 relative level, and it is not created by the
+derived-matrix algebra.** A, B and D — the matrices built from g22/g23/g33 alone — are clean at
+1e-8 *and still converging* (residual halving, r1 rising toward +1) exactly as smooth data should.
+F, which is derived through the same `A⁻¹` path as K and G, stays clean at 2e-7 because its inputs
+are clean. K and G are dirty only because E, C and H are.
+
+Per `Fourfit.jl:439-447`, the three dirty matrices are precisely the ones that additionally involve
+**g31**, **jtheta·imat**, and (for E) **q1 = dq/dψ**; the three clean ones use only g22/g23/g33.
+That is the actionable pointer: whatever sets the ~1e-5 floor lives in the construction of those
+metric/current quantities, not in the spline layer, not in the EL solver, and not in the input file.
+
+### The causal chain, end to end
+
+1. C/E/H node values carry a **relative error of ~1e-5 that does not shrink with mpsi** (§9).
+2. The cubic spline interpolates that error exactly, so the interpolant acquires knot-scale
+   wiggles whose contribution to f'' is ~ε/Δ² — growing 4× per mpsi doubling (§8).
+3. Once ε/Δ² exceeds the physical curvature, the integrand the solver sees is dominated by
+   knot-scale structure. This happens first where the grid packs hardest (near axis at mpsi=256),
+   and spreads outward with refinement (edge and mid-plasma by mpsi=1024).
+4. The adaptive controller prices exactly that structure, so the accepted step collapses onto the
+   knot scale: dψ ∝ Δ, ~6 steps per knot interval, invariant in mpsi (§4).
+5. Because the error being controlled is not smooth truncation error, Vern9 cannot realise its
+   formal order — measured effective order ≈ 7–8, collapsing to ≈ 5 at tight tolerance (§6) —
+   which is also why the cheaper Vern7 loses nothing (§7).
+
+So the premise "it is the same smooth function, just sampled more finely" is true of the *physics*
+and false of the *data*. Refining mpsi does not make the integrand a better approximation of a
+smooth function below the 1e-5 floor; past that point it makes the interpolant measurably rougher
+in exactly the derivative norms the error estimator reads.
+
+### Stripped-deck control
+
+The runs in this section drop the `[ForcingTerms]`/`[PerturbedEquilibrium]`/`[KineticForces]`
+sections and set `local_stability_flag = false` (31 s/run instead of 220 s). The slaving is
+unaffected — accepted steps 2309 / 3977 / 7638 for mpsi 256 / 512 / 1024, still tracking knot
+count — so the mechanism is a property of the EL integration, not of the surrounding pipeline.
+
 ## Implications / ranked follow-ups
 
 1. **Use the two-pass auto grid** (`mpsi=0`, `psi_accuracy`) — already the example default; it
@@ -153,9 +317,13 @@ edits were reverted after measurement — this branch touches no source.**
 2. **Integrator order** — measured (§7). Vern7 is ~20–26% faster in the EL phase and, at 1e-8,
    strictly better than Vern9 on both time and Δ' accuracy. Blocked on explaining Vern7's
    tolerance-independent 2.5e-4 Δ' offset; then a branch + regression harness.
-3. **Smoother coefficients**: fit F/K/G with smoothing (or higher-continuity) splines instead of
-   pure interpolation to lift the knot-scale noise floor that pins the step size.
-4. **Node-noise floor**: tightening the equilibrium field-line integration tolerance (`etol`)
-   reduces the noise that fine grids amplify — may decouple nstep from mpsi at high mpsi.
+3. **Fix the ~1e-5 node-error floor in C/E/H** (§9) — this is the root cause, and the only change
+   that would genuinely decouple nstep from mpsi rather than rescale it. Start at
+   `Fourfit.jl:439-447` and the construction of `g31`, `jtheta`/`imat` and `q1`, since A/B/D
+   (g22/g23/g33 only) are clean at 1e-8 and converging. Failing that, fit C/E/H with smoothing
+   rather than interpolating splines, so the floor is not differentiated.
+4. ~~Node-noise floor via `etol`~~ — **tested and refuted** (§8): 10⁴ in `etol` moves the step
+   count 2.7%. Likewise `mtheta` (4× → 0.3%) and the input equilibrium (analytic Solovev shows
+   the same divergence). Do not spend time on these.
 5. Spline-eval micro-optimizations (`precompute_transpose!`, extra hints, merged Series) are
    **not worth pursuing** for this issue — measured flat/marginal.

--- a/handoff/issue376/RESULTS.md
+++ b/handoff/issue376/RESULTS.md
@@ -1,0 +1,93 @@
+# Issue #376 investigation results — why does large mpsi slow ForceFreeStates?
+
+All runs on `examples/DIIID-like_ideal_example` (ideal path, `kinetic_factor=0`), branch
+`performance/regression-harness-threading` @ e7bb7cb8, single Julia thread, Vern9,
+`eulerlagrange_tolerance = 1e-10` unless noted. "Warm" numbers are the second `main()` call in
+one process (JIT excluded).
+
+## Conclusion
+
+**Spline evaluation cost is NOT the mechanism.** The hinted lookup and the series-spline kernel
+are knot-count-independent, exactly as the issue hoped. The slowdown is entirely **adaptive step
+count**: the integrator's accepted step size is slaved to the *local knot spacing* (median
+dψ ≈ 0.12·knotΔ, invariant across mpsi), so `nstep` scales with the number of knots in the
+regions where steps concentrate — dominated by the near-axis region where log-family grids pack
+hardest. Per-step cost is flat (~6 ms, Npert-sized LAPACK dominates).
+
+## 1. FastInterpolations microbenchmark (`microbench_mpsi.jl`)
+
+`CubicSeriesInterpolant`, 676 ComplexF64 series (mirrors `fmats/kmats/gmats`, numpert=26),
+non-uniform Vector grid, in-place eval, persistent `Ref(1)` hint, 16k queries:
+
+| npts | mono ns/ev | stage ns/ev | no-hint mono | range grid | 3-sep stage | B/eval | MB |
+|---|---|---|---|---|---|---|---|
+| 33   | 880 | 928 | 890 | 889 | 883 | 0 | 1.4 |
+| 129  | 898 | 913 | 915 | 925 | 893 | 0 | 5.6 |
+| 513  | 898 | 906 | 930 | 890 | 896 | 0 | 22.2 |
+| 1025 | 887 | 889 | 937 | 991 | 1020 | 0 | 44.4 |
+| 2049 | 892 | 909 | 948 | 901 | 935 | 0 | 88.8 |
+
+Flat in knot count; hint saves only ~5% here (payload dominates); zero allocations.
+Single-series control (`q_spline` analogue): ~2 ns/eval hinted (flat), 5→13 ns unhinted
+(the expected O(log n) — still negligible). First-touch lazy `permutedims` ≤ 11 ms one-time.
+So `precompute_transpose!`/extra-hint "quick wins" are marginal — not applied.
+
+## 2. End-to-end mpsi ladder (warm runs; `run_one.jl` + `parse_ladder.jl`)
+
+| mpsi | knots | EL int (s) | nstep | ms/step | balloon (s) | et[1] |
+|---|---|---|---|---|---|---|
+| 128  | 129  | 9.3  | 1190 | 7.8 | 1.7  | 1.391 |
+| 256  | 257  | 10.0 | 1753 | 5.7 | 3.7  | 0.376 |
+| 512  | 513  | 18.5 | 3010 | 6.2 | 8.2  | 0.783 |
+| 1024 | 1025 | 32.4 | 5683 | 5.7 | 18.7 | 0.803 |
+| auto | 558  | 16.9 | 2542 | 6.6 | 17.4 | 0.801 |
+
+- EL time ∝ nstep; ms/step flat → per-step cost is mpsi-independent.
+- `et[1]` converges to ~0.80 only by mpsi≈1024 on the fixed log grid; the two-pass **auto grid
+  reaches the converged value with 558 knots and half the EL time** — it is the right default.
+- Ballooning scan is O(mpsi) as expected (out of scope here per discussion).
+
+## 3. Where the steps go (`step_regions.jl`)
+
+Steps binned by ψ (accepted steps, from `integration/psi`):
+
+| region | 128 | 256 | 512 | 1024 | auto |
+|---|---|---|---|---|---|
+| ψ < 0.1 (axis packing)   | 553 | 964 | 1891 | 3806 | 581 |
+| 0.985–0.9935 (edge pack) | 117 | 157 | 217  | 418  | 227 |
+| q=2 surface ±            | 63  | 62  | 64   | 67   | 112 |
+| q=3 surface ±            | 59  | 60  | 58   | 59   | 87  |
+
+Singular-surface neighborhoods are **flat** (physics-controlled). Growth is where knots pack.
+
+## 4. Step size is slaved to knot spacing (`step_vs_knot.jl`)
+
+Within ψ<0.1: knots 73/145/289 (mpsi 128/256/512) → steps 553/964/1891, and
+dψ/knotΔ p25/med/p75 = 0.06/0.12/0.21 **at every mpsi**. If steps were tolerance/physics-limited,
+dψ would be mpsi-independent; instead it halves when knot spacing halves (~6.5 accepted steps
+per knot interval). Consistent with (i) C² knot discontinuities of cubic splines that a 9th-order
+error estimator can't step across cheaply, and (ii) node-noise amplification on fine grids
+(the h⁻⁴ effect warned about in `src/Equilibrium/GridRefinement.jl`).
+
+## 5. Discriminators (mpsi=512)
+
+- **`grid_type="uniform"`** (un-packs the axis): near-axis steps 1891 → **559**, total nstep
+  3010 → **2237**, EL ≈ 17.7 s. Steps follow knot density, not axis physics. (et[1]=0.993 —
+  uniform grid is physically under-resolved near axis; it's a mechanism probe, not a config
+  recommendation.)
+- **`eulerlagrange_tolerance = 1e-8`** (100× looser, auto-grid packing at 512): run was still in
+  flight at handoff — see HANDOFF.md. Prediction: if steps are knot-slaved, nstep barely drops.
+
+## Implications / ranked follow-ups
+
+1. **Use the two-pass auto grid** (`mpsi=0`, `psi_accuracy`) — already the example default; it
+   minimizes knots for a target accuracy, which this data shows is exactly what minimizes EL time.
+2. **Integrator order**: Vern9's 16 stages/step buy nothing when steps can't span a knot
+   interval. A 5–7th order method (Tsit5/Vern6/Vern7) may cut RHS evals per accepted step ~2×
+   at equal nstep. Cheap experiment, no physics change.
+3. **Smoother coefficients**: fit F/K/G with smoothing (or higher-continuity) splines instead of
+   pure interpolation to lift the knot-scale noise floor that pins the step size.
+4. **Node-noise floor**: tightening the equilibrium field-line integration tolerance (`etol`)
+   reduces the noise that fine grids amplify — may decouple nstep from mpsi at high mpsi.
+5. Spline-eval micro-optimizations (`precompute_transpose!`, extra hints, merged Series) are
+   **not worth pursuing** for this issue — measured flat/marginal.

--- a/handoff/issue376/RESULTS.md
+++ b/handoff/issue376/RESULTS.md
@@ -84,10 +84,12 @@ and the first is not the driver.**
   recommendation.)
 - **`eulerlagrange_tolerance = 1e-8`** (100× looser, same packing): nstep 3010 → **1629**
   (near-axis 1891 → 1057) with **identical physics** (et[1] = 0.78286 at both tolerances).
-  The ~1.85× drop matches the 9th-order expectation (100^{1/9} ≈ 1.7): the step size is genuinely
-  error-controlled, but the error *magnitude* per unit ψ is set by knot-scale roughness in the
-  spline coefficients — so dψ ∝ knotΔ at fixed tolerance (§4) and ∝ tol^{1/9} at fixed grid.
-  (The step count halves; §6 shows EL *wall time* does not — there is a step-independent floor.)
+  The step size is genuinely error-controlled, but the error *magnitude* per unit ψ is set by
+  knot-scale roughness in the spline coefficients — so dψ ∝ knotΔ at fixed tolerance (§4) and
+  ∝ tol^α at fixed grid. This drop was originally read as matching the 9th-order expectation
+  (100^{1/9} ≈ 1.7); **§6 measures α properly and it does not** — the effective order here is 7.3,
+  outside Vern9's formal band, which is itself part of the mechanism argument.
+  (The step count drops 1.88×; §6 shows EL *wall time* does not — there is a step-independent floor.)
 
 ## 6. Tolerance sweep (`parse_tolsweep.jl`, mpsi=512 fixed grid, 513 knots)
 

--- a/handoff/issue376/RESULTS.md
+++ b/handoff/issue376/RESULTS.md
@@ -75,8 +75,13 @@ error estimator can't step across cheaply, and (ii) node-noise amplification on 
   3010 → **2237**, EL ≈ 17.7 s. Steps follow knot density, not axis physics. (et[1]=0.993 —
   uniform grid is physically under-resolved near axis; it's a mechanism probe, not a config
   recommendation.)
-- **`eulerlagrange_tolerance = 1e-8`** (100× looser, auto-grid packing at 512): run was still in
-  flight at handoff — see HANDOFF.md. Prediction: if steps are knot-slaved, nstep barely drops.
+- **`eulerlagrange_tolerance = 1e-8`** (100× looser, same packing): nstep 3010 → **1629**
+  (near-axis 1891 → 1057) with **identical physics** (et[1] = 0.78286 at both tolerances).
+  The ~1.85× drop matches the 9th-order expectation (100^{1/9} ≈ 1.7): the step size is genuinely
+  error-controlled, but the error *magnitude* per unit ψ is set by knot-scale roughness in the
+  spline coefficients — so dψ ∝ knotΔ at fixed tolerance (§4) and ∝ tol^{1/9} at fixed grid.
+  Practical corollary: the default 1e-10 tolerance looks overly tight — 1e-8 halves EL cost on
+  this case with no change in et[1].
 
 ## Implications / ranked follow-ups
 

--- a/handoff/issue376/RESULTS.md
+++ b/handoff/issue376/RESULTS.md
@@ -119,6 +119,30 @@ Note: this sweep ran on the current branch tree, which has moved since the §2�
 within 0.3% on nstep (3018 vs 3010) and 4e-4 relative on et[1] (0.782559 vs 0.78286); conclusions
 are unaffected, but do not mix numbers across the two tables.
 
+## 7. Integrator order: Vern9 → Vern7 (mpsi=512, same grid)
+
+Working-tree swap of all six `Vern9()` call sites inside `ForceFreeStates` (`EulerLagrange.jl:766`
+and `Riccati.jl:1080,1443,1455,1515,1525`); the equilibrium-side Vern9 uses were left alone so the
+EL phase is isolated. Δ' deviation is again relative to the Vern9 1e-12 point of §6. **The `src/`
+edits were reverted after measurement — this branch touches no source.**
+
+| method | tol | nstep | tried | EL (s) | ms/step | et[1] | Δ'diag rel |
+|---|---|---|---|---|---|---|---|
+| Vern9 | 1e-10 | 3018 | 3977 | 18.9 | 6.26 | 0.782559048 | 6.2e-06 |
+| Vern7 | 1e-10 | 4163 | 5355 | 15.3 | 3.67 | 0.782559048 | 2.5e-04 |
+| Vern9 | 1e-8  | 1656 | 2116 | 14.7 | 8.85 | 0.782559057 | 6.9e-04 |
+| Vern7 | 1e-8  | 2317 | 2927 | 10.9 | 4.70 | 0.782559050 | 2.5e-04 |
+
+- The §2 prediction holds: Vern7 takes ~40% more steps but each step is **1.7× cheaper**
+  (10 stages vs 16), so EL wall time drops ~20% at 1e-10 and ~26% at 1e-8.
+- **Vern7 at 1e-8 dominates Vern9 at 1e-8** on both axes — 10.9 s vs 14.7 s *and* 2.5e-4 vs 6.9e-4
+  Δ' error. Against the current deck setting (Vern9 @ 1e-10) it is 42% faster for a Δ' error of
+  2.5e-4. et[1] is unchanged to 8 digits everywhere.
+- **Open question before acting on this**: Vern7's Δ' deviation is 2.47e-4 at 1e-10 and 2.50e-4 at
+  1e-8 — i.e. *tolerance-independent*, so it is not step-truncation error. Something in the
+  propagator/matching path carries a method-dependent offset that Vern9 does not have. That floor
+  should be understood before Vern7 is adopted; it is small, but it is not a convergence error.
+
 ## Implications / ranked follow-ups
 
 1. **Use the two-pass auto grid** (`mpsi=0`, `psi_accuracy`) — already the example default; it
@@ -126,9 +150,9 @@ are unaffected, but do not mix numbers across the two tables.
 1b. **`eulerlagrange_tolerance = 1e-8`** (the struct default) is the right per-deck value on the
    evidence of §6; the DIII-D decks' 1e-10 and the LAR decks' 1e-12 buy Δ' accuracy the case does
    not need. Any such deck edit is a separate branch and needs the regression harness.
-2. **Integrator order**: Vern9's 16 stages/step buy nothing when steps can't span a knot
-   interval. A 5–7th order method (Tsit5/Vern6/Vern7) may cut RHS evals per accepted step ~2×
-   at equal nstep. Cheap experiment, no physics change.
+2. **Integrator order** — measured (§7). Vern7 is ~20–26% faster in the EL phase and, at 1e-8,
+   strictly better than Vern9 on both time and Δ' accuracy. Blocked on explaining Vern7's
+   tolerance-independent 2.5e-4 Δ' offset; then a branch + regression harness.
 3. **Smoother coefficients**: fit F/K/G with smoothing (or higher-continuity) splines instead of
    pure interpolation to lift the knot-scale noise floor that pins the step size.
 4. **Node-noise floor**: tightening the equilibrium field-line integration tolerance (`etol`)

--- a/handoff/issue376/RESULTS.md
+++ b/handoff/issue376/RESULTS.md
@@ -14,6 +14,13 @@ dψ ≈ 0.12·knotΔ, invariant across mpsi), so `nstep` scales with the number 
 regions where steps concentrate — dominated by the near-axis region where log-family grids pack
 hardest. Per-step cost is flat (~6 ms, Npert-sized LAPACK dominates).
 
+**And the reason the step size follows the knot spacing (§8–§9):** the C/E/H coefficient matrices
+carry a ~1e-5 relative node-error floor that does not shrink with mpsi. The spline interpolates it
+exactly, contributing ~ε/Δ² to the integrand's second derivative — growing 4× per mpsi doubling
+until it swamps the physical curvature, first where the grid packs hardest. The integrand is
+therefore *not* the same smooth function at every mpsi: below the 1e-5 floor, refining the grid
+makes the interpolant measurably rougher in exactly the norms the error estimator reads.
+
 ## 1. FastInterpolations microbenchmark (`microbench_mpsi.jl`)
 
 `CubicSeriesInterpolant`, 676 ComplexF64 series (mirrors `fmats/kmats/gmats`, numpert=26),
@@ -65,9 +72,9 @@ Singular-surface neighborhoods are **flat** (physics-controlled). Growth is wher
 Within ψ<0.1: knots 73/145/289 (mpsi 128/256/512) → steps 553/964/1891, and
 dψ/knotΔ p25/med/p75 = 0.06/0.12/0.21 **at every mpsi**. If steps were tolerance/physics-limited,
 dψ would be mpsi-independent; instead it halves when knot spacing halves (~6.5 accepted steps
-per knot interval). Consistent with (i) C² knot discontinuities of cubic splines that a 9th-order
-error estimator can't step across cheaply, and (ii) node-noise amplification on fine grids
-(the h⁻⁴ effect warned about in `src/Equilibrium/GridRefinement.jl`).
+per knot interval). Two mechanisms were proposed here originally — C² knot discontinuities of the
+cubic spline, and node-noise amplification on fine grids. **§8–§9 test both: the second is right
+and the first is not the driver.**
 
 ## 5. Discriminators (mpsi=512)
 

--- a/handoff/issue376/microbench_mpsi.jl
+++ b/handoff/issue376/microbench_mpsi.jl
@@ -1,0 +1,162 @@
+# Issue #376 microbenchmark: does CubicSeriesInterpolant scalar eval cost grow with knot count?
+# Mirrors the ForceFreeStates hot path: 676 ComplexF64 series (numpert=26), non-uniform Vector
+# psi grid, in-place eval with a persistent hint, monotone / Vern9-stage-like query patterns.
+using FastInterpolations
+using Printf
+
+const NSERIES = 26^2
+const PSILOW, PSIHIGH = 1e-4, 0.995
+const NPOINTS_LADDER = [33, 65, 129, 257, 513, 1025, 2049]
+
+# Mildly non-uniform monotone grid (edge-packed like real ldp/auto grids)
+function make_grid(n)
+    t = range(0.0, 1.0; length=n)
+    return PSILOW .+ (PSIHIGH - PSILOW) .* (0.6 .* t .+ 0.4 .* t .^ 3)
+end
+
+# Smooth mode-dependent complex data, deterministic
+function make_series_data(x, nseries)
+    n = length(x)
+    Y = Matrix{ComplexF64}(undef, n, nseries)
+    for k in 1:nseries
+        f = 1.0 + 0.02 * k
+        @. Y[:, k] = complex(sin(f * x) + 0.1 * cos(3.1 * f * x), cos(0.7 * f * x))
+    end
+    return Y
+end
+
+# Vern9-like query schedule: n_steps ODE steps across the domain, 16 stage evals per step at
+# fixed non-monotone fractional offsets (stresses the hint walk the way an RK stage loop does).
+const STAGE_C = [0.0, 0.03462, 0.09703, 0.14553, 0.561, 0.229, 0.5449, 0.6453, 0.4874, 0.9648, 0.8755, 0.9553, 0.7514, 1.0, 0.9847, 1.0]
+function stage_queries(n_steps)
+    h = (PSIHIGH - PSILOW) / n_steps
+    q = Vector{Float64}(undef, n_steps * length(STAGE_C))
+    i = 0
+    for s in 1:n_steps
+        t0 = PSILOW + (s - 1) * h
+        for c in STAGE_C
+            q[i+=1] = min(t0 + c * h, PSIHIGH)
+        end
+    end
+    return q
+end
+
+monotone_queries(neval) = collect(range(PSILOW, PSIHIGH; length=neval))
+
+# One timed pass: reset hint, evaluate all queries in place; returns seconds
+function eval_pass!(out, sitp, queries, hint)
+    hint isa Base.RefValue && (hint[] = 1)
+    t0 = time_ns()
+    if hint === nothing
+        @inbounds for xq in queries
+            sitp(out, xq)
+        end
+    else
+        @inbounds for xq in queries
+            sitp(out, xq; hint=hint)
+        end
+    end
+    return (time_ns() - t0) / 1e9
+end
+
+function bench(sitp, queries; use_hint=true, reps=5)
+    out = Vector{ComplexF64}(undef, length(sitp(first(queries))))
+    hint = use_hint ? Ref(1) : nothing
+    eval_pass!(out, sitp, queries, hint)  # warmup (also builds lazy transpose)
+    best = minimum(eval_pass!(out, sitp, queries, hint) for _ in 1:reps)
+    allocs = @allocated eval_pass!(out, sitp, queries, hint)
+    return best / length(queries) * 1e9, allocs / length(queries)  # ns/eval, bytes/eval
+end
+
+# Single-series (q_spline analogue) control
+function bench_scalar(itp, queries; use_hint=true, reps=5)
+    hint = use_hint ? Ref(1) : nothing
+    function pass()
+        hint isa Base.RefValue && (hint[] = 1)
+        acc = 0.0
+        t0 = time_ns()
+        if hint === nothing
+            @inbounds for xq in queries
+                acc += itp(xq)
+            end
+        else
+            @inbounds for xq in queries
+                acc += itp(xq; hint=hint)
+            end
+        end
+        return (time_ns() - t0) / 1e9 + 0.0 * acc
+    end
+    pass()
+    best = minimum(pass() for _ in 1:reps)
+    return best / length(queries) * 1e9
+end
+
+function main()
+    n_ode_steps = 1000                 # fixed step density, independent of knot count (the real situation)
+    qs_stage = stage_queries(n_ode_steps)
+    qs_mono = monotone_queries(16 * n_ode_steps)
+
+    println("Queries: $(length(qs_stage)) stage-pattern evals, $(length(qs_mono)) monotone evals")
+    println("Series count: $NSERIES ComplexF64\n")
+
+    @printf("%7s | %11s %11s | %11s %11s | %11s | %11s | %9s | %10s\n",
+            "npts", "mono ns/ev", "stage ns/ev", "nohint mono", "nohint stg", "range grid", "3sep stage", "B/eval", "MB footpr")
+    for n in NPOINTS_LADDER
+        x = collect(make_grid(n))
+        Y = make_series_data(x, NSERIES)
+        sitp = cubic_interp(x, Series(Y); extrap=ExtendExtrap())
+        precompute_transpose!(sitp)
+
+        t_mono, b_mono = bench(sitp, qs_mono)
+        t_stage, _ = bench(sitp, qs_stage)
+        t_mono_nh, _ = bench(sitp, qs_mono; use_hint=false)
+        t_stage_nh, _ = bench(sitp, qs_stage; use_hint=false)
+
+        # uniform range grid (DirectSearch path)
+        xr = range(PSILOW, PSIHIGH; length=n)
+        sitp_r = cubic_interp(xr, Series(make_series_data(collect(xr), NSERIES)); extrap=ExtendExtrap())
+        precompute_transpose!(sitp_r)
+        t_range, _ = bench(sitp_r, qs_stage)
+
+        # 3 separate interpolants at same psi (fmats/kmats/gmats pattern) — report per single-interp eval
+        s1 = cubic_interp(x, Series(Y); extrap=ExtendExtrap())
+        s2 = cubic_interp(x, Series(make_series_data(x .* 0.999 .+ 1e-5, NSERIES)); extrap=ExtendExtrap())
+        s3 = cubic_interp(x, Series(make_series_data(x .* 1.001, NSERIES)); extrap=ExtendExtrap())
+        foreach(precompute_transpose!, (s1, s2, s3))
+        out3 = Vector{ComplexF64}(undef, NSERIES)
+        h3 = Ref(1)
+        function pass3()
+            h3[] = 1
+            t0 = time_ns()
+            @inbounds for xq in qs_stage
+                s1(out3, xq; hint=h3)
+                s2(out3, xq; hint=h3)
+                s3(out3, xq; hint=h3)
+            end
+            return (time_ns() - t0) / 1e9
+        end
+        pass3()
+        t_3sep = minimum(pass3() for _ in 1:3) / (3 * length(qs_stage)) * 1e9
+
+        mb = Base.summarysize(sitp) / 1e6
+        @printf("%7d | %11.1f %11.1f | %11.1f %11.1f | %11.1f | %11.1f | %9.1f | %10.2f\n",
+                n, t_mono, t_stage, t_mono_nh, t_stage_nh, t_range, t_3sep, b_mono, mb)
+    end
+
+    println("\nFirst-touch lazy transpose cost (ms) and single-series q_spline control (ns/eval, stage pattern):")
+    @printf("%7s | %12s | %12s %12s\n", "npts", "permute ms", "qspl hint", "qspl nohint")
+    for n in NPOINTS_LADDER
+        x = collect(make_grid(n))
+        sitp = cubic_interp(x, Series(make_series_data(x, NSERIES)); extrap=ExtendExtrap())
+        out = Vector{ComplexF64}(undef, NSERIES)
+        t_first = @elapsed sitp(out, 0.5)   # includes permutedims of y and z
+
+        y = sin.(3.0 .* x) .+ 0.2 .* x
+        itp = cubic_interp(x, y; extrap=ExtendExtrap())
+        tq = bench_scalar(itp, qs_stage)
+        tq_nh = bench_scalar(itp, qs_stage; use_hint=false)
+        @printf("%7d | %12.2f | %12.1f %12.1f\n", n, t_first * 1e3, tq, tq_nh)
+    end
+end
+
+main()

--- a/handoff/issue376/parse_ladder.jl
+++ b/handoff/issue376/parse_ladder.jl
@@ -1,0 +1,81 @@
+# Parse TSMARK phase timestamps from ladder logs + nstep/et from gpec.h5, print the ladder table.
+using HDF5, Printf
+
+const LADDER_DIR = @__DIR__
+
+function marks(logfile)
+    m = Tuple{Float64,String}[]
+    for line in eachline(logfile)
+        startswith(line, "TSMARK ") || continue
+        rest = split(line[8:end], " | "; limit=2)
+        length(rest) == 2 || continue
+        push!(m, (parse(Float64, rest[1]), String(rest[2])))
+    end
+    return m
+end
+
+# Timestamp of first mark whose tag starts with `prefix`, at or after index i0; returns (ts, idx)
+function tsafter(m, prefix, i0)
+    for i in i0:length(m)
+        startswith(m[i][2], prefix) && return m[i][1], i
+    end
+    return NaN, length(m) + 1
+end
+
+function phases(logfile)
+    m = marks(logfile)
+    _, i0 = tsafter(m, "RUN2_START", 1)
+    t = Dict{String,Float64}()
+    order = [("equil_start", "  Equilibrium"),
+             ("equil_end", "Equilibrium construction completed"),
+             ("ffs_start", "  Force-Free States"),
+             ("runparams", "Run parameters:"),
+             ("fgk", "Computing F, G, and K matrices"),
+             ("el", "Integrating Euler-Lagrange"),
+             ("freeb", "Computing free boundary"),
+             ("ffs_end", "Force-Free States completed"),
+             ("pe_start", "  Perturbed Equilibrium"),
+             ("pe_end", "Perturbed Equilibrium completed"),
+             ("run2_end", "RUN2_END")]
+    i = i0
+    for (key, prefix) in order
+        t[key], i = tsafter(m, prefix, i)
+    end
+    return (equil=t["equil_end"] - t["equil_start"],
+        balloon=t["runparams"] - t["ffs_start"],
+        metric=t["fgk"] - t["runparams"],
+        matrix=t["el"] - t["fgk"],
+        elint=t["freeb"] - t["el"],
+        ffs_rest=t["ffs_end"] - t["freeb"],
+        pe=t["pe_end"] - t["pe_start"],
+        total=t["run2_end"] - t["equil_start"])
+end
+
+function h5info(rundir)
+    h5open(joinpath(rundir, "gpec.h5"), "r") do h5
+        nstep = read(h5["integration/nstep"])
+        et = read(h5["FreeBoundaryStability/eigenmode_energies"])
+        npsi = try
+            length(read(h5["splines/profiles/xs"]))
+        catch
+            -1
+        end
+        return sum(nstep), real(et[1]), npsi
+    end
+end
+
+@printf("%6s | %6s | %7s %7s %7s %7s | %8s %8s | %7s %7s | %10s | %8s\n",
+        "mpsi", "knots", "equil", "balloon", "matrix", "elint", "nstep", "ms/step", "ffsrest", "pe", "et1", "total")
+for N in ["128", "256", "512", "1024", "auto"]
+    log = joinpath(LADDER_DIR, "mpsi_$N.log")
+    isfile(log) || continue
+    p = phases(log)
+    nstep, et1, npsi = try
+        h5info(joinpath(LADDER_DIR, "run_$N"))
+    catch e
+        (-1, NaN, -1)
+    end
+    @printf("%6s | %6d | %7.1f %7.1f %7.1f %7.1f | %8d %8.2f | %7.1f %7.1f | %10.4g | %8.1f\n",
+            N, npsi, p.equil, p.balloon, p.metric + p.matrix, p.elint, nstep,
+            nstep > 0 ? p.elint / nstep * 1e3 : NaN, p.ffs_rest, p.pe, et1, p.total)
+end

--- a/handoff/issue376/parse_tolsweep.jl
+++ b/handoff/issue376/parse_tolsweep.jl
@@ -1,0 +1,82 @@
+# Parse the eulerlagrange_tolerance sweep (fixed grid, mpsi=512): step counts, EL wall time,
+# and the physics observables (et[1], Δ' matrix) that decide whether a looser tolerance is safe.
+using HDF5, Printf, LinearAlgebra
+
+# Dir holding run_<tol>/ and tol_<tol>.log; defaults to this script's directory.
+const SWEEP_DIR = isempty(ARGS) ? (@__DIR__) : ARGS[1]
+const TOLS = ["1e-6", "1e-7", "1e-8", "1e-10", "1e-12"]
+const REFTOL = "1e-12"   # tightest point is the reference for physics deviations
+
+function marks(logfile)
+    m = Tuple{Float64,String}[]
+    for line in eachline(logfile)
+        startswith(line, "TSMARK ") || continue
+        rest = split(line[8:end], " | "; limit=2)
+        length(rest) == 2 || continue
+        push!(m, (parse(Float64, rest[1]), String(rest[2])))
+    end
+    return m
+end
+
+function tsafter(m, prefix, i0)
+    for i in i0:length(m)
+        startswith(m[i][2], prefix) && return m[i][1], i
+    end
+    return NaN, length(m) + 1
+end
+
+function phases(logfile)
+    m = marks(logfile)
+    _, i0 = tsafter(m, "RUN2_START", 1)
+    t = Dict{String,Float64}()
+    order = [("equil_start", "  Equilibrium"),
+        ("ffs_start", "  Force-Free States"),
+        ("el", "Integrating Euler-Lagrange"),
+        ("freeb", "Computing free boundary"),
+        ("run2_end", "RUN2_END")]
+    i = i0
+    for (key, prefix) in order
+        t[key], i = tsafter(m, prefix, i)
+    end
+    return (elint=t["freeb"] - t["el"], total=t["run2_end"] - t["equil_start"])
+end
+
+read_opt(h5, path) = haskey(h5, path) ? read(h5[path]) : nothing
+
+function h5info(rundir)
+    h5open(joinpath(rundir, "gpec.h5"), "r") do h5
+        psi = read(h5["integration/psi"])
+        return (nstep=sum(read(h5["integration/nstep"])),
+            nstep_total=read(h5["integration/nstep_total"]),
+            axis_steps=count(<(0.1), psi),
+            et1=real(read(h5["FreeBoundaryStability/eigenmode_energies"])[1]),
+            dp=read_opt(h5, "singular/delta_prime_matrix"),
+            npsi=length(read(h5["splines/profiles/xs"])))
+    end
+end
+
+# Deviation of a Δ' matrix from the reference: worst per-surface relative error on the diagonal
+# (the physically tracked quantity), and the full-matrix deviation normalised by its largest element.
+function dpdev(dp, ref)
+    (dp === nothing || ref === nothing || size(dp) != size(ref)) && return (NaN, NaN)
+    diagrel = maximum(abs.(diag(dp) .- diag(ref)) ./ abs.(diag(ref)))
+    return (diagrel, maximum(abs.(dp .- ref)) / maximum(abs.(ref)))
+end
+
+info = Dict{String,Any}()
+for T in TOLS
+    d = joinpath(SWEEP_DIR, "run_$T")
+    isfile(joinpath(d, "gpec.h5")) || continue
+    info[T] = merge(h5info(d), phases(joinpath(SWEEP_DIR, "tol_$T.log")))
+end
+ref = haskey(info, REFTOL) ? info[REFTOL].dp : nothing
+
+@printf("%6s | %8s %8s %8s | %8s %8s %8s | %14s | %10s %10s\n",
+    "tol", "nstep", "tried", "psi<0.1", "EL (s)", "ms/step", "run (s)", "et[1]", "Δ'diag rel", "Δ'mat rel")
+for T in TOLS
+    haskey(info, T) || continue
+    r = info[T]
+    ddiag, dmat = dpdev(r.dp, ref)
+    @printf("%6s | %8d %8d %8d | %8.1f %8.2f %8.1f | %14.8g | %10.2e %10.2e\n",
+        T, r.nstep, r.nstep_total, r.axis_steps, r.elint, r.elint / r.nstep * 1e3, r.total, r.et1, ddiag, dmat)
+end

--- a/handoff/issue376/roughness.jl
+++ b/handoff/issue376/roughness.jl
@@ -1,0 +1,111 @@
+# Is the EL integrand smooth at the knot scale, or has it hit a node-noise floor?
+#
+# Second divided differences of the splined EL coefficient matrices (matrices/ideal/F,K,G, i.e.
+# ffit.fmats_lower/kmats/gmats evaluated at their own knots) approximate f''. For a smooth
+# sampled function they vary smoothly knot to knot (lag-1 autocorrelation r1 → +1) and converge
+# as the grid refines. For node values sitting on a noise floor they alternate in sign
+# (r1 → −2/3, the white-noise value) and their magnitude grows as Δ⁻².
+#
+# Usage: julia --project=. roughness.jl <rundir> [<rundir> ...]
+using HDF5, Printf, Statistics
+
+# f[x_{i-1}, x_i, x_{i+1}] ≈ f''/2 on a non-uniform grid.
+function second_divided_difference(x, f)
+    n = length(x)
+    d = similar(f, n - 2)
+    for i in 2:n-1
+        left = (f[i] - f[i-1]) / (x[i] - x[i-1])
+        right = (f[i+1] - f[i]) / (x[i+1] - x[i])
+        d[i-1] = (right - left) / (x[i+1] - x[i-1])
+    end
+    return d
+end
+
+# Lag-1 autocorrelation: +1 for a smooth sequence, −2/3 for the 2nd difference of white noise.
+function lag1(d)
+    dc = d .- mean(d)
+    return sum(dc[1:end-1] .* dc[2:end]) / sum(abs2, dc)
+end
+
+# Restrict to a psi window so the axis and edge (where the grid packs) can be looked at separately.
+window(x, lo, hi) = findall(p -> lo <= p <= hi, x)
+
+"""
+Roughness statistics for one (npsi, np, np) matrix stack over a psi window: the lag-1
+autocorrelation of f'' pooled over the largest matrix elements, and the median |f''|.
+"""
+function roughness(psi, mats, idx; nelem=20)
+    x = psi[idx]
+    # Rank elements by magnitude so the statistic is not dominated by numerically empty entries.
+    amp = dropdims(sum(abs, view(mats, idx, :, :); dims=1); dims=1)
+    order = sortperm(vec(amp); rev=true)[1:min(nelem, length(amp))]
+    r1s = Float64[]
+    curv = Float64[]
+    for lin in order
+        i, j = Tuple(CartesianIndices(amp)[lin])
+        f = view(mats, idx, i, j)
+        d = second_divided_difference(x, collect(f))
+        scale = maximum(abs, f)
+        scale == 0 && continue
+        push!(r1s, lag1(real.(d)))
+        push!(curv, median(abs.(d)) / scale)   # |f''|/|f|, units of psi^-2
+    end
+    return median(r1s), median(curv)
+end
+
+"""
+Node-error amplitude: RMS residual of a local degree-4 least-squares fit over a sliding window of
+`w` knots, relative to |f|. Smooth data leaves a residual that falls like Δ^5 (≈32x per mpsi
+doubling); data sitting on a noise floor leaves a residual that is constant in Δ.
+"""
+function fit_residual(x, f; w=9, deg=4)
+    n = length(x)
+    n < w + 2 && return NaN
+    res = Float64[]
+    half = w ÷ 2
+    for c in (half+1):(n-half)
+        idx = (c-half):(c+half)
+        # Center and scale so the Vandermonde system stays conditioned on a graded grid.
+        t = (x[idx] .- x[c]) ./ (x[c+half] - x[c-half])
+        V = reduce(hcat, [t .^ p for p in 0:deg])
+        push!(res, abs(f[c] - (V * (V \ collect(f[idx])))[half+1]))
+    end
+    return sqrt(mean(abs2, res)) / maximum(abs, f)
+end
+
+function noise_floor(psi, mats, idx; nelem=20)
+    x = psi[idx]
+    amp = dropdims(sum(abs, view(mats, idx, :, :); dims=1); dims=1)
+    order = sortperm(vec(amp); rev=true)[1:min(nelem, length(amp))]
+    vals = Float64[]
+    for lin in order
+        i, j = Tuple(CartesianIndices(amp)[lin])
+        r = fit_residual(x, collect(view(mats, idx, i, j)))
+        isnan(r) || push!(vals, r)
+    end
+    return isempty(vals) ? NaN : median(vals)
+end
+
+const REGIONS = [("psi<0.1 (axis pack)", 0.0, 0.1), ("0.3-0.7 (mid)", 0.3, 0.7), ("psi>0.95 (edge pack)", 0.95, 1.0)]
+
+for rundir in ARGS
+    h5open(joinpath(rundir, "gpec.h5"), "r") do h5
+        psi = read(h5["matrices/psi"])
+        qprof = read(h5["splines/profiles/q"])
+        @printf("\n%s  (npsi = %d)\n", basename(rundir), length(psi))
+        @printf("  %-22s | %-6s | %-30s | %-30s | %-30s\n", "region", "nknot", "F: r1 / |f''|/|f| / resid", "K: r1 / |f''|/|f| / resid", "G: r1 / |f''|/|f| / resid")
+        for (name, lo, hi) in REGIONS
+            idx = window(psi, lo, hi)
+            length(idx) < 8 && continue
+            cols = String[]
+            for key in ("F", "K", "G")
+                mats = read(h5["matrices/ideal"][key])
+                r1, curv = roughness(psi, mats, idx)
+                push!(cols, @sprintf("%+.3f /%9.2e /%9.2e", r1, curv, noise_floor(psi, mats, idx)))
+            end
+            # q(psi) is a genuinely smooth control on the same grid.
+            dq = second_divided_difference(psi[idx], qprof[idx])
+            @printf("  %-22s | %6d | %-30s | %-30s | %-30s | q ctrl r1 %+.3f\n", name, length(idx), cols[1], cols[2], cols[3], lag1(dq))
+        end
+    end
+end

--- a/handoff/issue376/roughness.jl
+++ b/handoff/issue376/roughness.jl
@@ -88,24 +88,36 @@ end
 
 const REGIONS = [("psi<0.1 (axis pack)", 0.0, 0.1), ("0.3-0.7 (mid)", 0.3, 0.7), ("psi>0.95 (edge pack)", 0.95, 1.0)]
 
+# Set GPEC_ROUGHNESS_MATS=A,B,C,D,E,H,F,K,G to include the primitive matrices (RESULTS.md section 9,
+# which localises the node-error floor to C/E/H); the default is the three EL integrand matrices.
+const MATS = split(get(ENV, "GPEC_ROUGHNESS_MATS", "F,K,G"), ",")
+
 for rundir in ARGS
     h5open(joinpath(rundir, "gpec.h5"), "r") do h5
         psi = read(h5["matrices/psi"])
         qprof = read(h5["splines/profiles/q"])
         @printf("\n%s  (npsi = %d)\n", basename(rundir), length(psi))
-        @printf("  %-22s | %-6s | %-30s | %-30s | %-30s\n", "region", "nknot", "F: r1 / |f''|/|f| / resid", "K: r1 / |f''|/|f| / resid", "G: r1 / |f''|/|f| / resid")
+        @printf("  %-22s | %-6s", "region", "nknot")
+        for key in MATS
+            @printf(" | %-28s", "$key: r1 / |f''|/|f| / resid")
+        end
+        println()
         for (name, lo, hi) in REGIONS
             idx = window(psi, lo, hi)
             length(idx) < 8 && continue
             cols = String[]
-            for key in ("F", "K", "G")
+            for key in MATS
                 mats = read(h5["matrices/ideal"][key])
                 r1, curv = roughness(psi, mats, idx)
                 push!(cols, @sprintf("%+.3f /%9.2e /%9.2e", r1, curv, noise_floor(psi, mats, idx)))
             end
             # q(psi) is a genuinely smooth control on the same grid.
             dq = second_divided_difference(psi[idx], qprof[idx])
-            @printf("  %-22s | %6d | %-30s | %-30s | %-30s | q ctrl r1 %+.3f\n", name, length(idx), cols[1], cols[2], cols[3], lag1(dq))
+            @printf("  %-22s | %6d", name, length(idx))
+            for c in cols
+                @printf(" | %-28s", c)
+            end
+            @printf(" | q ctrl r1 %+.3f\n", lag1(dq))
         end
     end
 end

--- a/handoff/issue376/run_one.jl
+++ b/handoff/issue376/run_one.jl
@@ -1,0 +1,29 @@
+# Run one GPEC case twice (cold + warm) with a timestamping logger so phase boundaries
+# can be recovered from the existing @info markers without touching src/.
+using Logging, Dates
+
+struct TSLogger <: Logging.AbstractLogger
+    inner::Logging.AbstractLogger
+end
+Logging.min_enabled_level(l::TSLogger) = Logging.min_enabled_level(l.inner)
+Logging.shouldlog(l::TSLogger, level, args...) = Logging.shouldlog(l.inner, level, args...)
+Logging.catch_exceptions(l::TSLogger) = true
+function Logging.handle_message(l::TSLogger, level, message, _module, group, id, file, line; kwargs...)
+    msg = string(message)
+    lines = filter(!isempty, split(msg, '\n'))
+    tag = isempty(lines) ? "" : String(lines[1])
+    println(stdout, "TSMARK ", Dates.datetime2unix(Dates.now()), " | ", tag)
+    flush(stdout)
+    Logging.handle_message(l.inner, level, message, _module, group, id, file, line; kwargs...)
+end
+
+global_logger(TSLogger(global_logger()))
+
+using GeneralizedPerturbedEquilibrium
+
+println("TSMARK ", Dates.datetime2unix(Dates.now()), " | RUN1_START")
+GeneralizedPerturbedEquilibrium.main([ARGS[1]])
+println("TSMARK ", Dates.datetime2unix(Dates.now()), " | RUN1_END")
+println("TSMARK ", Dates.datetime2unix(Dates.now()), " | RUN2_START")
+GeneralizedPerturbedEquilibrium.main([ARGS[1]])
+println("TSMARK ", Dates.datetime2unix(Dates.now()), " | RUN2_END")

--- a/handoff/issue376/step_regions.jl
+++ b/handoff/issue376/step_regions.jl
@@ -1,0 +1,43 @@
+# Where do the extra ODE steps go as mpsi grows? Bin accepted steps by psi region.
+using HDF5, Printf
+
+const LADDER_DIR = @__DIR__
+const EDGES = [0.0, 0.1, 0.3, 0.5, 0.516, 0.52, 0.6, 0.769, 0.772, 0.85, 0.89, 0.93, 0.955, 0.97, 0.985, 0.9935, 1.0]
+# bins isolate q=2 (~0.518) and q=3 (~0.770) singular surfaces and the packed edge (q=4,5,6 land above 0.85)
+
+function stepcounts(rundir)
+    h5open(joinpath(rundir, "gpec.h5"), "r") do h5
+        psi = read(h5["integration/psi"])
+        counts = zeros(Int, length(EDGES) - 1)
+        for p in psi
+            b = clamp(searchsortedlast(EDGES, p), 1, length(counts))
+            counts[b] += 1
+        end
+        return counts
+    end
+end
+
+rows = []
+for N in ["128", "256", "512", "1024", "auto"]
+    d = joinpath(LADDER_DIR, "run_$N")
+    isfile(joinpath(d, "gpec.h5")) || continue
+    push!(rows, (N, stepcounts(d)))
+end
+
+@printf("%13s |", "psi bin")
+for (N, _) in rows
+    @printf(" %6s", N)
+end
+println()
+for i in 1:length(EDGES)-1
+    @printf("%6.3f-%6.4f |", EDGES[i], EDGES[i+1])
+    for (_, c) in rows
+        @printf(" %6d", c[i])
+    end
+    println()
+end
+@printf("%13s |", "TOTAL")
+for (_, c) in rows
+    @printf(" %6d", sum(c))
+end
+println()

--- a/handoff/issue376/step_vs_knot.jl
+++ b/handoff/issue376/step_vs_knot.jl
@@ -1,0 +1,28 @@
+# Compare ODE step sizes with local knot spacing: is dpsi pinned to ~k knot intervals?
+using HDF5, Printf, Statistics
+
+const LADDER_DIR = @__DIR__
+
+function analyze(rundir)
+    h5open(joinpath(rundir, "gpec.h5"), "r") do h5
+        psi = read(h5["integration/psi"])
+        xs = read(h5["splines/profiles/xs"])
+        dpsi = diff(psi)
+        keep = dpsi .> 0            # drop chunk-boundary resets
+        dpsi = dpsi[keep]
+        pmid = psi[1:end-1][keep] .+ dpsi ./ 2
+        # local knot spacing at each step midpoint
+        dxs = diff(xs)
+        spacing = [dxs[clamp(searchsortedlast(xs, p), 1, length(dxs))] for p in pmid]
+        ratio = dpsi ./ spacing
+        return length(psi), median(ratio), quantile(ratio, 0.1), quantile(ratio, 0.9), median(dpsi), median(spacing)
+    end
+end
+
+@printf("%6s | %6s | %12s (%5s–%5s) | %10s %10s\n", "mpsi", "nstep", "med dψ/knot", "p10", "p90", "med dψ", "med knotΔ")
+for N in ["128", "256", "512", "1024", "auto"]
+    d = joinpath(LADDER_DIR, "run_$N")
+    isfile(joinpath(d, "gpec.h5")) || continue
+    n, med, p10, p90, mdp, msp = analyze(d)
+    @printf("%6s | %6d | %12.2f (%5.2f–%5.2f) | %10.2e %10.2e\n", N, n, med, p10, p90, mdp, msp)
+end


### PR DESCRIPTION
## Purpose

**Machine-transfer handoff for the issue #376 investigation — NOT for merging.** Contains the investigation scripts, results (`handoff/issue376/RESULTS.md`), and a handoff doc (`handoff/issue376/HANDOFF.md`) with next steps and instructions for removing the handoff directory once the work lands.

## TL;DR of findings

- Spline evaluation is **not** the mpsi cost: hinted `CubicSeriesInterpolant` eval is flat ~890 ns/eval from 33 to 2049 knots (676 series, zero-alloc).
- The EL slowdown is **adaptive step-count growth at flat per-step cost**: accepted step size stays ~0.12× the local knot spacing at every mpsi, so nstep tracks knot count where knots pack (near-axis dominates on log-family grids). Singular-surface step counts are mpsi-flat.
- Uniform-grid discriminator at mpsi=512: near-axis steps 1891→559, nstep 3010→2237 — steps follow knot density, not axis physics.
- The two-pass auto grid reaches converged et[1] with 558 knots and ~half the EL time of a fixed 1024-knot grid.

Ranked follow-ups (integrator order, spline smoothing, node-noise floor) are in RESULTS.md; the planned spline micro-optimizations were measured to be marginal and dropped.

## ***⚠️ DO NOT MERGE — THIS PR REQUIRES THIRD-PARTY HUMAN REVIEW, AND IS ADDITIONALLY A TEMPORARY HANDOFF VEHICLE THAT SHOULD BE CLOSED WITHOUT MERGING. NO PR MAY EVER BE MERGED INTO `develop` WITHOUT A HUMAN REVIEWER'S APPROVAL — NON-NEGOTIABLE.***

🤖 Generated with [Claude Code](https://claude.com/claude-code)