### PR TITLE
InnerLayer.SLAYER - BUGFIX - Use the shear magnitude in the layer timescales and widths

### DIFF
--- a/src/InnerLayer/SLAYER/LayerParameters.jl
+++ b/src/InnerLayer/SLAYER/LayerParameters.jl
@@ -133,11 +133,11 @@ function _solve_dc_tmp(; dc_type::Symbol, dr_val::Real, dgeo_val::Real,
     Wd = 0.1
     converged = false
     for _ in 1:max_iter
-        chi_par_lmfp = (2.0 * R0 * vte) / (sqrt(π) * n_tor * sval_r * Wd)
+        chi_par_lmfp = (2.0 * R0 * vte) / (sqrt(π) * n_tor * abs(sval_r) * Wd)
         chi_par = (chi_par_smfp * chi_par_lmfp) /
                   (chi_par_smfp + chi_par_lmfp)
         Wd_new = sqrt(8.0) * (chi_perp / chi_par)^0.25 *
-                 (1.0 / sqrt((rs / R0) * sval_r * n_tor))
+                 (1.0 / sqrt((rs / R0) * abs(sval_r) * n_tor))
         if abs(Wd_new - Wd) / max(abs(Wd), 1e-30) < tol
             Wd = Wd_new
             converged = true
@@ -147,13 +147,13 @@ function _solve_dc_tmp(; dc_type::Symbol, dr_val::Real, dgeo_val::Real,
     end
     converged || error("SLAYERParameters: Wd iteration failed to converge")
 
-    chi_par_lmfp = (2.0 * R0 * vte) / (sqrt(π) * n_tor * sval_r * Wd)
+    chi_par_lmfp = (2.0 * R0 * vte) / (sqrt(π) * n_tor * abs(sval_r) * Wd)
     chi_par = (chi_par_smfp * chi_par_lmfp) / (chi_par_smfp + chi_par_lmfp)
 
     if dc_type === :lar
         return 0.5 * (-dr_val) * π^1.5 *
                (chi_par / chi_perp)^0.25 *
-               sqrt((n_tor * sval_r) / (R0 * rs))
+               sqrt((n_tor * abs(sval_r)) / (R0 * rs))
     elseif dc_type === :rfitzp
         return -(sqrt(2.0) * π^1.5 * dr_val) / Wd
     elseif dc_type === :toroidal
@@ -297,8 +297,10 @@ function slayer_parameters(;
 
     # Alfven time uses minor-radius shear directly (sval enters the
     # b_l = (n/m) r_s sval bt / R0 expression and cancels through to
-    # tau_h = R0 sqrt(mu0 rho) / (n sval bt)).
-    tau_h = R0 * sqrt(MU_0 * rho) / (n * sval_r * bt)
+    # tau_h = R0 sqrt(mu0 rho) / (n sval bt)). Magnitude only: the layer timescales and
+    # widths depend on |dq/dr|, not its sign, and a reverse-shear surface would otherwise
+    # give tau_h < 0, hence lu < 0 and a DomainError in lu^(1/3) below.
+    tau_h = R0 * sqrt(MU_0 * rho) / (n * abs(sval_r) * bt)
     # Resistive diffusion time τ_R = μ₀ r_s² / η (Fitzpatrick 2023), with
     # the selected η closure — neoclassical by default — setting the
     # Lundquist number.


### PR DESCRIPTION
## Release note

- **Audience:** users
- **Numerical impact:** none on any existing result. `abs(s) == s` wherever the shear is positive, so every surface that produced a value before produces the same value; this only turns a crash into a result on reverse-shear surfaces. _(harness @ 66cc5ed08)_
- **Migration:** none.

`slayer_parameters` used the signed r-based shear `sval_r` in five expressions that are magnitudes. On a reverse-shear surface this made the Alfvén time negative, hence a negative Lundquist number, and `tauk = lu^(1/3)*tau_h` threw a `DomainError` before any layer quantity was produced.

## The five sites

| line | expression | why it needs `|s|` |
|---|---|---|
| `chi_par_lmfp` (×2) | `(2 R0 vte)/(√π n s Wd)` | a parallel diffusivity; must not change sign with shear direction |
| `Wd` | `1/√((rs/R0) s n)` | an island width; `sqrt` of a negative argument throws |
| `:lar` critical-Δ | `√((n s)/(R0 rs))` | same |
| `tau_h` | `R0 √(μ₀ρ)/(n s bt)` | a timescale; negative `tau_h` ⇒ negative `lu` ⇒ `lu^(1/3)` throws |

The layer timescales and widths depend on `|dq/dr|`, not its sign. The module's own diffusive-resistive width derivation already states the convention as `(n|s|)`.

## How it was found

Scanning DIII-D reconstructions for a separate piece of work. Shot **153072_3415** has `q` dipping to 1.855 off-axis (q0 = 2.364), which puts two q = 2 surfaces in the plasma with the inner one on the negative-shear branch. `_find_rational_surfaces` is deliberately reverse-shear-safe — it segments between q-extrema — so it finds both and hands them straight to the layer build, which then throws. Every SLAYER path is affected, not just the caller that surfaced it.

No shipped deck or harness case has reverse shear, which is why this has gone unnoticed.

## Validation

- [x] `runtests_slayer_params` 49/49, `runtests_slayer_riccati` 29/29, `runtests_innerlayer` 57/57 on this branch
- [x] Reproduced the original failure and confirmed the fix scans 153072_3415 end to end (16 surfaces located, including both q = 2 branches)
- [x] Regression harness, `diiid_slayer_n1`, develop `d7e6e6fe` vs this head `66cc5ed08`, both sides `--force`:

```
SLAYER surface indices / m / n        0.0e+00   OK
SLAYER minor radius rs                0.0e+00   OK
SLAYER r-based shear                  0.0e+00   OK
SLAYER Lundquist S                    0.0e+00   OK
SLAYER D_norm                         0.0e+00   OK
SLAYER P_perp / tauk / iota_e         0.0e+00   OK
SLAYER Q_root [2/1,3/1,4/1]           5.1e-06   OK
SLAYER ω_Hz  [2/1,3/1,4/1]            1.9e-06   OK
SLAYER γ_Hz  [2/1,3/1,4/1]   1.276e-01 (0.02%)  ** CHANGED **
SLAYER no_root flags / enabled        0.0e+00   OK
Summary: 1 changed, 14 unchanged
```

**The γ line is solver noise, not this change, and the report itself proves it:** every layer *input* is bit-identical at `0.0e+00` — including `sval_r`, `S` and `tauk`, which are exactly the quantities `abs()` would have moved had it done anything on this deck. With identical inputs, a 0.13 Hz shift in the extracted root can only come from the root search. That magnitude sits inside the measured same-source reproducibility of the threaded search (0.076 / 0.122 / 0.145 Hz per surface, #418), which is above the case's current 1e-1 threshold — the subject of a separate threshold PR.

No shipped deck has a negative-shear rational surface, so zero change is the expected result and this is it.

> [!NOTE]
> Opened as a draft. Reviewer suggestions: @logan-nc or @jhalpern30 — the substantive question is whether the shear *sign* is load-bearing anywhere else in the layer physics (the ω_* orientation being the obvious candidate), which I have not audited.
