### PR TITLE
ForceFreeStates - BUGFIX! - Snap the periodic theta endpoint before integrating GGJ geometry

### DIFF
--- a/src/ForceFreeStates/Surfaces/Resist.jl
+++ b/src/ForceFreeStates/Surfaces/Resist.jl
@@ -94,9 +94,7 @@ function resist_eval(sing::SingType, equil::Equilibrium.PlasmaEquilibrium,
         ff[itheta, 6] = dpsisq / bsq
         @views ff[itheta, :] .*= jac / v1
     end
-    # Snap the repeated endpoint exactly equal to the start (see Equilibrium.jl's
-    # GS-residual integrator and issue #240 -- independent spline evaluations at
-    # theta=0/1 can differ by machine epsilon and trip PeriodicBC's check)
+    # Snap the repeated endpoint exactly equal to the start
     @views ff[end, :] .= ff[1, :]
     itp = cubic_interp(equil.rzphi_ys, Series(ff); bc=PeriodicBC())
     avg = FastInterpolations.integrate(itp)

--- a/src/ForceFreeStates/Surfaces/Resist.jl
+++ b/src/ForceFreeStates/Surfaces/Resist.jl
@@ -94,6 +94,10 @@ function resist_eval(sing::SingType, equil::Equilibrium.PlasmaEquilibrium,
         ff[itheta, 6] = dpsisq / bsq
         @views ff[itheta, :] .*= jac / v1
     end
+    # Snap the repeated endpoint exactly equal to the start (see Equilibrium.jl's
+    # GS-residual integrator and issue #240 -- independent spline evaluations at
+    # theta=0/1 can differ by machine epsilon and trip PeriodicBC's check)
+    @views ff[end, :] .= ff[1, :]
     itp = cubic_interp(equil.rzphi_ys, Series(ff); bc=PeriodicBC())
     avg = FastInterpolations.integrate(itp)
 

--- a/src/ForceFreeStates/Surfaces/ResistEval.jl
+++ b/src/ForceFreeStates/Surfaces/ResistEval.jl
@@ -165,6 +165,10 @@ function resist_geometry(equil::Equilibrium.PlasmaEquilibrium,
         ff[itheta, 7] = B_here
         @views ff[itheta, :] .*= jac / v1
     end
+    # Snap the repeated endpoint exactly equal to the start (see Equilibrium.jl's
+    # GS-residual integrator and issue #240 -- independent spline evaluations at
+    # theta=0/1 can differ by machine epsilon and trip PeriodicBC's check)
+    @views ff[end, :] .= ff[1, :]
 
     # Integrate each column around θ using the same periodic cubic-spline
     # integrator Mercier.jl uses

--- a/src/ForceFreeStates/Surfaces/ResistEval.jl
+++ b/src/ForceFreeStates/Surfaces/ResistEval.jl
@@ -165,9 +165,7 @@ function resist_geometry(equil::Equilibrium.PlasmaEquilibrium,
         ff[itheta, 7] = B_here
         @views ff[itheta, :] .*= jac / v1
     end
-    # Snap the repeated endpoint exactly equal to the start (see Equilibrium.jl's
-    # GS-residual integrator and issue #240 -- independent spline evaluations at
-    # theta=0/1 can differ by machine epsilon and trip PeriodicBC's check)
+    # Snap the repeated endpoint exactly equal to the start
     @views ff[end, :] .= ff[1, :]
 
     # Integrate each column around θ using the same periodic cubic-spline


### PR DESCRIPTION
## Release note

- **Audience:** developers
- **Numerical impact:** none _(harness @ 987e63f3b, diiid_n1: 47/47 quantities bit-identical, develop vs. local)_
- **Migration:** none

`resist_geometry` (ResistEval.jl) and `resist_eval` (Resist.jl) build the GGJ
theta-integrand independently at each theta node, including both periodic
endpoints, then integrate with `cubic_interp(...; bc=PeriodicBC())`. The two
endpoint evaluations can differ by machine epsilon, which a stricter
`PeriodicBC(endpoint=:inclusive)` validator now rejects outright, aborting
force-free-state prep on some equilibria (mine hit it via a DIII-D case
driven from TokToxStability).

## What

Snap `ff[end, :] .= ff[1, :]` right before each `cubic_interp` call, in both
`ForceFreeStates/Surfaces/ResistEval.jl` and the sibling
`ForceFreeStates/Surfaces/Resist.jl` (same GGJ-integrand pattern, same latent
bug -- not yet observed in the wild but a spot check shows it will trip the
same way on the right input).

This mirrors the fix already in `Equilibrium.jl`'s GS-residual integrator:

    # Snap the repeated endpoint exactly equal to the start
    fs_matrix[end, :] .= fs_matrix[1, :]
    itp = cubic_interp(equil.rzphi_ys, Series(fs_matrix); bc=PeriodicBC())

## Context

- Closes the remaining gap from #240, whose "proper fix" pattern (explicit
  endpoint closure at the data-construction site, not `check=false`) was
  applied everywhere in PR #243 except `ForceFreeStates/Surfaces/`.
- Unrelated to the still-open KineticForces parallel-velocity-spline
  periodicity issue (#341, #390) -- that's a different spline (`tspl`/`vpar`
  in `Torque.jl`/`BounceAveraging.jl`), not the GGJ geometry integrand here.

## Regression report

```
regress --cases diiid_n1 --refs develop,local

Regression Report: diiid_n1
=================================================================================================
Ref 1: develop  @ 987e63f3b (2026-08-28)
Ref 2: local    @ local     (2026-09-01)
-------------------------------------------------------------------------------------------------
Summary: 47 unchanged
```

Also ran the existing `test/runtests_resist_eval.jl` suite: 63/63 passed.

## Notes for reviewers

No behavior change expected or observed -- this only prevents a false-positive
validator abort on machine-epsilon endpoint drift, matching the fix pattern
already established for #240.