### PR TITLE
InnerLayer.SLAYER - TEST - Pin the reverse-shear invariance of the layer magnitudes

### DIFF
--- a/test/runtests_slayer_params.jl
+++ b/test/runtests_slayer_params.jl
@@ -165,4 +165,31 @@
         @test_throws ArgumentError r_based_shear(0.5, 2.0, 1.0, 0.0)
         @test_throws ArgumentError r_based_shear(0.5, 0.0, 1.0, 0.5)
     end
+
+    @testset "Test 3: reverse-shear invariance" begin
+        # The layer timescales and widths depend on |dq/dr|, not its sign, so a
+        # negative-shear rational surface must reduce to its positive-shear mirror.
+        # Only the recorded `sval_r` diagnostic keeps the sign. `dc_type=:lar`
+        # with a nonzero `dr_val` exercises the Wd iteration and the critical-Δ
+        # square roots as well as tau_h.
+        base = _ref_kwargs(; dr_val=-0.1, dc_type=:lar)
+        pos = slayer_parameters(; base...)
+        neg = slayer_parameters(; merge(base, (; sval_r=-1.0))...)
+
+        # The sign survives where it is a diagnostic, not a magnitude.
+        @test pos.sval_r == 1.0
+        @test neg.sval_r == -1.0
+
+        # Every normalized layer quantity is bit-identical: abs(-1.0) === 1.0,
+        # so the whole downstream chain reproduces exactly.
+        for f in (:tau, :lu, :c_beta, :D_norm, :P_perp, :P_tor, :Q_e, :Q_i,
+                  :iota_e, :tauk, :tau_r, :delta_n, :eta, :d_beta, :dc_tmp)
+            @test getfield(neg, f) == getfield(pos, f)
+        end
+
+        # tau_h > 0 keeps the Lundquist number positive, so the S^(1/3) that
+        # used to raise a DomainError on a reverse-shear surface now evaluates.
+        @test neg.lu > 0
+        @test neg.tauk > 0
+    end
 end

--- a/test/runtests_slayer_params.jl
+++ b/test/runtests_slayer_params.jl
@@ -167,11 +167,10 @@
     end
 
     @testset "Test 3: reverse-shear invariance" begin
-        # The layer timescales and widths depend on |dq/dr|, not its sign, so a
-        # negative-shear rational surface must reduce to its positive-shear mirror.
-        # Only the recorded `sval_r` diagnostic keeps the sign. `dc_type=:lar`
-        # with a nonzero `dr_val` exercises the Wd iteration and the critical-Δ
-        # square roots as well as tau_h.
+        # The layer timescales and widths depend on |dq/dr|, not its sign: a negative-shear
+        # surface must reduce to its positive-shear mirror, with only the recorded sval_r
+        # diagnostic keeping the sign. dc_type=:lar with nonzero dr_val exercises the Wd
+        # iteration and the critical-Δ square roots as well as tau_h.
         base = _ref_kwargs(; dr_val=-0.1, dc_type=:lar)
         pos = slayer_parameters(; base...)
         neg = slayer_parameters(; merge(base, (; sval_r=-1.0))...)
@@ -187,8 +186,7 @@
             @test getfield(neg, f) == getfield(pos, f)
         end
 
-        # tau_h > 0 keeps the Lundquist number positive, so the S^(1/3) that
-        # used to raise a DomainError on a reverse-shear surface now evaluates.
+        # tau_h > 0 keeps the Lundquist number positive, so S^(1/3) is defined on reverse shear.
         @test neg.lu > 0
         @test neg.tauk > 0
     end


### PR DESCRIPTION
## Release note

- **Audience:** developers
- **Numerical impact:** none. Test-only; the diff touches no file under `src/`.
- **Migration:** none.

#431 made the SLAYER layer timescales and widths use `|s|` so a reverse-shear rational surface produces a result instead of a `DomainError`. Nothing in the suite pinned that behaviour. This adds the missing coverage.

## Why this was a gap

Every existing SLAYER testset constructs its parameters at `sval_r = 1.0` — `runtests_slayer_params.jl:13,132`, `runtests_slayer_riccati.jl:19,32`, `runtests_slayer_runner.jl:20`, `runtests_dispersion_coupled.jl:25`, `runtests_dispersion_residual.jl:25`. No shipped deck has a reverse-shear rational surface either, so neither the suite nor the regression harness would notice if the `abs()` calls were reverted. #431's own validation was an out-of-tree scan of DIII-D shot 153072_3415, which is not reproducible in CI.

## What is asserted

`dc_type=:lar` with a nonzero `dr_val` is used so the check covers the `Wd` self-consistency iteration and both critical-Δ square roots, not just `tau_h`.

- `sval_r` keeps its sign in the struct — it is a diagnostic, not a magnitude
- all 15 normalized layer quantities are **bit-identical** between `sval_r = ±1.0` (`abs(-1.0) === 1.0`, so `==` is the right assertion, not `≈`)
- `lu > 0` and `tauk > 0`, so the `S^(1/3)` that used to throw now evaluates

## Regression report

The diff adds one testset and changes no file under `src/`, so the harness is inert by construction and was not run. Stating this rather than pasting a run that could only report "unchanged".

```
(no src/ change — harness not applicable)
```

## Validation

- [x] `julia --project=. test/runtests.jl runtests_slayer_params.jl` — **68/68 pass** (49 before this PR)

## Notes for reviewers

Opened as a draft.

Suggested reviewer @matt-pharr (InnerLayer focus per `docs/development/contributors.md`); assignee @d-burg. Say the word if you would rather it went to @logan-nc, who reviewed #431.

> [!NOTE]
> #298 carries a cherry-picked copy of the #431 fix ("*the copy resolves away once #431 merges*"). That sync is now due, and merging this first means #298 picks the test up on the same sync.
