### PR TITLE
InnerLayer.SLAYER - BUGFIX - Restore the toroidal mode number in the diamagnetic frequencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ scratch/
 
 # Local profiling scratch (one-off study scripts, not part of the package)
 profiling/
+
+# Override-case rundirs materialized beside their example by the regression harness
+.regress-override-*

--- a/regression-harness/cases/diiid_slayer_n2.toml
+++ b/regression-harness/cases/diiid_slayer_n2.toml
@@ -1,0 +1,173 @@
+# Regression case: DIII-D-like H-mode n=2 SLAYER tearing-mode growth rates.
+# Reuses the n=1 SLAYER deck via [overrides] at toroidal mode number 2, where the deck's
+# qmin = 1.204 puts the 3/2 surface in the plasma. Exists to guard the n-dependence of the
+# layer build — in particular the diamagnetic frequencies ω_* ∝ n feeding Q_e/Q_i, which
+# no n=1 case can constrain — with the inner rationals 3/2, 4/2, 5/2 as the tracked roots.
+# Each [quantities.*] block names an HDF5 path in the run output, how to extract it,
+# and the noise floor below which a difference is treated as zero.
+[case]
+name = "diiid_slayer_n2"
+description = "DIII-D-like H-mode equilibrium, n=2, SLAYER tearing-mode analysis guarding the 3/2 surface and the n-scaling of Q_e/Q_i (reuses the n=1 deck via overrides)"
+example_dir = "examples/DIIID-like_SLAYER_example"
+
+# Run the shared SLAYER deck at n = 2 (no separate n=2 example directory).
+[overrides]
+"ForceFreeStates.nn_low" = 2
+"ForceFreeStates.nn_high" = 2
+
+# Per-surface SLAYER layer parameters (geometry + dimensionless)
+[quantities.slayer_ising]
+h5path = "Tearing/PerSurface/rational_index"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER surface indices"
+noise_threshold = 0
+order = 10
+
+[quantities.slayer_m]
+h5path = "Tearing/PerSurface/m"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER poloidal m"
+noise_threshold = 0
+order = 11
+
+[quantities.slayer_n]
+h5path = "Tearing/PerSurface/n"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER toroidal n"
+noise_threshold = 0
+order = 12
+
+[quantities.slayer_rs]
+h5path = "Tearing/PerSurface/rs"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER minor radius rs"
+noise_threshold = 1e-10
+order = 13
+
+[quantities.slayer_sval_r]
+h5path = "Tearing/PerSurface/sval_r"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER r-based shear"
+noise_threshold = 1e-10
+order = 14
+
+[quantities.slayer_lu]
+h5path = "Tearing/PerSurface/lu"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER Lundquist S"
+noise_threshold = 1e-8
+order = 15
+
+[quantities.slayer_D_norm]
+h5path = "Tearing/PerSurface/D_norm"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER D_norm"
+noise_threshold = 1e-10
+order = 16
+
+[quantities.slayer_P_perp]
+h5path = "Tearing/PerSurface/P_perp"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER P_perp"
+noise_threshold = 1e-8
+order = 17
+
+[quantities.slayer_tauk]
+h5path = "Tearing/PerSurface/tau_k"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER tauk"
+noise_threshold = 1e-12
+order = 18
+
+[quantities.slayer_Q_e]
+h5path = "Tearing/PerSurface/Q_e"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER Q_e"
+noise_threshold = 1e-12
+order = 20
+
+[quantities.slayer_Q_i]
+h5path = "Tearing/PerSurface/Q_i"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER Q_i"
+noise_threshold = 1e-12
+order = 21
+
+[quantities.slayer_iota_e]
+h5path = "Tearing/PerSurface/iota_e"
+type = "real_vector"
+extract = "all_real"
+label = "SLAYER iota_e"
+noise_threshold = 1e-12
+order = 19
+
+# Tearing eigenvalue (coupled mode → length 1). The headline deliverable:
+# a real, nonzero growth rate on a realistic equilibrium. Root-extraction
+# is sensitive to the AMR cell topology and ODE solver, so the Q/ω/γ
+# thresholds are absolute and modestly loose; re-pin intentionally if a
+# solver/AMR change shifts the root inventory.
+# Growth-rate / frequency / root outputs. Pinned for the inner three rational
+# surfaces only (3/2, 4/2, 5/2) via `first_3`: the Δ'/γ contour search is
+# numerically unreliable on the outermost surfaces near the edge, so those are
+# deliberately not golden-tracked.
+[quantities.slayer_Q]
+h5path = "Tearing/Roots/Q_root"
+type = "complex_vector"
+extract = "first_3_complex"
+label = "SLAYER Q_root [3/2,4/2,5/2]"
+noise_threshold = 1e-4
+order = 30
+
+[quantities.slayer_omega_Hz]
+h5path = "Tearing/Roots/omega"
+type = "real_vector"
+extract = "first_3"
+label = "SLAYER ω_Hz [3/2,4/2,5/2]"
+noise_threshold = 1.0
+order = 32
+
+[quantities.slayer_gamma_Hz]
+h5path = "Tearing/Roots/gamma"
+type = "real_vector"
+extract = "first_3"
+label = "SLAYER γ_Hz [3/2,4/2,5/2]"
+noise_threshold = 1e-1
+order = 33
+
+# no_root flag (1 = extraction failed). Pinned for the inner three surfaces
+# so the 3/2, 4/2, 5/2 root inventory cannot drift silently.
+[quantities.slayer_no_root]
+h5path = "Tearing/Roots/no_root"
+type = "real_vector"
+extract = "first_3"
+label = "SLAYER no_root flags [3/2,4/2,5/2]"
+noise_threshold = 0
+order = 34
+
+# Settings (catches accidental config drift)
+[quantities.slayer_enabled]
+h5path = "Tearing/enabled"
+type = "int_scalar"
+extract = "value"
+label = "SLAYER enabled flag"
+noise_threshold = 0
+order = 90
+
+[quantities.runtime]
+h5path = ""
+type = "runtime"
+extract = "value"
+label = "Runtime (s)"
+noise_threshold = 0.0
+order = 999

--- a/regression-harness/src/runner.jl
+++ b/regression-harness/src/runner.jl
@@ -525,6 +525,7 @@ function run_local(db::SQLite.DB, case_spec::CaseSpec, repo_root::String;
             rm(runinfo_file; force=true)
         end
         if rundir_is_temp && rundir !== nothing
+            # rundir sits beside the example; removing its parent would delete examples/ itself
             rm(rundir; recursive=true, force=true)
         end
     end
@@ -649,6 +650,7 @@ function run_at_commit(db::SQLite.DB, commit_hash::String, ref_name::String,
             rm(runinfo_file; force=true)
         end
         if rundir_is_temp && rundir !== nothing
+            # rundir sits beside the example; removing its parent would delete examples/ itself
             rm(rundir; recursive=true, force=true)
         end
         if own_worktree && worktree_path !== nothing

--- a/regression-harness/src/runner.jl
+++ b/regression-harness/src/runner.jl
@@ -27,15 +27,17 @@ end
 Materialize the directory GPEC will actually run in.
 
 With no `overrides`, the example deck runs in place (returns it untouched). With overrides,
-the deck is copied to a throwaway temp dir and the named gpec.toml keys are patched there,
-so one shared example can serve several cases (e.g. a collisionless variant via
-`"KineticForces.nutype" => "zero"`). Override keys are dotted paths into the TOML; missing
-intermediate tables are created. Returns `(rundir, is_temp)`; the caller removes the temp
-tree when `is_temp`.
+the deck is copied to a throwaway sibling of the example dir and the named gpec.toml keys are
+patched there, so one shared example can serve several cases (e.g. a collisionless variant via
+`"KineticForces.nutype" => "zero"`). The copy sits beside the original so relative file
+references in the deck (e.g. `SLAYER.profile_file = "../<other_example>/..."`) still resolve.
+Override keys are dotted paths into the TOML; missing intermediate tables are created.
+Returns `(rundir, is_temp)`; the caller removes `rundir` when `is_temp`.
 """
 function _materialize_rundir(example_path::String, overrides::Dict{String,Any})
     isempty(overrides) && return (example_path, false)
-    rundir = joinpath(mktempdir(), "deck")
+    rundir = joinpath(dirname(example_path), ".regress-override-" * basename(example_path))
+    rm(rundir; recursive=true, force=true)   # stale leftover from a crashed run
     cp(example_path, rundir)
     rm(joinpath(rundir, "gpec.h5"); force=true)   # drop any stale output copied along
     cfg = TOML.parsefile(joinpath(rundir, "gpec.toml"))
@@ -523,7 +525,7 @@ function run_local(db::SQLite.DB, case_spec::CaseSpec, repo_root::String;
             rm(runinfo_file; force=true)
         end
         if rundir_is_temp && rundir !== nothing
-            rm(dirname(rundir); recursive=true, force=true)
+            rm(rundir; recursive=true, force=true)
         end
     end
 end
@@ -647,7 +649,7 @@ function run_at_commit(db::SQLite.DB, commit_hash::String, ref_name::String,
             rm(runinfo_file; force=true)
         end
         if rundir_is_temp && rundir !== nothing
-            rm(dirname(rundir); recursive=true, force=true)
+            rm(rundir; recursive=true, force=true)
         end
         if own_worktree && worktree_path !== nothing
             remove_worktree(worktree_path, repo_root)

--- a/src/InnerLayer/SLAYER/LayerInputs.jl
+++ b/src/InnerLayer/SLAYER/LayerInputs.jl
@@ -224,11 +224,9 @@ function build_slayer_inputs(equil, sings, profiles::KineticProfiles;
         n_res = sing.n[1]
 
         prof = profiles(psi)
-        # Override ω_*e, ω_*i with spline-derivative values when requested.
-        # ω_* = k_θ·v_* carries the poloidal mode number; writing it in flux
-        # coordinates absorbs q (dψ/dr = r·B_φ/q), leaving ω_* = n·(dp/dψ)/(e·n_e).
-        # `_omega_star_at` returns the n = 1 value, so restore the factor n here.
-        # Values supplied through `profiles` are taken to be physical already.
+        # Override ω_*e, ω_*i with spline-derivative values when requested. In flux coordinates
+        # ω_* = n·(dp/dψ)/(e·n_e); `_omega_star_at` returns the n = 1 value, so restore the
+        # factor n here. Values supplied through `profiles` are taken to be physical already.
         ω_e_use, ω_i_use = if compute_omega_star
             ωe1, ωi1 = _omega_star_at(psi)
             (n_res * ωe1, n_res * ωi1)

--- a/src/InnerLayer/SLAYER/LayerInputs.jl
+++ b/src/InnerLayer/SLAYER/LayerInputs.jl
@@ -217,19 +217,24 @@ function build_slayer_inputs(equil, sings, profiles::KineticProfiles;
         da_dpsi = _da_dpsi_at(psi)
         sval_r = r_based_shear(rs, q, q1, da_dpsi)
 
-        prof = profiles(psi)
-        # Override ω_*e, ω_*i with spline-derivative values when requested.
-        ω_e_use, ω_i_use = if compute_omega_star
-            _omega_star_at(psi)
-        else
-            (prof.omega_e, prof.omega_i)
-        end
-
         # Resonant (m, n): take the first element of the mode-number vectors.
         # Parallel-FM `sing.m`/`sing.n` hold exactly one entry each; ideal
         # DCON may hold multiple — we pick the first and document the choice.
         m_res = sing.m[1]
         n_res = sing.n[1]
+
+        prof = profiles(psi)
+        # Override ω_*e, ω_*i with spline-derivative values when requested.
+        # ω_* = k_θ·v_* carries the poloidal mode number; writing it in flux
+        # coordinates absorbs q (dψ/dr = r·B_φ/q), leaving ω_* = n·(dp/dψ)/(e·n_e).
+        # `_omega_star_at` returns the n = 1 value, so restore the factor n here.
+        # Values supplied through `profiles` are taken to be physical already.
+        ω_e_use, ω_i_use = if compute_omega_star
+            ωe1, ωi1 = _omega_star_at(psi)
+            (n_res * ωe1, n_res * ωi1)
+        else
+            (prof.omega_e, prof.omega_i)
+        end
 
         # Pull geometric trapped-fraction inputs from ResistGeometry when
         # available (populated by ForceFreeStates.resist_eval_all!); else

--- a/test/runtests_slayer_inputs.jl
+++ b/test/runtests_slayer_inputs.jl
@@ -185,12 +185,10 @@
     end
 
     @testset "build_slayer_inputs: omega_star carries the toroidal mode number" begin
-        # ω_* = k_θ·v_* scales with the poloidal mode number; written in flux
-        # coordinates the q is absorbed by dψ/dr = r·B_φ/q, leaving
-        # ω_* = n·(dp/dψ)/(e·n_e). Resolve the same surface at n = 1 and n = 2:
-        # Q/tauk = -ω_* must double, while iota_e = Q_e/(Q_e - Q_i) is a ratio
-        # and must not move. Asserted through the returned parameters so the
-        # check survives a refactor of where the factor is applied.
+        # In flux coordinates ω_* = n·(dp/dψ)/(e·n_e): resolving the same surface at n = 1
+        # and n = 2 must double Q/tauk = -ω_*, while the ratio iota_e must not move.
+        # Asserted through the returned parameters so the check survives a refactor of
+        # where the factor is applied.
         s1 = [_mk_sing(psi=0.3, q=2.0, q1=1.5, m=2, n=1)]
         s2 = [_mk_sing(psi=0.3, q=2.0, q1=1.5, m=4, n=2)]
         sl1 = build_slayer_inputs(equil, s1, profiles; bt=2.0, dr_val=0.0)

--- a/test/runtests_slayer_inputs.jl
+++ b/test/runtests_slayer_inputs.jl
@@ -183,4 +183,22 @@
         @test sl isa Vector{SLAYERParameters}
         @test isempty(sl)
     end
+
+    @testset "build_slayer_inputs: omega_star carries the toroidal mode number" begin
+        # ω_* = k_θ·v_* scales with the poloidal mode number; written in flux
+        # coordinates the q is absorbed by dψ/dr = r·B_φ/q, leaving
+        # ω_* = n·(dp/dψ)/(e·n_e). Resolve the same surface at n = 1 and n = 2:
+        # Q/tauk = -ω_* must double, while iota_e = Q_e/(Q_e - Q_i) is a ratio
+        # and must not move. Asserted through the returned parameters so the
+        # check survives a refactor of where the factor is applied.
+        s1 = [_mk_sing(psi=0.3, q=2.0, q1=1.5, m=2, n=1)]
+        s2 = [_mk_sing(psi=0.3, q=2.0, q1=1.5, m=4, n=2)]
+        sl1 = build_slayer_inputs(equil, s1, profiles; bt=2.0, dr_val=0.0)
+        sl2 = build_slayer_inputs(equil, s2, profiles; bt=2.0, dr_val=0.0)
+
+        @test sl2[1].Q_e / sl2[1].tauk ≈ 2 * (sl1[1].Q_e / sl1[1].tauk) rtol = 1e-12
+        @test sl2[1].Q_i / sl2[1].tauk ≈ 2 * (sl1[1].Q_i / sl1[1].tauk) rtol = 1e-12
+        @test sl2[1].iota_e ≈ sl1[1].iota_e rtol = 1e-12
+    end
+
 end


### PR DESCRIPTION
## Release note

- **Audience:** users
- **Numerical impact:** none on any shipped deck. Every SLAYER deck is `nn = 1`, where the restored factor is exactly `1.0` and the arithmetic is bit-identical. Results move for any run at n ≥ 2. _(harness @ 0d5275e31)_
- **Migration:** none.

`build_slayer_inputs` computed the electron and ion diamagnetic frequencies without the toroidal mode number, so `Q_e` and `Q_i` were low by a factor of `n` at every rational surface. Drift stabilization was therefore underestimated for any n ≥ 2 layer calculation.

## The defect

`_omega_star_at` returns

```julia
ω_star_e = (2π / chi1) * (T_e * dn_e / n_e + dT_e)
```

which is `(dp_e/dψ)/(e·n_e)` — the **n = 1** diamagnetic frequency. The physical quantity is `ω_*e = k_θ·v_*e = (m/r_s)·(dp_e/dr)/(e·n_e·B)`. Writing that in flux coordinates, `dψ/dr = r·B_φ/q` absorbs the `q` in `m = n·q` and leaves an explicit

```
ω_*e = n · (dp_e/dψ) / (e · n_e)
```

Nothing downstream restored the `n`: `Q_e = -tauk * omega_e` in `LayerParameters.jl`, with no mode-number factor anywhere in the chain.

## How it was found

Auditing whether the shear sign from #431 was load-bearing elsewhere in the layer physics. It is not — but the ExB rotation *does* pick up its mode number downstream (`1im * mc.ntor * mc.rotation[k]`, `Tearing/Dispersion/CoupledFullMatch.jl`) while ω_* never did, and the `omega` kwarg to `slayer_parameters` is accepted but unused in the body. That asymmetry was the tell.

## Confirmed against TJ

Fitzpatrick's TJ carries the mode number explicitly. `Documentation/LayerParameters.tex`:

$$\omega_{\ast k} = \frac{m_k\,B_0\,p_2'(\hat r_k)}{\mu_0\,R_0^2\,e\,n_{ek}\,g_k\,\hat r_k}$$

and `TJ/Rational.cpp:180`:

```c
double wak = double(mres[k]) * B0 * ppk /mu0 /R0/R0 /e /nek /gk /rres[k];
```

Converting TJ's r-form to the flux form gives ratio `TJ/GPEC = m/(q·g) = n`.

The same cross-check validates the neighbouring quantities, which are **not** changed here: TJ's `tHk = Lsk/m/VAk` reduces to `R₀/(n·s·V_A)`, matching GPEC's `tau_h` exactly; the `W_d` iteration and the `:rfitzp` critical-Δ match term for term.

## Blast radius

| quantity | effect |
|---|---|
| `Q_e`, `Q_i` | low by `n` — drift stabilization underestimated at n ≥ 2 |
| `iota_e = Q_e/(Q_e − Q_i)` | **unaffected** — the factor cancels in the ratio |
| `lu`, `tauk`, `D_norm`, `P_perp`, `delta_n`, `tau_r` | unaffected |

Entirely latent today: every SLAYER deck is `nn = 1`, and the only n > 1 example (`Solovev_ideal_example_multi_n`, `nn_high = 2`) is an ideal run that never builds a layer. The regression harness cannot catch this — there is no n > 1 SLAYER case.

## Validation

- [x] New test `build_slayer_inputs: omega_star carries the toroidal mode number` resolves the same surface at n = 1 and n = 2 and asserts `Q/tauk` doubles while `iota_e` does not move
- [x] **Verified non-vacuous**: with the fix reverted, exactly the two scaling assertions fail and the `iota_e` assertion still passes — the predicted signature
- [x] `runtests_slayer_inputs` 38/38
- [x] Full suite `julia -t 4 --project=. test/runtests.jl` at `53fffc0d0`: **62 testsets, 2348 assertions, 0 failures**

- [x] Post-review refactor (`_omega_star_at` now takes the mode number) re-verified: `runtests_slayer_inputs` **38/38**, `runtests_slayer_params` **68/68**, `runtests_slayer_runner` **73/73**

## Regression report

`diiid_slayer_n1`, `develop` (`df8f940d5`) vs this head (`0d5275e31`), both sides `--force`, identical pinned environments. Re-run after merging `develop` in, so both sides carry #403.

```
Regression Report: diiid_slayer_n1
==========================================================================================
Ref 1: df8f940d5  @ df8f940d5 (2026-09-17)
       env: julia 1.11.6, arm64-apple-darwin24.0.0, manifest 7e5c34ad (pinned), 8 threads/8 BLAS
Ref 2: 0d5275e31  @ 0d5275e31 (2026-09-17)
       env: julia 1.11.6, arm64-apple-darwin24.0.0, manifest 7e5c34ad (pinned), 8 threads/8 BLAS
------------------------------------------------------------------------------------------
Quantity                            df8f940d5  0d5275e31  Diff               Status       
------------------------------------------------------------------------------------------
SLAYER surface indices              [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER poloidal m                   [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER toroidal n                   [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER minor radius rs              [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER r-based shear                [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER Lundquist S                  [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER D_norm                       [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER P_perp                       [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER tauk                         [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER iota_e                       [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER Q_e                          [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER Q_i                          [6 elem]   [6 elem]   0.0e+00            OK           
SLAYER Q_root [2/1,3/1,4/1]         [3 elem]   [3 elem]   5.9e-06            OK           
SLAYER ω_Hz [2/1,3/1,4/1]           [3 elem]   [3 elem]   3.2e-06            OK           
SLAYER γ_Hz [2/1,3/1,4/1]           [3 elem]   [3 elem]   1.475e-01 (0.01%)  ** CHANGED **
SLAYER no_root flags [2/1,3/1,4/1]  [3 elem]   [3 elem]   0.0e+00            OK           
SLAYER enabled flag                 1          1          0.0e+00            OK           
Runtime (s)                         172.8s     146.7s                        --           
==========================================================================================
Summary: 1 changed, 16 unchanged
```

**Inert on the shipped deck, as predicted.** Every tracked quantity is unchanged — including `Q_e` and `Q_i`, now pinned by this case, which is the direct statement that the restored factor does nothing at n = 1. The root lines sit at 1e-5 Hz and below, inside the threaded root search's own floor (0.076/0.122/0.145 Hz per surface, #418).


## The n = 2 demonstration

There is no n > 1 SLAYER case in the harness, so this defect was invisible to it. While preparing this PR I built one — `diiid_slayer_n2`, the n = 1 deck re-run via `[overrides]` at `nn = 2` — to produce the measurement below. **It is not part of this PR:** on review (@jhalpern30) it was dropped as regression bloat, since it cost 273s/ref to guard something a unit test covers for free. Its two novel quantities, `Q_e` and `Q_i`, were folded into `diiid_slayer_n1` instead, and the n-scaling is guarded by `test/runtests_slayer_inputs.jl`.

The measurement stands as validation even though the case is gone. `develop` (`e09795119`) vs `21fd7240e`:

```
SLAYER minor radius rs              [13 elem]  [13 elem]  0.0e+00              OK
SLAYER Lundquist S                  [13 elem]  [13 elem]  0.0e+00              OK
SLAYER D_norm                       [13 elem]  [13 elem]  0.0e+00              OK
SLAYER tauk                         [13 elem]  [13 elem]  0.0e+00              OK
SLAYER iota_e                       [13 elem]  [13 elem]  0.0e+00              OK
SLAYER Q_e                          [13 elem]  [13 elem]  1.158e+00 (100.00%)  ** CHANGED **
SLAYER Q_i                          [13 elem]  [13 elem]  2.122e+00 (100.00%)  ** CHANGED **
SLAYER Q_root [3/2,4/2,5/2]         [3 elem]   [3 elem]   8.407e-01 (100.02%)  ** CHANGED **
SLAYER ω_Hz [3/2,4/2,5/2]           [3 elem]   [3 elem]   1.094e+04 (100.02%)  ** CHANGED **
SLAYER γ_Hz [3/2,4/2,5/2]           [3 elem]   [3 elem]   8.441e-01 (0.13%)    ** CHANGED **
SLAYER no_root flags [3/2,4/2,5/2]  [3 elem]   [3 elem]   0.0e+00              OK
```

With every geometric and resistive input bit-identical, `Q_e` and `Q_i` move by **exactly 100%** — the restored factor n = 2 — and the mode rotation `ω_Hz` doubles with them (drift rotation ∝ ω_*), while `γ_Hz` moves 0.13%. The root inventory is unchanged. On `develop`, an n = 2 run underestimates the diamagnetic drive by exactly half; any 3/2 analysis needs this PR first.

The harness fix that made `[overrides]` usable here (`8ae06cd23`, plus the `4c70d4232` gitignore) is kept — it is a general capability for any deck with relative file references, not specific to the removed case.

## Notes for reviewers

The mode number is applied inside `_omega_star_at(ψ, n_tor)`, which returns the physical ω_*. (It was originally applied at the call site; @jhalpern30 correctly pushed back that a helper named for ω_* should return ω_*.) The parameter is `n_tor` rather than `n` because `n_e` and `n_i` are densities in the same scope.

The `compute_omega_star=false` branch reads `profiles.omega_e/omega_i`, which are **literal zeros** in production: `run_slayer.jl:44` hardcodes `zeros(npsi)`, `compute_omega_star` defaults to `true`, and no caller in `src/` passes it. The kinetic file schema has no ω_* column either, so nothing can supply one. That branch is a library-only path.

> [!NOTE]
> Found alongside a second, independent discrepancy in `D_norm` — see the companion PR. The two are in different files and do not conflict.



