### PR TITLE
KF/PE - BUGFIX! - Self-consistent xi_s for the NTV kernel input; static scheduling for the kinetic kernel loop

### DIFF
--- a/src/KineticForces/CalculatedKineticMatrices.jl
+++ b/src/KineticForces/CalculatedKineticMatrices.jl
@@ -120,7 +120,7 @@ function compute_calculated_kinetic_matrices(
     thread_block_w = [zeros(ComplexF64, mpert, mpert, 6) for _ in 1:nthreads]
     thread_block_t = [zeros(ComplexF64, mpert, mpert, 6) for _ in 1:nthreads]
 
-    Threads.@threads for ipsi in 1:mpsi
+    Threads.@threads :static for ipsi in 1:mpsi
         tid = Threads.threadid()
         intr_t = thread_intrs[tid]
         full_w = thread_full_w[tid]

--- a/src/PerturbedEquilibrium/FieldReconstruction.jl
+++ b/src/PerturbedEquilibrium/FieldReconstruction.jl
@@ -365,6 +365,25 @@ function compute_clebsch_displacements(
         return clebsch_psi, clebsch_psi1, clebsch_alpha
     end
 
+    # Kinetic runs: mirror Fortran gpeq.f kin_flag — regularize the STORED self-consistent ξ_s
+    # by the same singfac factor and never re-solve from matrices. The ideal-matrix resolve is
+    # inconsistent with the kinetic solution's tangential response (the resonant layers live in
+    # exactly that dynamics), and the kinetic A is non-Hermitian and must not be re-inverted
+    # here. Kinetic-ness detected by populated kwmats splines (sentinel has 5 knots).
+    if length(ffit.kwmats[1].cache.x) > 8
+        for ipsi in 1:npsi
+            q = equil.profiles.q_spline(psi_grid[ipsi])
+            for ipert in 1:mpert
+                m = mlow + ipert - 1
+                singfac = m - nn * q
+                reg_factor = singfac^2 / (singfac^2 + reg_spot^2)
+                clebsch_psi1[ipsi, ipert] = xi_psi1_modes[ipsi, ipert] * reg_factor
+                clebsch_alpha[ipsi, ipert] = xi_s_modes[ipsi, ipert] * reg_factor / chi1
+            end
+        end
+        return clebsch_psi, clebsch_psi1, clebsch_alpha
+    end
+
     # Per-thread workspaces: matrix ops and spline hints are not safe to share across threads.
     # Size by maxthreadid() and index by threadid() under :static scheduling (GPEC convention).
     nt = Threads.maxthreadid()


### PR DESCRIPTION
Stacked on #422 (`feature/kinetic-resonance-knots`). The overnight resolution of the PE-vs-NTV torque discrepancy (issue #423's measured motivation; RESULTS.md §34–§35).

## The bug

In kinetic runs, the Clebsch ξ^α fed to the NTV kernel (via `dbob_m`/`divx_m`) was **re-solved from the ideal A, B, C matrices** — inconsistent with the self-consistent kinetic tangential response exactly where resonant layers live. Fortran (`gpeq.f`, `kin_flag`) instead scales the **stored self-consistent ξ_s** by the singfac regularization factor and inverts nothing. This is the same physics flaw #407 fixes on the MatrixSplines branch (there: a silently broken Cholesky of the non-Hermitian kinetic A; here: a *valid* Cholesky of the *wrong* — ideal — A).

## The consequence (measured, DIII-D kinetic-calculated full chain)

The perturbative NTV evaluation was driven by a tangential displacement that ignores the kinetic layer response, producing a **phantom 4× torque** concentrated in a ~2e-3-wide resonant core at the pedestal ω_E crossing (fgar: 0.7241 N·m, of which +0.622 in ψ∈[0.90, 0.95]; the self-consistent EL solution collects 0.046 there — and the EL side was verified faithful at every level: boundary ≡ volume torque to 7 digits, FKG assembly and kinetic RHS sign-by-sign Fortran-conformant per fortran-physics-reviewer, matrix-spline resolution and integrator step size both exonerated by direct null experiments).

With the fix, the phantom collapses (+0.622 → +0.033) and the two independent torque calculations agree band-by-band (resonant layer: 0.0461 vs 0.0455). Domain-matched totals (ΔIm over [ψ_c, psilim] — fgar's exact domain; the sub-ψ_c Im(u1†u2) offset is non-dissipative initial-condition content, ±0.05 with opposite signs across cases):

| case (deterministic, post-:static) | PE (domain-matched) | fgar | agreement |
|---|---|---|---|
| rot factor 0.2, reg_spot 0.05 | 0.1456 | 0.1460 | **0.3%** |
| rot factor 1.0, reg_spot 0.05 | 0.1322 | 0.1655 | 20% |
| rot factor 1.0, reg_spot 0.01 | 0.1322 | 0.1397 | 5.4% |

Where the comparison is regularization-unambiguous (rot=0.2: resonances away from rationals), the two independent torque calculations now agree to **0.3%**. The rot=1.0 residual sits inside fgar's own reg_spot sensitivity band (its answer moves 18% between reg 0.05 and 0.01 — the acknowledged near-rational input ambiguity, present in Fortran too); PE is reg-independent by construction.

## Second fix in this PR: determinism

`CalculatedKineticMatrices.jl`'s per-surface kernel loop was the **only** threaded loop in the codebase using `Threads.@threads` without `:static` while indexing per-thread scratch by `threadid()` — dynamic-scheduling task migration corrupts kinetic matrix rows at rare-migration frequency. Observed live: three runs of one identical deck gave et[1] = 1.0053 / 1.1355 / 0.9895. With `:static`, identical decks reproduce **bit-identically** (verified), and et returns exactly to the pre-fix value — every historical calculated-kinetic result carries this latent race.

**Effects on outputs**: kinetic-run regularized quantities (`xi_clebsch_alpha`, `*_reg` fields) and every NTV torque driven by them change; ideal runs and `reg_spot = 0` are bit-unaffected. Kinetic harness cases will move — new baselines with this physics justification.

## Review items

- Kinetic-ness is currently detected via populated `kwmats` splines (sentinel = 5 knots); reviewers may prefer threading an explicit flag from `kinetic_factor > 0` — noted as the clean alternative.
- The domain-matched comparison rule (and the eventual `gpout_dw` ψ-profile port, issue #423) is where the "which torque is which" delineation (#424) completes.

# ⚠️ **REQUIRES THIRD-PARTY HUMAN REVIEW BEFORE MERGING — NON-NEGOTIABLE. DO NOT MERGE WITHOUT AN APPROVING HUMAN REVIEW.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzbLFQKyuRE5DYZmLokKmk
