### PR TITLE
FFS - IMPROVEMENT - Cap the core knot density of the EL coefficient splines

### DIFF
--- a/src/ForceFreeStates/Fourfit.jl
+++ b/src/ForceFreeStates/Fourfit.jl
@@ -496,23 +496,38 @@ function make_matrix(equil::Equilibrium.PlasmaEquilibrium, intr::ForceFreeStates
 
     # FastInterpolations now natively supports complex values - no need to split real/imag
     # Create complex series interpolants with per-column extrap BC
-    ffit.amats = cubic_interp(metric.xs, Series(amats_flat); ffit.itp_opts...)
-    ffit.bmats = cubic_interp(metric.xs, Series(bmats_flat); ffit.itp_opts...)
-    ffit.cmats = cubic_interp(metric.xs, Series(cmats_flat); ffit.itp_opts...)
-    ffit.dmats_prim = cubic_interp(metric.xs, Series(dmats_flat); ffit.itp_opts...)
-    ffit.emats_prim = cubic_interp(metric.xs, Series(emats_flat); ffit.itp_opts...)
-    ffit.hmats = cubic_interp(metric.xs, Series(hmats_flat); ffit.itp_opts...)
-    ffit.fmats_lower = cubic_interp(metric.xs, Series(fmats_lower_flat); ffit.itp_opts...)
-    ffit.fmats_prim = cubic_interp(metric.xs, Series(fmats_prim_flat); ffit.itp_opts...)
-    ffit.fmats_gal = cubic_interp(metric.xs, Series(fmats_gal_flat); ffit.itp_opts...)
-    ffit.gmats = cubic_interp(metric.xs, Series(gmats_flat); ffit.itp_opts...)
-    ffit.kmats = cubic_interp(metric.xs, Series(kmats_flat); ffit.itp_opts...)
+    # Decouple the coefficient-spline knots from the equilibrium grid in the packed core:
+    # a cubic spline's third-derivative jumps scale as (node error)/dpsi^3, so equilibrium-grade
+    # core packing amplifies tolerance-level node error into jumps that slave the EL step size.
+    # The coefficients are near-cylindrical there; cap the density at dpsi >= 0.05*psi below psi=0.1.
+    keep = Int[1]
+    for i in 2:length(metric.xs)-1
+        x = metric.xs[i]
+        if x >= 0.1 || (x - metric.xs[keep[end]]) >= 0.05 * x
+            push!(keep, i)
+        end
+    end
+    push!(keep, length(metric.xs))
+    mxs = metric.xs[keep]
+    @info "EL coefficient-spline grid: $(length(metric.xs)) -> $(length(mxs)) knots after core density cap"
+
+    ffit.amats = cubic_interp(mxs, Series(amats_flat[keep, :]); ffit.itp_opts...)
+    ffit.bmats = cubic_interp(mxs, Series(bmats_flat[keep, :]); ffit.itp_opts...)
+    ffit.cmats = cubic_interp(mxs, Series(cmats_flat[keep, :]); ffit.itp_opts...)
+    ffit.dmats_prim = cubic_interp(mxs, Series(dmats_flat[keep, :]); ffit.itp_opts...)
+    ffit.emats_prim = cubic_interp(mxs, Series(emats_flat[keep, :]); ffit.itp_opts...)
+    ffit.hmats = cubic_interp(mxs, Series(hmats_flat[keep, :]); ffit.itp_opts...)
+    ffit.fmats_lower = cubic_interp(mxs, Series(fmats_lower_flat[keep, :]); ffit.itp_opts...)
+    ffit.fmats_prim = cubic_interp(mxs, Series(fmats_prim_flat[keep, :]); ffit.itp_opts...)
+    ffit.fmats_gal = cubic_interp(mxs, Series(fmats_gal_flat[keep, :]); ffit.itp_opts...)
+    ffit.gmats = cubic_interp(mxs, Series(gmats_flat[keep, :]); ffit.itp_opts...)
+    ffit.kmats = cubic_interp(mxs, Series(kmats_flat[keep, :]); ffit.itp_opts...)
 
     # TODO: set powers
     # Do we need this yet? Only called if power_flag = true
 
     # Jacobian Fourier band ψ-spline, used for the power normalization in Free.jl
-    ffit.jmats = cubic_interp(metric.xs, Series(jmats_flat); ffit.itp_opts...)
+    ffit.jmats = cubic_interp(mxs, Series(jmats_flat[keep, :]); ffit.itp_opts...)
 
     return ffit
 end

--- a/src/ForceFreeStates/Fourfit.jl
+++ b/src/ForceFreeStates/Fourfit.jl
@@ -499,11 +499,22 @@ function make_matrix(equil::Equilibrium.PlasmaEquilibrium, intr::ForceFreeStates
     # Decouple the coefficient-spline knots from the equilibrium grid in the packed core:
     # a cubic spline's third-derivative jumps scale as (node error)/dpsi^3, so equilibrium-grade
     # core packing amplifies tolerance-level node error into jumps that slave the EL step size.
-    # The coefficients are near-cylindrical there; cap the density at dpsi >= 0.05*psi below psi=0.1.
+    # Near the axis every component is a Frobenius power law in psi, and power laws are scale-free,
+    # so log-uniform sampling (dpsi >= c*psi) resolves them at constant relative accuracy: cubic
+    # interpolation of psi^p on that grid errs by ~(p*c)^4/384, so c = 0.05 resolves even the
+    # steepest spectrum component (p = mmax/2) to ~2e-4 while the physics responds far below that
+    # (the steep components carry vanishing solution amplitude). The capped region ends at the
+    # innermost rational surface (or psi = 0.1, whichever is smaller) and never removes a knot
+    # inside a rational's resolution window, preserving the Delta'-stencil structure the
+    # equilibrium grid encodes (GridRefinement RATIONAL_RES_RADIUS).
+    cap_edge = 0.1
+    rationals = [s.psifac for s in intr.sing]
+    isempty(rationals) || (cap_edge = min(cap_edge, minimum(rationals) - Equilibrium.RATIONAL_RES_RADIUS))
+    in_rational_window(x) = any(abs(x - r) <= Equilibrium.RATIONAL_RES_RADIUS for r in rationals)
     keep = Int[1]
     for i in 2:length(metric.xs)-1
         x = metric.xs[i]
-        if x >= 0.1 || (x - metric.xs[keep[end]]) >= 0.05 * x
+        if x >= cap_edge || in_rational_window(x) || (x - metric.xs[keep[end]]) >= 0.05 * x
             push!(keep, i)
         end
     end

--- a/src/ForceFreeStates/Fourfit.jl
+++ b/src/ForceFreeStates/Fourfit.jl
@@ -509,7 +509,8 @@ function make_matrix(equil::Equilibrium.PlasmaEquilibrium, intr::ForceFreeStates
     end
     push!(keep, length(metric.xs))
     mxs = metric.xs[keep]
-    @info "EL coefficient-spline grid: $(length(metric.xs)) -> $(length(mxs)) knots after core density cap"
+    length(mxs) < length(metric.xs) &&
+        @info "EL coefficient-spline grid: $(length(metric.xs)) -> $(length(mxs)) knots after core density cap"
 
     ffit.amats = cubic_interp(mxs, Series(amats_flat[keep, :]); ffit.itp_opts...)
     ffit.bmats = cubic_interp(mxs, Series(bmats_flat[keep, :]); ffit.itp_opts...)


### PR DESCRIPTION
## Summary

The Euler-Lagrange coefficient splines (`fmats`/`kmats`/`gmats` and the primitives) inherited **every knot of the equilibrium grid**. A cubic spline's third-derivative jumps at knots scale as (node error)/Δψ³, so the equilibrium's near-axis packing (Δψ ~ 1e-6 at high mpsi) amplifies even tolerance-level node error (~1e-9, measured) into huge C² kinks — and the adaptive integrator's step size becomes slaved to the knot spacing. Measured directly: core jump magnitudes grow ~34× per mpsi doubling, and an (tol/J)^¼ step model reproduces the observed step-count ladder.

The coefficients are near-cylindrical in the core and do not need that packing. This PR builds their splines on a subset of the equilibrium grid with **core density capped at Δψ ≥ 0.05·ψ below ψ = 0.1**. Node *values* are unchanged — only interpolation density — which is why the physics moves at the 1e-7–1e-8 level.

**Stacked on #398** (route (a), same investigation); diff shows only the cap once #398 lands.

## Measured (DIII-D stripped decks, route-(a) base, mpsi 512/1024)

| | mψ=512 | mψ=1024 |
|---|---|---|
| accepted EL steps | 2768 → **2188** | 4403 → **3034** |
| step growth per doubling | — | 1.59× → **1.39×** |
| warm run | 12.8 → **10.4 s (−19%)** | — |
| et[1] relative change | **3e-8** | 3e-8 |
| Riccati Δ′ diagonal (all 5 surfaces) | **4e-7** | — |

## Not a tuned hack: the rule's basis and its generalization

**Form**: near the axis every component is a Frobenius power law in ψ; power laws are scale-free, so log-uniform sampling (Δψ ≥ c·ψ) resolves them at constant relative accuracy. **Constant**: cubic interpolation of ψ^p on a log-uniform grid errs by ~(p·c)⁴/384, so c = 0.05 resolves even the steepest spectrum component (p = m_max/2 = 11) to ~2e-4 — and the physics responds far below that because the steep components carry vanishing solution amplitude. **Region**: ends at min(0.1, innermost rational − `RATIONAL_RES_RADIUS`), and no knot inside a rational's resolution window is ever removed — guards for decks (e.g. higher n) whose rationals reach the core; verified no-ops on every current case.

**Cross-equilibrium check** (four equilibria, two construction paths, three grid families):

| case | knots | EL steps | et[1] change |
|---|---|---|---|
| DIII-D efit, traced, log-family m1024 | 1025→575 | −31% | 3e-8 |
| tj_analytic_direct, traced, log-family m1024 | 1025→575 | **−35%** | **1.3e-9** |
| LAR, **inversion**, packed auto m1024 | 1025→575 | −8% | **exact to 8 digits** |
| Solovev, traced, **ldp** m512/m1024 | 505→468 | ~0 | ~4.5e-7 abs (3e-5 rel via the ±10.4 → 0.0146 cancellation) |

The LAR row is the anti-over-fit witness: clean geometry with no noise to exploit, and the cap is still harmless.

## Two properties reviewers should know

1. **No-op on production decks.** The two-pass auto grid's core spacing already satisfies the cap — verified: 287 → 287 knots on the DIII-D auto deck, and the full harness (`diiid_n1, solovev_n1, diiid_n1_riccati, gal_resistive_diiid`) reproduces #398's numbers exactly. The cap engages only on explicitly packed fine grids (large `mpsi`), which is precisely the issue #376 scenario.
2. **A fixed cap beats general curvature selection — measured, not assumed.** Removal-error knot selection (drop any knot whose interpolated value matches within δ for every element of all 12 matrices) was implemented and swept: it reaches the physics plateau only at δ=1e-7 where it keeps 504/513 knots and buys nothing, and breaks et[1]/Δ′ at any δ loose enough to matter. The core knots that are *safe* to remove **fail** the interpolation test (real coefficient curvature, but the solution components multiplying them vanish as ψ^|m|/2). Interpolation error is the wrong objective; the fixed mechanism-based cap is the right scope for the ideal path. Record: `handoff/issue376/RESULTS.md` §22–§23 (experiment branch).

## Verification

- Tests: `runtests_eulerlagrange`, `runtests_riccati`, `runtests_sing` — all pass.
- Harness vs develop @ 9491f893d across all four cases: identical to #398's report (see property 1); Δ′-tracking cases included.
- Mechanism measurement and step-model validation: `handoff/issue376/RESULTS.md` §22.

⚠️ **Requires third-party human review before merging — do not merge without an approving review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
