### PR TITLE
InnerLayer.SLAYER - BUGFIX! - Normalize D by the electron diamagnetic share, not the temperature ratio

### DIFF
--- a/src/InnerLayer/SLAYER/LayerParameters.jl
+++ b/src/InnerLayer/SLAYER/LayerParameters.jl
@@ -355,6 +355,7 @@ function slayer_parameters(;
 
     # Normalized beta-related width and Δ-normalization
     d_beta = c_beta * d_i
+    # D = S^(1/3)·iota_e^(1/2)·(d_beta/r_s), Fitzpatrick's ion-sound-radius normalization.
     # iota_e is the electron share of the total diamagnetic frequency; it reduces to
     # 1/(1+tau) only when the electron and ion pressure-gradient scale lengths match.
     D_norm = (d_beta / rs) * lu^(1.0 / 3.0) * sqrt(iota_e)

--- a/src/InnerLayer/SLAYER/LayerParameters.jl
+++ b/src/InnerLayer/SLAYER/LayerParameters.jl
@@ -355,9 +355,8 @@ function slayer_parameters(;
 
     # Normalized beta-related width and Δ-normalization
     d_beta = c_beta * d_i
-    # D = S^(1/3)·iota_e^(1/2)·(d_beta/r_s). iota_e is the electron share of the
-    # total diamagnetic frequency; it reduces to 1/(1+tau) only when the electron
-    # and ion pressure-gradient scale lengths match, so use the computed value.
+    # iota_e is the electron share of the total diamagnetic frequency; it reduces to
+    # 1/(1+tau) only when the electron and ion pressure-gradient scale lengths match.
     D_norm = (d_beta / rs) * lu^(1.0 / 3.0) * sqrt(iota_e)
     delta_n = lu^(1.0 / 3.0) / rs
 

--- a/src/InnerLayer/SLAYER/LayerParameters.jl
+++ b/src/InnerLayer/SLAYER/LayerParameters.jl
@@ -27,7 +27,7 @@ de-normalization. The parametrization uses `P_perp`, `P_tor`, and
 | `tau`      | T_i / T_e                                                         |
 | `lu`       | Lundquist number S = τ_R / τ_H                                    |
 | `c_beta`   | Compressibility √(β_local / (1 + β_local))                        |
-| `D_norm`   | (d_β/r_s) · S^(1/3) · √(τ/(1+τ))  (Fitzpatrick normalized scale)  |
+| `D_norm`   | (d_β/r_s) · S^(1/3) · √ι_e  (Fitzpatrick normalized scale)        |
 | `P_perp`   | Perpendicular Prandtl number τ_R / τ_⊥                            |
 | `P_tor`    | Toroidal-direction Prandtl number τ_R / τ_‖tor                    |
 | `Q_e`      | Normalized electron diamagnetic: −tauk · ω_*e                     |
@@ -329,6 +329,19 @@ function slayer_parameters(;
             )
         )
     iota_e = Q_e / Q_e_minus_Q_i
+    # D below takes sqrt(iota_e). iota_e lies in (0,1) whenever ω_*e and ω_*i have
+    # opposite signs — the physical case and the convention stated above. Surface a
+    # negative value as a clear error rather than a bare DomainError.
+    iota_e > 0 ||
+        throw(
+            ArgumentError(
+                "slayer_parameters: iota_e = Q_e/(Q_e - Q_i) = $iota_e is " *
+                "not positive, so the ion-sound-radius normalization " *
+                "D_norm = (d_beta/r_s)·S^(1/3)·sqrt(iota_e) is undefined. " *
+                "Check the diamagnetic-frequency inputs ω_*e, ω_*i — they " *
+                "are expected to carry opposite signs."
+            )
+        )
 
     # Plasma beta and compressibility
     lbeta = (5.0 / 3.0) * MU_0 * n_e * E_CHG * (t_e + t_i) / bt^2
@@ -342,7 +355,10 @@ function slayer_parameters(;
 
     # Normalized beta-related width and Δ-normalization
     d_beta = c_beta * d_i
-    D_norm = (d_beta / rs) * lu^(1.0 / 3.0) * sqrt(tau / (1.0 + tau))
+    # D = S^(1/3)·iota_e^(1/2)·(d_beta/r_s). iota_e is the electron share of the
+    # total diamagnetic frequency; it reduces to 1/(1+tau) only when the electron
+    # and ion pressure-gradient scale lengths match, so use the computed value.
+    D_norm = (d_beta / rs) * lu^(1.0 / 3.0) * sqrt(iota_e)
     delta_n = lu^(1.0 / 3.0) / rs
 
     # Critical-Δ offset from chi_parallel matching

--- a/test/runtests_dispersion_coupled.jl
+++ b/test/runtests_dispersion_coupled.jl
@@ -21,7 +21,7 @@
     function _slayer_ref()
         return slayer_parameters(
             n_e=5.0e19, t_e=1000.0, t_i=1000.0,
-            omega=0.0, omega_e=1.0e4, omega_i=5.0e3,
+            omega=0.0, omega_e=-1.0e4, omega_i=5.0e3,
             qval=2.0, sval_r=1.0, bt=2.0,
             rs=0.5, R0=1.7, mu_i=2.0, zeff=1.0,
             chi_perp=1.0, chi_tor=1.0, m=2, n=1)

--- a/test/runtests_dispersion_residual.jl
+++ b/test/runtests_dispersion_residual.jl
@@ -21,7 +21,7 @@
     function _slayer_ref()
         return slayer_parameters(
             n_e=5.0e19, t_e=1000.0, t_i=1000.0,
-            omega=0.0, omega_e=1.0e4, omega_i=5.0e3,
+            omega=0.0, omega_e=-1.0e4, omega_i=5.0e3,
             qval=2.0, sval_r=1.0, bt=2.0,
             rs=0.5, R0=1.7, mu_i=2.0, zeff=1.0,
             chi_perp=1.0, chi_tor=1.0, m=2, n=1)

--- a/test/runtests_slayer_params.jl
+++ b/test/runtests_slayer_params.jl
@@ -83,8 +83,9 @@
         @test p.P_perp ≈ p.P_tor
         @test p.P_perp > 0
 
-        # D_norm = (d_β/r_s)·S^(1/3)·√(τ/(1+τ))
-        D_norm_expected = (p.d_beta / p.rs) * p.lu^(1 / 3) * sqrt(p.tau / (1 + p.tau))
+        # D_norm = (d_β/r_s)·S^(1/3)·√ι_e — the electron share of the total
+        # diamagnetic frequency, not the temperature ratio.
+        D_norm_expected = (p.d_beta / p.rs) * p.lu^(1 / 3) * sqrt(p.iota_e)
         @test p.D_norm ≈ D_norm_expected rtol = 1e-12
 
         # delta_n = S^(1/3)/r_s

--- a/test/runtests_slayer_params.jl
+++ b/test/runtests_slayer_params.jl
@@ -9,7 +9,7 @@
     function _ref_kwargs(; dr_val=0.0, dc_type=:none)
         return (
             n_e=5.0e19, t_e=1000.0, t_i=1000.0,
-            omega=0.0, omega_e=1.0e4, omega_i=5.0e3,
+            omega=0.0, omega_e=-1.0e4, omega_i=5.0e3,
             qval=2.0, sval_r=1.0, bt=2.0,
             rs=0.5, R0=1.7, mu_i=2.0, zeff=1.0,
             chi_perp=1.0, chi_tor=1.0,
@@ -36,13 +36,13 @@
 
         # Trivially exact ratios
         @test p.tau ≈ 1.0
-        # Q_e = −tauk·1e4 = negative; Q_i = −tauk·5e3 = negative
-        # Q_e − Q_i = −tauk·5e3 = Q_i (since Q_e = 2·Q_i) ⇒ iota_e = Q_e/Q_i = 2
-        @test p.iota_e ≈ 2.0
+        # Physical opposite-drift inputs: ω_*e < 0 < ω_*i, so Q = −tauk·ω gives
+        # Q_e > 0 > Q_i and iota_e = Q_e/(Q_e − Q_i) = 1e4/(1e4 + 5e3) = 2/3
+        @test p.iota_e ≈ 2 / 3
 
-        # Sign convention check (SLAYER layerinputs)
-        @test p.Q_e == -p.tauk * 1.0e4
-        @test p.Q_i == -p.tauk * 5.0e3    # SLAYER params convention: Q_i = −tauk·ω*i
+        # Sign convention check (SLAYER layerinputs): Q = −tauk·ω
+        @test p.Q_e == p.tauk * 1.0e4
+        @test p.Q_i == -p.tauk * 5.0e3
 
         # Default resistivity closure is neoclassical (Sauter F_33). The
         # trapped-particle correction raises η above plain Spitzer at the

--- a/test/runtests_slayer_riccati.jl
+++ b/test/runtests_slayer_riccati.jl
@@ -15,7 +15,7 @@
     function _ref_params_large_D()
         return slayer_parameters(;
             n_e=5.0e19, t_e=3000.0, t_i=3000.0,
-            omega=0.0, omega_e=1.0e4, omega_i=5.0e3,
+            omega=0.0, omega_e=-1.0e4, omega_i=5.0e3,
             qval=2.0, sval_r=1.0, bt=2.0,
             rs=0.5, R0=1.7, mu_i=2.0, zeff=1.0,
             chi_perp=1.0, chi_tor=1.0,


### PR DESCRIPTION
## Release note

- **Audience:** users
- **Numerical impact:** **`D_norm` moves on every deck with T_i ≠ T_e**, including the shipped `diiid_slayer_n1` case (**D_norm 20.4%**, **γ_Hz 9.8%** on `diiid_slayer_n1`). The ion-sound-radius normalization had the electron and ion temperatures transposed. _(harness @ 74b6c94f5)_
- **Migration:** re-run any SLAYER case whose profiles have T_i ≠ T_e — saved `D_norm`, `Q_root`, `ω_Hz` and `γ_Hz` from earlier runs are not comparable to new ones, so archived numbers and any figures built from them need regenerating. No API change. One behavioural change to watch for: a caller passing same-sign `ω_*e`/`ω_*i` (unphysical, but previously silently accepted) now raises an `ArgumentError` from `slayer_parameters` instead of producing a value.

`D_norm` used `√(τ/(1+τ))` with `τ = T_i/T_e`. Fitzpatrick's definition is `D = S^(1/3)·ι_e^(1/2)·d̂_β`, and `ι_e` reduces to `1/(1+τ)`, not `τ/(1+τ)`. The two agree only at `T_i = T_e`. GPEC already computes the correct `ι_e` and did not use it.

## The defect

From TJ `Documentation/Layer.tex`:

| eq. | statement |
|---|---|
| (228) | `D = S^(1/3) · ι_e^(1/2) · d̂_β` |
| (282) | `ι_e = Q_e/(Q_e − Q_i)` |
| (213) | `ι = (T_e/T_i)·((1+η_e)/(1+η_i))`, with `ι_e = ι/(1+ι)` |

With `η_e = η_i` the third line gives `ι = T_e/T_i = 1/τ`, hence

```
ι_e = (1/τ)/(1 + 1/τ) = 1/(1+τ) = T_e/(T_e + T_i)
```

GPEC used `τ/(1+τ) = T_i/(T_e + T_i)` — the same expression with the two temperatures swapped. Equal at `τ = 1`, divergent in opposite directions otherwise.

Note that (282) is **exactly** the `iota_e` GPEC already computes and stores from ω_*e/ω_*i. The fix is to use it.

## Why the computed `iota_e` and not `1/(1+τ)`

`1/(1+τ)` is only the `η_e = η_i` limit. The full `ι` also carries `(1+η_e)/(1+η_i)`, the ratio of the electron and ion pressure-gradient scale lengths — TJ's own text calls `ι` "the ratio of the electron to the ion pressure gradient at the rational surface". GPEC's `iota_e = Q_e/(Q_e − Q_i)`, built from the actual ω_*e and ω_*i spline derivatives, captures that automatically. It is both TJ-faithful and strictly more general than either closed form. TJ itself hardcodes `ι_e = 0.5` (`Rational.cpp:198`), so this is a case where GPEC can do better than the reference.

## Impact on the shipped deck

`examples/DIIID-like_ideal_example/TkMkr_D3Dlike_Hmode_kinetic.h5` has `T_i ≠ T_e` — 2534.73 vs 1952.59 eV at index 200, so `τ ≈ 1.298`:

| | value |
|---|---|
| old factor `√(τ/(1+τ))` | 0.752 |
| new factor `√ι_e` (η-equal estimate 0.435) | 0.660 |
| **`D_norm` ratio** | **≈ 0.88** |

So this is **not** latent — unlike the companion n-factor PR, it changes `diiid_slayer_n1` today.

## Guard

`√ι_e` requires `ι_e > 0`, which holds whenever ω_*e and ω_*i have opposite signs — the physical case, and the sign convention the `slayer_parameters` docstring already states. Same-sign inputs with `|Q_i| > |Q_e|` would make `ι_e < 0`; that now raises a clear `ArgumentError` rather than a bare `DomainError`, mirroring the existing degenerate-`Q_e == Q_i` guard immediately above it.

## Validation

- [x] `runtests_slayer_params` 49/49 — the one failure this produced was `runtests_slayer_params.jl:88`, the assertion that pins the **definition** of `D_norm`; it is updated to the corrected formula in this PR. That is a definition change, not a loosened tolerance.
- [x] `runtests_slayer_riccati` 29/29 — the large-D/small-D branch selection assertions still hold. Worth knowing: that fixture passes same-sign ω_*e/ω_*i (`1e4`, `5e3`), which is unphysical and gives `iota_e = 2.0`, so `D_norm` roughly doubles there. The branch inequalities survive because the fixture sits well inside its regime, but the fixture arguably wants fixing separately — flagging rather than quietly retuning it.
- [x] Full suite `julia -t 4 --project=. test/runtests.jl` at `a5dea9fed`: **62 testsets, 2345 assertions, 0 failures**
- [x] Regression harness — below

## Regression report

`diiid_slayer_n1`, `develop` (`ed72b9f55`) vs this head (`74b6c94f5`), both sides `--force`, identical pinned environments (julia 1.11.6, manifest `7e5c34ad`). Re-run after merging `develop` in, so both sides carry #403.

```
Regression Report: diiid_slayer_n1
===========================================================================================
Ref 1: ed72b9f55  @ ed72b9f55 (2026-09-16)
       env: julia 1.11.6, arm64-apple-darwin24.0.0, manifest 7e5c34ad (pinned), 8 threads/8 BLAS
Ref 2: 74b6c94f5  @ 74b6c94f5 (2026-09-16)
       env: julia 1.11.6, arm64-apple-darwin24.0.0, manifest 7e5c34ad (pinned), 8 threads/8 BLAS
-------------------------------------------------------------------------------------------
Quantity                            ed72b9f55  74b6c94f5  Diff                Status       
-------------------------------------------------------------------------------------------
SLAYER surface indices              [6 elem]   [6 elem]   0.0e+00             OK           
SLAYER poloidal m                   [6 elem]   [6 elem]   0.0e+00             OK           
SLAYER toroidal n                   [6 elem]   [6 elem]   0.0e+00             OK           
SLAYER minor radius rs              [6 elem]   [6 elem]   0.0e+00             OK           
SLAYER r-based shear                [6 elem]   [6 elem]   0.0e+00             OK           
SLAYER Lundquist S                  [6 elem]   [6 elem]   0.0e+00             OK           
SLAYER D_norm                       [6 elem]   [6 elem]   5.587e-01 (20.44%)  ** CHANGED **
SLAYER P_perp                       [6 elem]   [6 elem]   0.0e+00             OK           
SLAYER tauk                         [6 elem]   [6 elem]   0.0e+00             OK           
SLAYER iota_e                       [6 elem]   [6 elem]   0.0e+00             OK           
SLAYER Q_root [2/1,3/1,4/1]         [3 elem]   [3 elem]   2.949e-03 (0.42%)   ** CHANGED **
SLAYER ω_Hz [2/1,3/1,4/1]           [3 elem]   [3 elem]   1.515e+00 (0.01%)   ** CHANGED **
SLAYER γ_Hz [2/1,3/1,4/1]           [3 elem]   [3 elem]   1.101e+02 (9.84%)   ** CHANGED **
SLAYER no_root flags [2/1,3/1,4/1]  [3 elem]   [3 elem]   0.0e+00             OK           
SLAYER enabled flag                 1          1          0.0e+00             OK           
Runtime (s)                         164.4s     161.5s                         --           
===========================================================================================
Summary: 4 changed, 11 unchanged
```

### The report is self-verifying

The change is surgical, and the table proves it rather than asserting it:

- **`iota_e` is `0.0e+00`.** It was already computed correctly on `develop` — this PR only starts *using* it. That is the single strongest line in the table: it separates "we changed which quantity `D` is built from" from "we changed `iota_e`".
- **Every other layer input is bit-identical** — `rs`, shear, Lundquist `S`, `tauk`, `P_perp`, the surface and mode-number lists. Nothing upstream of `D` moved.
- **`D_norm` moves 20.4%**, and `γ_Hz` follows at 9.8%. That is the physical consequence: the ion sound radius sets the drift-tearing layer response.

**The γ shift is real, not solver noise.** `diiid_slayer_n1`'s γ line has a known reproducibility floor from the threaded root search — 0.076/0.122/0.145 Hz per surface (#418), which showed up as 0.02% in #431. Here it is **110.1 Hz, 9.84%** — nearly three orders of magnitude above that floor.

**On my pre-run estimate:** I predicted ≈12% on `D_norm` from a single mid-radius point assuming η_e = η_i. The measured 20.4% is larger because τ varies across the six surfaces and the computed `iota_e` also carries the (1+η_e)/(1+η_i) factor that the closed form drops. The direction and order of magnitude held; the point estimate was not a prediction of the max.

> [!NOTE]
> `develop` was merged in at `87a9b607f` and the harness re-run against it. The previous
> report was taken before #403 landed on `develop`; comparing across that gap mixed this
> PR's `D_norm` change with #403's Δ′ conversion pulling the other way, which showed up as
> spurious motion in `r-based shear` and `Lundquist S` and inflated γ to 36.6%. With both
> sides carrying #403 those two lines are `0.0e+00` again and γ is back to 9.83%.

## Notes for reviewers

Opened as a draft. **This one changes shipped numbers and wants a physics sign-off before it goes anywhere near ready.**

Found while auditing whether the #431 shear sign was load-bearing elsewhere. Independent of the companion n-factor PR — different file, no textual conflict, and the missing `n` cancels in `iota_e`, so the `iota_e` this PR starts using is already correct on `develop`.

Cross-checks worth confirming against Park 2022 (`docs/resources/2022-Park-Parametric dependencies...`) and Burgess 2026, which I have not read for this: TJ is one source and the SLAYER lineage may have intended a different closure.

Suggested reviewer @matt-pharr (InnerLayer focus); assignee @d-burg. @logan-nc may want to see this too given it moves a harness case.




