### PR TITLE
Equilibrium - BUGFIX - Sample knot midpoints so the round-trip check can see spline ringing

### DIFF
--- a/src/Equilibrium/DirectEquilibriumByInversion.jl
+++ b/src/Equilibrium/DirectEquilibriumByInversion.jl
@@ -10,6 +10,20 @@ Select via `eq_type = "efit_by_inversion"` in `gpec.toml`.
 
 import Contour as Ctr
 
+# Round-trip (ψ,θ)→(R,Z)→ψ residual above which the traced edge geometry is not trusted.
+const ROUNDTRIP_TOL = 2e-3
+# Fraction of the radial grid treated as "the edge" for the round-trip check.
+const ROUNDTRIP_EDGE_FRAC = 0.9
+# How much larger the midpoint residual may be than the on-knot one before the rzphi splines are
+# judged to be ringing between knots. Grid-invariant, being a ratio of two residuals measured the
+# same way. Calibrated on a DIII-D-like psihigh ladder, where it reads 1.2 while the ForceFreeStates
+# energies are sound and 10^2-10^3 once they are not; a separation that wide leaves the exact
+# threshold uncritical.
+const ROUNDTRIP_RATIO_TOL = 10.0
+# Midpoint residual below which the ratio is not consulted, since both residuals are then at the
+# rounding floor and their ratio measures noise rather than ringing.
+const ROUNDTRIP_RINGING_FLOOR = ROUNDTRIP_TOL / 20
+
 """
     _is_closed_curve(curve)
 
@@ -692,27 +706,46 @@ function equilibrium_solver_by_inversion(
 
     pe = equilibrium_solver(inv_input; override_psi_nodes)
 
-    # Round-trip validation: (ψ,θ) → (R,Z) → ψ_spline − ψ_target.
-    # Checks 4 angles at the outermost surface and at 75% of the radial grid.
-    # A large error indicates that Contour.jl resolution was insufficient near the
-    # x-point and the traced surface positions are inaccurate.
-    max_rt_err = 0.0
-    for ψ_check in (pe.rzphi_xs[end], pe.rzphi_xs[max(1, length(pe.rzphi_xs) * 3 ÷ 4)])
-        for θ_check in (0.0, 0.25, 0.5, 0.75)
+    # Round-trip validation: (ψ,θ) → (R,Z) → ψ_spline − ψ_target, over 4 angles on the outer
+    # ROUNDTRIP_EDGE_FRAC of the radial grid. A large residual means Contour.jl resolution was
+    # insufficient near the x-point and the traced surface positions are inaccurate.
+    #
+    # Measured twice, at the ψ knots and at the knot midpoints, because the rzphi splines
+    # interpolate exactly at their own knots: an on-knot residual cannot see inter-knot ringing
+    # at all, and stays flat at ~1e-6 on a psihigh ladder whose stability energies degrade by
+    # six orders of magnitude. The midpoint residual tracks that degradation, and their RATIO is
+    # the usable signal — dimensionless, so it needs no per-grid calibration.
+    rt_residual(ψ_samples) = maximum(
+        begin
             r2 = pe.rzphi_rsquared((ψ_check, θ_check))
             off = pe.rzphi_offset((ψ_check, θ_check))
             rfac = sqrt(max(r2, 0.0))
             η = 2π * (θ_check + off)
-            R = pe.ro + rfac * cos(η)
-            Z = pe.zo + rfac * sin(η)
-            ψ_rt = 1.0 - raw_profile.psi_in((R, Z)) / psio
-            max_rt_err = max(max_rt_err, abs(ψ_rt - ψ_check))
+            abs((1.0 - raw_profile.psi_in((pe.ro + rfac * cos(η), pe.zo + rfac * sin(η))) / psio) - ψ_check)
         end
-    end
-    if max_rt_err > 2e-3
-        @warn "efit_by_inversion: round-trip error at edge = $(@sprintf("%.2e", max_rt_err)) > 2e-3; accuracy near psihigh may be limited. Consider reducing psihigh or increasing resolution_factor."
+        for ψ_check in ψ_samples, θ_check in (0.0, 0.25, 0.5, 0.75))
+
+    xs = pe.rzphi_xs
+    knots = @view xs[max(1, ceil(Int, length(xs) * ROUNDTRIP_EDGE_FRAC)):end]
+    max_rt_err = rt_residual(knots)
+    mids = [(knots[i] + knots[i+1]) / 2 for i in 1:(length(knots)-1)]
+    rt_mid = isempty(mids) ? NaN : rt_residual(mids)
+    rt_ratio = rt_mid / max(max_rt_err, eps())
+
+    # The ratio only means something once the midpoint residual is above the noise it would
+    # otherwise be measuring: on a clean grid both residuals sit near 1e-6, where their ratio is
+    # dominated by rounding rather than by ringing.
+    ringing = rt_mid > ROUNDTRIP_RINGING_FLOOR && rt_ratio > ROUNDTRIP_RATIO_TOL
+    too_large = max_rt_err > ROUNDTRIP_TOL || rt_mid > ROUNDTRIP_TOL
+    msg =
+        "efit_by_inversion: round-trip error at edge = $(@sprintf("%.2e", max_rt_err)) on knots, " *
+        "$(@sprintf("%.2e", rt_mid)) at knot midpoints (ratio $(@sprintf("%.1f", rt_ratio)))"
+    if too_large
+        @warn "$msg; exceeds $(ROUNDTRIP_TOL), so accuracy near psihigh may be limited. Consider reducing psihigh or increasing resolution_factor."
+    elseif ringing
+        @warn "$msg; the midpoint residual is $(@sprintf("%.0f", rt_ratio))x the on-knot one, so the rzphi splines are ringing between knots even though both residuals are small. Consider reducing psihigh or increasing resolution_factor."
     else
-        @info "efit_by_inversion: round-trip error at edge = $(@sprintf("%.2e", max_rt_err))"
+        @info msg
     end
 
     return pe

--- a/test/runtests_equil.jl
+++ b/test/runtests_equil.jl
@@ -68,6 +68,39 @@
         @test all(>(0), B_nodes)
     end
 
+    @testset "Round-trip check sees inter-knot ringing" begin
+        EQ = GeneralizedPerturbedEquilibrium.Equilibrium
+        # The rzphi splines interpolate exactly at their own knots, so an on-knot residual is
+        # blind to ringing between them. The check therefore samples the knot midpoints too and
+        # compares the two, and the ringing verdict is not consulted while the midpoint residual
+        # is still at the rounding floor, where the ratio would measure noise.
+        @test EQ.ROUNDTRIP_RINGING_FLOOR < EQ.ROUNDTRIP_TOL
+        @test EQ.ROUNDTRIP_RATIO_TOL > 1
+        @test 0 < EQ.ROUNDTRIP_EDGE_FRAC < 1
+
+        # False-positive control: a deck that traces cleanly must report both residuals and stay
+        # at Info. The DIII-D-like geqdsk is used because the CHEASE deck above is the case that
+        # already trips the pre-existing absolute tolerance on this path.
+        cfg = EQ.EquilibriumConfig(;
+            eq_filename=joinpath(@__DIR__, "..", "examples", "DIIID-like_ideal_example", "TkMkr_D3Dlike_Hmode.geqdsk"),
+            eq_type="efit_by_inversion",
+            jac_type="hamada",
+            grid_type="log_asymptotic",
+            psilow=1e-4,
+            psihigh=0.995,
+            mpsi=128,
+            mtheta=128
+        )
+        logs, _ = Test.collect_test_logs(; min_level=Base.CoreLogging.Info) do
+            EQ.setup_equilibrium(cfg)
+        end
+        rt = filter(l -> occursin("round-trip error at edge", string(l.message)), logs)
+        @test length(rt) == 1
+        @test rt[1].level == Base.CoreLogging.Info
+        @test occursin("at knot midpoints", string(rt[1].message))
+        @test occursin("ratio", string(rt[1].message))
+    end
+
     @testset "Resolved psihigh" begin
         # The config holds the user's request and is never written to; the value the
         # equilibrium is actually formed on rides on params.psihigh_resolved.


### PR DESCRIPTION
## Release note

- **Audience:** users
- **Numerical impact:** none _(harness @ 26f17d0b3d3714f0915109fd8bcd0cc5a09594f0)_
- **Migration:** none

The `efit_by_inversion` edge-accuracy check measured its round-trip error only at the spline knots,
where the splines are exact by construction, so it reported a clean edge on reconstructions that
were badly rung between knots. It now also samples the knot midpoints and warns when they disagree,
which catches an over-extended `psihigh` that previously passed silently.

## Regression report

```
Regression Report: diiid_n1
====================================================================================================================
Ref 1: develop  @ f36ecef86 (2026-09-11)
       env: julia 1.11.7, x86_64-linux-gnu, manifest e0a28574 (pinned), 16 threads/16 BLAS
Ref 2: bugfix/roundtrip-ringing-detection  @ 26f17d0b3 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest e0a28574 (pinned), 16 threads/16 BLAS
--------------------------------------------------------------------------------------------------------------------
Quantity                                      develop          bugfix/roundtrip-ringing-detection  Diff       Status
--------------------------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01                        0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05                        0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00                       0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00                        0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01                        0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]                           0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]                           0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]                           0.0e+00    OK    
ODE steps (saved)                             2576             2576                                0.0e+00    OK    
ODE steps (total)                             4572             4572                                0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00                        0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00                        0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02                        0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00                        0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01                        0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01                        0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01                        0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01                        0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01                        0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01                        0.0e+00    OK    
# singular surfaces                           5                5                                   0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]                            0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]                            0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01                        0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01                        0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00                        0.0e+00    OK    
mpert                                         35               35                                  0.0e+00    OK    
npert                                         1                1                                   0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00                        0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01                        0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00                        0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00                        0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...                     identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...                     identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...                     identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...                     identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...                     identical  OK    
island half-widths                            [5 elem]         [5 elem]                            0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]                            0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04                        0.0e+00    OK    
PE plasma energy                              3.422677e+00     3.422677e+00                        0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00                        0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00                        0.0e+00    OK    
PE toroidal torque                            5.087465e-02     5.087465e-02                        0.0e+00    OK    
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01                        0.0e+00    OK    
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02                        0.0e+00    OK    
Runtime (s)                                   302.9s           300.2s                                         --    
resonant area-weighted field b^r              [5 elem]         [5 elem]                            0.0e+00    OK    
====================================================================================================================
Summary: 47 unchanged
```

## The bug

The `efit_by_inversion` round-trip check measures `(psi,theta) -> (R,Z) -> psi` **only at psi knots**.
The `rzphi` cubic splines interpolate *exactly* at their own knots. So the residual is near zero there
no matter how badly the splines behave in between — inter-knot ringing is invisible to this
measurement by construction, and the check reports a clean edge while the reconstruction is unusable.

## Evidence

DIII-D-like deck, fixed `mpsi=512`, pushing `psihigh` toward 1:

| psihigh | on-knot | midpoint | ratio | resulting `et[1]` |
|---|---|---|---|---|
| 0.995 | 4.10e-06 | 5.02e-06 | 1.2 | +0.80 |
| 0.999 | 3.57e-06 | 4.19e-06 | 1.2 | +0.81 |
| 0.9999 | 1.14e-05 | 1.29e-03 | 113.1 | +4.70 |
| 0.99999 | 2.65e-05 | 2.18e-02 | 823.2 | **−47707** |

The on-knot column is flat across the whole ladder while the stability energies collapse by six
orders of magnitude. The midpoint residual tracks the degradation.

**Provenance, so nobody is misled by a single table:** the three residual columns were re-measured
through the shipped code path. The `et[1]` column is from the earlier instrumented ladder that ran
ForceFreeStates; the re-measurement script does not. The correlation claim — on-knot flat while the
energies collapse — was established on that earlier run, where both were measured together. The two
runs also used different sampling density, so residual magnitudes are not comparable rung-by-rung
with that earlier table; the *ordering and the separation* are what reproduce.

## The fix

Measure the residual at the knots **and** at the knot midpoints, and report both plus their ratio.
The ratio is the usable signal: dimensionless, so it needs no per-grid calibration, and good/bad sit
two orders of magnitude either side of a threshold of 10.

Two details that are load-bearing, both settled by measurement rather than taste:

- **An absolute tolerance alone is not enough.** At `psihigh=0.9999` the midpoint residual is
  1.29e-3, *under* the existing 2e-3. Only the ratio catches that rung.
- **The ratio alone is not enough either.** On a clean grid both residuals sit at the rounding floor
  and their ratio is noise. So the ratio is consulted only once the midpoint residual clears
  `ROUNDTRIP_TOL/20`.

Sampling widened from two fixed knots to every knot and midpoint in the outer `ROUNDTRIP_EDGE_FRAC`
(0.9) of the grid — the region the check is named for and where the failure lives. **This window
matters:** I first tried the minimal version that keeps the two existing knots and adds only their
neighbouring midpoints. It reads ratio **1.0** at `psihigh=0.99999` and misses the worst rung
entirely, because the ringing lives in an interval those two samples don't touch. The band variant
catches every bad rung. (Widening further, to 0.75, pulls in coarser interior knots whose ordinary
interpolation error inflates the healthy baseline from 1.2 to 7.3 against a threshold of 10 — too
little margin, hence 0.9.)

The new testset reaches log levels through `Base.CoreLogging` rather than importing `Logging`, which
is only a transitive dependency: `Pkg.test` sandboxes to the declared deps, so a direct import
resolves locally via `@stdlib` but not on CI.

## A pre-existing defect this surfaces

On `test_data/CHEASE_test_data/EQDSK_COCOS_02` at `psihigh=0.994`, knot i=128 (psi=0.99385) traces to
**(R=3.32, Z=3.91)** on a machine with `ro=7.04` — a badly mis-located surface. The residual there is
0.517.

This deck **already warns on `develop`**: develop's outermost sample reads 0.048, well over 2e-3. So
this is not introduced here — the warning just gets louder (0.517) and now names where the problem is.
**I have deliberately not tried to fix the tracing defect in this PR.** Flagging it for whoever owns
that path.

Separately, `psihigh=0.95` and `0.97` on that same deck die in an unrelated pre-existing `DomainError`
(`sqrt` of a negative) in `equilibrium_global_parameters!` at `Equilibrium.jl:371`. Also not touched
here.

## Verification

- Full `Pkg.test()` suite in the CI sandbox — **passes**. The targeted `runtests_equil.jl` run is
  286/286, including a new false-positive control asserting a cleanly traced deck still reports at
  Info with both residuals and the ratio in the message.
- Ladder above re-measured through the shipped code path, not a replica.
- Regression harness table above: **47 quantities, all unchanged** against `develop @ f36ecef86`.

  Being straight about what that does and doesn't show: `diiid_n1` uses `eq_type = "efit"`, so it does
  not execute the changed code at all. It confirms no leakage into other paths — the change is log
  output only — but it is **not** coverage of this fix. **No regression case currently uses
  `eq_type = "efit_by_inversion"`**, which looks like a real gap worth closing separately; I'd rather
  propose that than bolt a new pinned case onto a small bugfix.

## Scope

`Equilibrium` only; no SLAYER/Tearing code touched. Split out of the `FKR-width` work as an
independent fix. Stacks cleanly alongside #442 (different files).

---

# ⚠️ NO MERGE WITHOUT THIRD-PARTY HUMAN REVIEW — NON-NEGOTIABLE ⚠️

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSrf6JCViFfVzqzkQ66o6b
