### PR TITLE
PerturbedEquilibrium - FEATURE - Add resonant-coupling SVD and overlap analysis API

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -98,6 +98,7 @@ Splines are provided by the external `FastInterpolations` package rather than by
        - Island half-widths and Chirikov parameters
        - Green's functions at interior flux surfaces
        - Surface inductance for singular surfaces
+     - `ResonantCoupling.jl` - `ResonantCoupling` (in-memory or from gpec.h5): windowed SVD for the dominant applied-field mode, and the normalization/overlap helpers that project coil spectra onto it
      - `Utils.jl` - Helper functions
    - Status: Core plasma response and singular coupling calculations implemented; active area of development
 

--- a/docs/src/perturbed_equilibrium.md
+++ b/docs/src/perturbed_equilibrium.md
@@ -17,6 +17,49 @@ GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.compute_perturbed_equilibri
 GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.write_outputs_to_HDF5
 ```
 
+## Dominant resonant-coupling mode
+
+The singular-coupling matrix `C_resonant_area_weighted_field` maps an applied
+root-area-weighted field spectrum `b̃` on the control surface to the resonant field at each
+rational surface. Its singular-value decomposition over a chosen set of rational surfaces
+ranks the applied spectra by how strongly they drive resonant field there: the first right
+singular vector is the **dominant mode**, the spectrum the plasma is most sensitive to, and the
+singular values are coordinate-invariant.
+
+The run always writes the full coupling matrix, so the surface window is an analysis choice
+made afterwards — never a reason to re-run. A `ResonantCoupling` bundles the matrix with the
+labels and normalization needed to evaluate arbitrary applied spectra against it, and is built
+the same way from a finished run in memory or from its `gpec.h5`:
+
+```julia
+using GeneralizedPerturbedEquilibrium.PerturbedEquilibrium
+
+rc = ResonantCoupling("gpec.h5")                 # post hoc; or ResonantCoupling(pe_state, ffs) in memory
+dom = dominant_coupling(rc; psi_low=0.3, psi_high=0.95)   # SVD over the surfaces in the window
+
+b̃ = rootarea_field(rc, coil_modes)               # unit-norm forcing modes → root-area-weighted field
+c = coupling_overlap(dom, b̃)                     # Vᴴ·b̃: c[1] is the overlap with the dominant mode
+dom.singular_values[1] * abs(c[1])               # resonant field the dominant mode drives
+```
+
+`rootarea_field` takes care of the mode ordering and the `R⁻¹` conform between the unit-norm
+convention the forcing loaders and coil integration produce and the b̃ basis the matrix acts on;
+`coupling_overlap` takes care of the conjugation. Singular vectors carry an arbitrary global
+phase, so compare `abs` of overlaps across runs, not the complex value.
+
+As a summary the run also stores the full-window decomposition under
+`PerturbedEquilibrium/SingularCoupling/DominantMode/`, with `forcing_overlap` holding the run's
+own forcing coefficients `Vᴴ·b̃_x`.
+
+```@docs
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.ResonantCoupling
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.DominantCoupling
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.dominant_coupling
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.rootarea_field
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.coupling_overlap
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.compute_dominant_coupling!
+```
+
 ## Plotting per-surface results against ψ or q
 
 `SingularCoupling/` quantities are indexed by rational-surface **index**, not by q: with

--- a/regression-harness/cases/diiid_n1.toml
+++ b/regression-harness/cases/diiid_n1.toml
@@ -303,6 +303,25 @@ extract = "all_complex"
 label = "resonant area-weighted field b^r"
 noise_threshold = 1e-8
 
+# Dominant resonant-coupling mode: singular values of the b̃-space coupling matrix over every
+# rational surface (coordinate-invariant), and the applied forcing's magnitude on the dominant
+# mode. Singular vectors carry an arbitrary phase, so only the magnitude is tracked.
+[quantities.dominant_singular_values]
+h5path = "PerturbedEquilibrium/SingularCoupling/DominantMode/singular_values"
+type = "real_vector"
+extract = "all_real"
+label = "dominant-coupling singular values"
+noise_threshold = 1e-8
+order = 84
+
+[quantities.dominant_forcing_overlap]
+h5path = "PerturbedEquilibrium/SingularCoupling/DominantMode/forcing_overlap"
+type = "complex_vector"
+extract = "abs_first"
+label = "|forcing overlap with dominant mode|"
+noise_threshold = 1e-8
+order = 85
+
 # Perturbed equilibrium: energies
 [quantities.pe_plasma_energy]
 h5path = "PerturbedEquilibrium/Energies/plasma_energy"

--- a/src/PerturbedEquilibrium/PerturbedEquilibrium.jl
+++ b/src/PerturbedEquilibrium/PerturbedEquilibrium.jl
@@ -25,6 +25,7 @@ include("ResponseMatrices.jl")
 include("FieldReconstruction.jl")
 include("Response.jl")
 include("SingularCoupling.jl")
+include("ResonantCoupling.jl")
 include("Utils.jl")
 
 # Export main types
@@ -36,6 +37,7 @@ export ForcingMode
 # Export main functions
 export compute_perturbed_equilibrium
 export write_outputs_to_HDF5
+export ResonantCoupling, DominantCoupling, dominant_coupling, rootarea_field, coupling_overlap
 
 """
     compute_perturbed_equilibrium(ffs, forcing, ctrl, intr)::PerturbedEquilibriumState
@@ -100,6 +102,7 @@ function compute_perturbed_equilibrium(
        ForceFreeStates.require(ffs, :free_boundary, "singular coupling calculation") &&
        ForceFreeStates.require_solution(ffs, "singular coupling calculation")
         compute_singular_coupling_metrics!(state, equil, solution, mthvac, ffs, intr, ctrl, mats)
+        compute_dominant_coupling!(state, ctrl)
     end
 
     # Step 4: Output eigenmode fields (integrated into HDF5 output)

--- a/src/PerturbedEquilibrium/PerturbedEquilibriumStructs.jl
+++ b/src/PerturbedEquilibrium/PerturbedEquilibriumStructs.jl
@@ -26,7 +26,9 @@ Medium Priority (defer for MWE):
   - `singular_point_method::String` - Method for singular point treatment (default: "standard")
 
 Regularization:
-    # High Priority (MWE)
+
+# High Priority (MWE)
+
   - `reg_spot::Float64` - Regularization width for singular surface smoothing (default: 0.05). Set to 0 to disable. Must be ≥ 0.
 """
 @kwdef struct PerturbedEquilibriumControl
@@ -119,8 +121,19 @@ Metadata [n_rational] — identifies each (surface, n) row:
 
   - `rational_psi`, `rational_q`, `rational_m_res`, `rational_n`, `rational_surface_idx`
 
+Dominant resonant-coupling modes — the run summary SVD `U·diag(σ)·Vᴴ` of
+`C_resonant_area_weighted_field` over every resonant row (window post hoc with `dominant_coupling`
+on a `ResonantCoupling`):
+
+  - `dominant_singular_values` - σ, descending [rank]
+  - `dominant_right_singular_vectors` - V, applied-b̃ spectra ranked by resonant drive [numpert_total × rank]
+  - `dominant_left_singular_vectors` - U, resonant-field patterns over the retained surfaces [n_retained × rank]
+  - `dominant_rational_index` - rows of the `rational_*` arrays retained in the window [n_retained]
+  - `dominant_forcing_overlap` - Vᴴ·b̃_x, the applied forcing's coefficient on each mode [rank]
+
 Control-surface forcing/response spectra [numpert_total], in the three Pharr (2026) field
 representations (all tesla; no flux/weber is stored):
+
   - `forcing_b`/`response_b` - bare normal field b (Σ⁻¹·b̃)
   - `forcing_b_rootarea`/`response_b_rootarea` - root-area-weighted field b̃ (coordinate-invariant)
   - `forcing_b_area`/`response_b_area` - area-weighted field b̄ (= S·b̃; flux is Φ = A·b̄)
@@ -186,19 +199,26 @@ well-conditioned flux-space inductances L, Λ:
     rational_n::Vector{Int} = Int[]
     rational_surface_idx::Vector{Int} = Int[]
 
+    # Dominant resonant-coupling modes: SVD of C_resonant_area_weighted_field over the retained rows
+    dominant_singular_values::Vector{Float64} = Float64[]
+    dominant_right_singular_vectors::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # V [numpert_total × rank]
+    dominant_left_singular_vectors::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)   # U [n_retained × rank]
+    dominant_rational_index::Vector{Int} = Int[]                                  # retained rows of rational_*
+    dominant_forcing_overlap::Vector{ComplexF64} = ComplexF64[]                    # Vᴴ·b̃_x [rank]
+
     # Control-surface forcing/response spectra in the three weightings of field representations [numpert_total], tesla
-    forcing_b::Vector{ComplexF64}           = ComplexF64[]  # bare normal field b (forcing Φ_x)
-    forcing_b_rootarea::Vector{ComplexF64}  = ComplexF64[]  # root-area-weighted field b̃ (coordinate-invariant)
-    forcing_b_area::Vector{ComplexF64}      = ComplexF64[]  # area-weighted field b̄
-    response_b::Vector{ComplexF64}          = ComplexF64[]  # bare normal field b (response Φ_tot = P·Φ_x)
+    forcing_b::Vector{ComplexF64} = ComplexF64[]  # bare normal field b (forcing Φ_x)
+    forcing_b_rootarea::Vector{ComplexF64} = ComplexF64[]  # root-area-weighted field b̃ (coordinate-invariant)
+    forcing_b_area::Vector{ComplexF64} = ComplexF64[]  # area-weighted field b̄
+    response_b::Vector{ComplexF64} = ComplexF64[]  # bare normal field b (response Φ_tot = P·Φ_x)
     response_b_rootarea::Vector{ComplexF64} = ComplexF64[]  # root-area-weighted field b̃
-    response_b_area::Vector{ComplexF64}     = ComplexF64[]  # area-weighted field b̄
+    response_b_area::Vector{ComplexF64} = ComplexF64[]  # area-weighted field b̄
 
     # Control surface matrices [numpert_total × numpert_total], root-area-weighted field (b̃) space
-    plasma_inductance::Matrix{ComplexF64}  = zeros(ComplexF64, 0, 0)  # Λ̃ (field space)
+    plasma_inductance::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # Λ̃ (field space)
     surface_inductance::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # L̃ (field space)
-    permeability::Matrix{ComplexF64}       = zeros(ComplexF64, 0, 0)  # P̃ = R⁻¹·Λ·L⁻¹·R
-    reluctance::Matrix{ComplexF64}         = zeros(ComplexF64, 0, 0)  # ϱ̃ = R†·L⁻¹·(Λ−L)·L⁻¹·R
+    permeability::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # P̃ = R⁻¹·Λ·L⁻¹·R
+    reluctance::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # ϱ̃ = R†·L⁻¹·(Λ−L)·L⁻¹·R
     rootarea_to_area_weight::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # S = Σ/√A at psilim: b̃→b̄ recovery operator
     surface_area::Float64 = 0.0  # scalar control-surface area A = ∫J|∇ψ|dθ (flux: Φ = A·b̄; conform R = S·A)
 

--- a/src/PerturbedEquilibrium/ResonantCoupling.jl
+++ b/src/PerturbedEquilibrium/ResonantCoupling.jl
@@ -1,0 +1,176 @@
+"""
+    ResonantCoupling
+
+Everything needed to project an applied control-surface field onto the resonant responses of a
+perturbed-equilibrium solve, detached from the run that produced it. Build it in memory from a
+`PerturbedEquilibriumState` and its `ForceFreeStatesResult`, or post hoc from a `gpec.h5`; then
+window and decompose it with [`dominant_coupling`](@ref) and evaluate coil spectra with
+[`rootarea_field`](@ref) and [`coupling_overlap`](@ref) as often as needed without re-running.
+
+## Fields
+
+  - `C::Matrix{ComplexF64}` - coupling from the applied root-area-weighted field b̃ to the resonant
+    area-weighted field, one row per resonant (surface, n) pair `[n_rational × numpert_total]`
+  - `rational_psi`, `rational_q`, `rational_m`, `rational_n` - row labels `[n_rational]`
+  - `m_modes`, `n_modes` - column labels: the poloidal and toroidal mode number of each entry of an
+    applied spectrum `[numpert_total]`
+  - `flux_conform::Matrix{ComplexF64}` - `R = S·A`, mapping b̃ to the unit-norm flux the forcing
+    loaders and coil integration produce, `Φ_x = R·b̃` `[numpert_total × numpert_total]`
+"""
+struct ResonantCoupling
+    C::Matrix{ComplexF64}
+    rational_psi::Vector{Float64}
+    rational_q::Vector{Float64}
+    rational_m::Vector{Int}
+    rational_n::Vector{Int}
+    m_modes::Vector{Int}
+    n_modes::Vector{Int}
+    flux_conform::Matrix{ComplexF64}
+end
+
+"""
+    ResonantCoupling(state::PerturbedEquilibriumState, ffs::ForceFreeStatesResult)
+
+In-memory construction from a solve: the coupling matrix and row labels come from `state`, the
+column ordering from `ffs`, and the conform operator from `state` when the response step ran or
+from the equilibrium otherwise. Errors when `state` carries no singular-coupling matrix.
+"""
+function ResonantCoupling(state::PerturbedEquilibriumState, ffs::ForceFreeStatesResult)
+    isempty(state.C_resonant_area_weighted_field) &&
+        throw(ArgumentError("the perturbed-equilibrium state carries no singular-coupling matrix (compute_singular_coupling off, or no resonant surfaces)"))
+    flux_conform = if isempty(state.rootarea_to_area_weight)
+        S, A = build_control_surface_rootarea_to_area_weight(ffs.equil, ffs)
+        S .* A
+    else
+        state.rootarea_to_area_weight .* state.surface_area
+    end
+    N = ffs.numpert_total
+    m_modes = [(i - 1) % ffs.mpert + ffs.mlow for i in 1:N]
+    n_modes = [(i - 1) ÷ ffs.mpert + ffs.nlow for i in 1:N]
+    return ResonantCoupling(state.C_resonant_area_weighted_field, state.rational_psi, state.rational_q,
+        state.rational_m_res, state.rational_n, m_modes, n_modes, flux_conform)
+end
+
+"""
+    ResonantCoupling(h5path::AbstractString)
+
+Post-hoc construction from a `gpec.h5` written with both the response and singular-coupling
+steps enabled: reads `PerturbedEquilibrium/SingularCoupling/`, the stored conform operator under
+`PerturbedEquilibrium/ResponseMatrices/`, and the column labels from `Info/mn_index`.
+"""
+function ResonantCoupling(h5path::AbstractString)
+    h5open(h5path, "r") do f
+        haskey(f, "PerturbedEquilibrium/SingularCoupling/C_resonant_area_weighted_field") ||
+            throw(ArgumentError("$h5path has no singular-coupling matrix"))
+        haskey(f, "PerturbedEquilibrium/ResponseMatrices/rootarea_to_area_weight_operator") ||
+            throw(ArgumentError("$h5path has no control-surface conform operator (run with compute_response = true)"))
+        haskey(f, "Info/mn_index") || throw(ArgumentError("$h5path has no Info/mn_index mode labels"))
+        sc = f["PerturbedEquilibrium/SingularCoupling"]
+        mn = read(f["Info/mn_index"])
+        S = read(f["PerturbedEquilibrium/ResponseMatrices/rootarea_to_area_weight_operator"])
+        A = read(f["PerturbedEquilibrium/ResponseMatrices/surface_area"])
+        return ResonantCoupling(read(sc["C_resonant_area_weighted_field"]), read(sc["rational_psi"]), read(sc["rational_q"]),
+            read(sc["rational_m"]), read(sc["rational_n"]), mn[:, 1], mn[:, 2], S .* A)
+    end
+end
+
+"""
+    rootarea_field(rc::ResonantCoupling, modes) -> Vector{ComplexF64}
+
+Root-area-weighted control-surface field b̃ of an applied spectrum given in the unit-norm
+(Φ_x) convention — what the forcing-file loaders and the coil integration produce. `modes` is a
+`Vector{ForcingMode}`, placed on `rc`'s (m, n) column ordering (modes outside the basis are
+ignored), or an already-ordered amplitude vector. The result is conformed with R⁻¹
+(`Φ_x = R·b̃`) and is the vector the coupling matrix and its singular vectors act on.
+"""
+function rootarea_field(rc::ResonantCoupling, modes::AbstractVector{ForcingMode})
+    flux = zeros(ComplexF64, length(rc.m_modes))
+    for mode in modes
+        j = findfirst(k -> rc.m_modes[k] == mode.m && rc.n_modes[k] == mode.n, eachindex(rc.m_modes))
+        j === nothing || (flux[j] += mode.amplitude)
+    end
+    return rootarea_field(rc, flux)
+end
+
+function rootarea_field(rc::ResonantCoupling, flux::AbstractVector{<:Number})
+    length(flux) == length(rc.m_modes) || throw(DimensionMismatch("applied spectrum has $(length(flux)) entries; the basis has $(length(rc.m_modes))"))
+    return rc.flux_conform \ Vector{ComplexF64}(flux)
+end
+
+"""
+    DominantCoupling
+
+Singular-value decomposition `U·diag(σ)·Vᴴ` of a resonant coupling matrix over a set of retained
+rational surfaces, produced by [`dominant_coupling`](@ref).
+
+## Fields
+
+  - `singular_values` - σ, descending `[rank]`
+  - `right_singular_vectors` - V: applied-b̃ spectra ranked by resonant drive `[numpert_total × rank]`
+  - `left_singular_vectors` - U: resonant-field patterns over the retained surfaces `[n_retained × rank]`
+  - `rational_index` - rows of the coupling matrix (and its `rational_*` labels) that were retained `[n_retained]`
+"""
+struct DominantCoupling
+    singular_values::Vector{Float64}
+    right_singular_vectors::Matrix{ComplexF64}
+    left_singular_vectors::Matrix{ComplexF64}
+    rational_index::Vector{Int}
+end
+
+"""
+    dominant_coupling(rc::ResonantCoupling; psi_low=0.0, psi_high=1.0) -> DominantCoupling
+    dominant_coupling(C, rational_psi; psi_low=0.0, psi_high=1.0) -> DominantCoupling
+
+Singular-value decomposition of the resonant coupling matrix restricted to the rational
+surfaces with `psi_low ≤ ψ_N ≤ psi_high`. With `C_w = U·diag(σ)·Vᴴ` on the retained rows, the
+right singular vectors `V[:, k]` are the applied-field spectra ordered by how strongly they drive
+resonant field inside the window, and the singular values are coordinate-invariant. The overlap
+of an applied spectrum `b̃` with mode `k` is `dot(V[:, k], b̃)` — see [`coupling_overlap`](@ref) —
+and the resonant field it drives is `σ[k]` times that coefficient; `k = 1` is the dominant mode
+[Park 2007b]. The window is an analysis choice, so re-evaluate it freely on the same `rc`.
+
+Throws `ArgumentError` when the window contains no rational surface.
+"""
+function dominant_coupling(C::AbstractMatrix{ComplexF64}, rational_psi::AbstractVector{<:Real}; psi_low::Real=0.0, psi_high::Real=1.0)
+    size(C, 1) == length(rational_psi) ||
+        throw(DimensionMismatch("C has $(size(C, 1)) rows but rational_psi has $(length(rational_psi)) entries"))
+    rational_index = findall(ψ -> psi_low <= ψ <= psi_high, rational_psi)
+    isempty(rational_index) && throw(ArgumentError("no rational surfaces with ψ_N in [$psi_low, $psi_high]"))
+    F = svd(C[rational_index, :])
+    return DominantCoupling(F.S, Matrix(F.V), Matrix(F.U), rational_index)
+end
+
+dominant_coupling(rc::ResonantCoupling; kwargs...) = dominant_coupling(rc.C, rc.rational_psi; kwargs...)
+
+"""
+    coupling_overlap(dom::DominantCoupling, b̃) -> Vector{ComplexF64}
+    coupling_overlap(dom, rc::ResonantCoupling, modes) -> Vector{ComplexF64}
+
+Coefficients `Vᴴ·b̃` of an applied root-area-weighted field on the singular modes of `dom`; the
+first entry is the overlap with the dominant mode. `dom.singular_values .* coupling_overlap(dom, b̃)`
+is the resonant field each mode drives, with `dom.left_singular_vectors` giving its pattern over the
+retained surfaces. The second form conforms `modes` through [`rootarea_field`](@ref) first.
+"""
+coupling_overlap(dom::DominantCoupling, b̃::AbstractVector{<:Number}) = dom.right_singular_vectors' * b̃
+coupling_overlap(dom::DominantCoupling, rc::ResonantCoupling, modes) = coupling_overlap(dom, rootarea_field(rc, modes))
+
+"""
+    compute_dominant_coupling!(state, ctrl)
+
+Store the full-window dominant resonant-coupling decomposition of
+`state.C_resonant_area_weighted_field` on `state` as a run summary, with the applied forcing's
+coefficients on each mode when the response spectrum is available. Windowed analyses are done
+post hoc on a [`ResonantCoupling`](@ref). Returns without change when no coupling matrix exists.
+"""
+function compute_dominant_coupling!(state::PerturbedEquilibriumState, ctrl::PerturbedEquilibriumControl)
+    isempty(state.C_resonant_area_weighted_field) && return nothing
+    dom = dominant_coupling(state.C_resonant_area_weighted_field, state.rational_psi)
+    state.dominant_singular_values = dom.singular_values
+    state.dominant_right_singular_vectors = dom.right_singular_vectors
+    state.dominant_left_singular_vectors = dom.left_singular_vectors
+    state.dominant_rational_index = dom.rational_index
+    isempty(state.forcing_b_rootarea) || (state.dominant_forcing_overlap = coupling_overlap(dom, state.forcing_b_rootarea))
+    ctrl.verbose &&
+        @info "Dominant resonant coupling: $(length(dom.singular_values)) modes over $(length(dom.rational_index)) rational surfaces, σ₁ = $(@sprintf("%.3e", dom.singular_values[1]))"
+    return nothing
+end

--- a/src/PerturbedEquilibrium/Utils.jl
+++ b/src/PerturbedEquilibrium/Utils.jl
@@ -12,8 +12,9 @@ avoiding repeated index arithmetic throughout the code.
 ## Mode Indexing Convention
 
 For linear index i ∈ [1, numpert_total]:
-- m_modes[i] = (i-1) % mpert + mlow
-- n_modes[i] = (i-1) ÷ mpert + nlow
+
+  - m_modes[i] = (i-1) % mpert + mlow
+  - n_modes[i] = (i-1) ÷ mpert + nlow
 
 This matches the convention used in ForceFreeStates where modes are ordered as:
 (m1,n1), (m2,n1), ..., (mpert,n1), (m1,n2), (m2,n2), ..., (mpert,npert)
@@ -92,7 +93,13 @@ PerturbedEquilibrium/
 │   ├── rational_psi         # [n_rational] surface metadata
 │   ├── rational_q
 │   ├── rational_m
-│   └── rational_n
+│   ├── rational_n
+│   └── DominantMode/        # SVD U·diag(σ)·Vᴴ of C_resonant_area_weighted_field over the retained rational surfaces
+│       ├── singular_values          # σ, descending [rank]
+│       ├── right_singular_vectors   # V: applied-b̃ spectra ranked by resonant drive [numpert_total × rank]
+│       ├── left_singular_vectors    # U: resonant-field patterns over the retained surfaces [n_retained × rank]
+│       ├── rational_index           # rows of rational_* retained in the ψ_N window [n_retained]
+│       └── forcing_overlap          # Vᴴ·b̃_x, applied forcing's coefficient on each mode [rank]
 └── Energies/
     ├── vacuum_energy
     ├── surface_energy
@@ -110,47 +117,47 @@ function write_outputs_to_HDF5(
 
         # Forcing modes
         forcing_group = haskey(pe_group, "ForcingModes") ? pe_group["ForcingModes"] : create_group(pe_group, "ForcingModes")
-        forcing_group["n"]         = [mode.n for mode in intr.forcing_modes]
-        forcing_group["m"]         = [mode.m for mode in intr.forcing_modes]
+        forcing_group["n"] = [mode.n for mode in intr.forcing_modes]
+        forcing_group["m"] = [mode.m for mode in intr.forcing_modes]
         forcing_group["amplitude"] = [mode.amplitude for mode in intr.forcing_modes]
 
         # Control-surface forcing/response spectra in the three Pharr field representations
         # (all tesla; flux/weber is never stored). b̃ = root-area-weighted (coordinate-invariant).
-        !isempty(state.forcing_b)           && (pe_group["forcing_b"]            = state.forcing_b)
-        !isempty(state.forcing_b_rootarea)  && (pe_group["forcing_b_root_area"]  = state.forcing_b_rootarea)
-        !isempty(state.forcing_b_area)      && (pe_group["forcing_b_area"]       = state.forcing_b_area)
-        !isempty(state.response_b)          && (pe_group["response_b"]           = state.response_b)
+        !isempty(state.forcing_b) && (pe_group["forcing_b"] = state.forcing_b)
+        !isempty(state.forcing_b_rootarea) && (pe_group["forcing_b_root_area"] = state.forcing_b_rootarea)
+        !isempty(state.forcing_b_area) && (pe_group["forcing_b_area"] = state.forcing_b_area)
+        !isempty(state.response_b) && (pe_group["response_b"] = state.response_b)
         !isempty(state.response_b_rootarea) && (pe_group["response_b_root_area"] = state.response_b_rootarea)
-        !isempty(state.response_b_area)     && (pe_group["response_b_area"]      = state.response_b_area)
+        !isempty(state.response_b_area) && (pe_group["response_b_area"] = state.response_b_area)
 
         # Control surface matrices [numpert_total × numpert_total], in coordinate-invariant
         # root-area-weighted field (b̃) space. Recover the area-weighted field b̄ with the stored
         # operator S ≡ rootarea_to_area_weight (b̄ = S·b̃): e.g. L_b̄ = S·L̃·S†; recover flux with the
         # scalar surface_area A: Φ = A·b̄  (internally R = S·A, Φ = R·b̃). [Pharr 2026]
         mat_group = haskey(pe_group, "ResponseMatrices") ? pe_group["ResponseMatrices"] : create_group(pe_group, "ResponseMatrices")
-        !isempty(state.plasma_inductance)  && (mat_group["plasma_inductance"]  = state.plasma_inductance)
+        !isempty(state.plasma_inductance) && (mat_group["plasma_inductance"] = state.plasma_inductance)
         !isempty(state.surface_inductance) && (mat_group["surface_inductance"] = state.surface_inductance)
-        !isempty(state.permeability)       && (mat_group["permeability"]       = state.permeability)
-        !isempty(state.reluctance)         && (mat_group["reluctance"]         = state.reluctance)
+        !isempty(state.permeability) && (mat_group["permeability"] = state.permeability)
+        !isempty(state.reluctance) && (mat_group["reluctance"] = state.reluctance)
         !isempty(state.rootarea_to_area_weight) && (mat_group["rootarea_to_area_weight_operator"] = state.rootarea_to_area_weight)
-        (state.surface_area != 0.0)        && (mat_group["surface_area"]       = state.surface_area)
+        (state.surface_area != 0.0) && (mat_group["surface_area"] = state.surface_area)
 
         # Response fields (ComplexF64 directly)
         response_group = haskey(pe_group, "Response") ? pe_group["Response"] : create_group(pe_group, "Response")
         !isempty(state.psi_grid) && (response_group["psi"] = state.psi_grid)
         have_xi = !isnothing(state.xi_modes)
-        have_b  = have_xi && !isnothing(state.b_modes)
-        response_group["xi_psi"]    = have_xi ? state.xi_modes.psi      : ComplexF64[]
-        response_group["b_psi_area_weighted"]  = have_b  ? state.b_modes.b_psi_area_weighted : ComplexF64[]
-        response_group["Jb_theta"]   = have_b  ? state.b_modes.theta    : ComplexF64[]
-        response_group["Jb_zeta"]    = have_b  ? state.b_modes.zeta     : ComplexF64[]
-        response_group["b_n"]       = !isnothing(state.b_n_modes)  ? state.b_n_modes  : ComplexF64[]
-        response_group["xi_n"]      = !isnothing(state.xi_n_modes) ? state.xi_n_modes : ComplexF64[]
+        have_b = have_xi && !isnothing(state.b_modes)
+        response_group["xi_psi"] = have_xi ? state.xi_modes.psi : ComplexF64[]
+        response_group["b_psi_area_weighted"] = have_b ? state.b_modes.b_psi_area_weighted : ComplexF64[]
+        response_group["Jb_theta"] = have_b ? state.b_modes.theta : ComplexF64[]
+        response_group["Jb_zeta"] = have_b ? state.b_modes.zeta : ComplexF64[]
+        response_group["b_n"] = !isnothing(state.b_n_modes) ? state.b_n_modes : ComplexF64[]
+        response_group["xi_n"] = !isnothing(state.xi_n_modes) ? state.xi_n_modes : ComplexF64[]
 
         # Clebsch displacements for PENTRC (matches Fortran gpout_xclebsch)
         if have_xi
-            response_group["xi_clebsch_psi"]   = state.xi_modes.clebsch_psi
-            response_group["dxi_clebsch_psidpsi"]  = state.xi_modes.clebsch_psi1
+            response_group["xi_clebsch_psi"] = state.xi_modes.clebsch_psi
+            response_group["dxi_clebsch_psidpsi"] = state.xi_modes.clebsch_psi1
             response_group["xi_clebsch_alpha"] = state.xi_modes.clebsch_alpha
         end
 
@@ -158,36 +165,36 @@ function write_outputs_to_HDF5(
         if have_xi
             response_group["Jxi_psi"] = state.xi_modes.psi_J
             response_group["Jxi_theta"] = state.xi_modes.theta
-            response_group["Jxi_zeta"]  = state.xi_modes.zeta
+            response_group["Jxi_zeta"] = state.xi_modes.zeta
         end
 
         # Covariant components (from gpeq_cova)
         if have_xi
-            response_group["xi_cov_psi"]   = state.xi_modes.cova_psi
+            response_group["xi_cov_psi"] = state.xi_modes.cova_psi
             response_group["xi_cov_theta"] = state.xi_modes.cova_theta
-            response_group["xi_cov_zeta"]  = state.xi_modes.cova_zeta
+            response_group["xi_cov_zeta"] = state.xi_modes.cova_zeta
         end
         if have_xi
             response_group["Jxi_theta_reg"] = state.xi_modes.theta_reg
-            response_group["Jxi_zeta_reg"]  = state.xi_modes.zeta_reg
+            response_group["Jxi_zeta_reg"] = state.xi_modes.zeta_reg
         end
         if have_b
             response_group["Jb_theta_reg"] = state.b_modes.theta_reg
-            response_group["Jb_zeta_reg"]  = state.b_modes.zeta_reg
-            response_group["b_cov_psi"]   = state.b_modes.cova_psi
+            response_group["Jb_zeta_reg"] = state.b_modes.zeta_reg
+            response_group["b_cov_psi"] = state.b_modes.cova_psi
             response_group["b_cov_theta"] = state.b_modes.cova_theta
-            response_group["b_cov_zeta"]  = state.b_modes.cova_zeta
+            response_group["b_cov_zeta"] = state.b_modes.cova_zeta
         end
 
         # R,Z,φ cylindrical components in mode-space (from gpeq_rzphi)
         if have_xi
-            response_group["xi_R"]   = state.xi_modes.R
-            response_group["xi_Z"]   = state.xi_modes.Z
+            response_group["xi_R"] = state.xi_modes.R
+            response_group["xi_Z"] = state.xi_modes.Z
             response_group["xi_phi"] = state.xi_modes.phi
         end
         if have_b
-            response_group["b_R"]   = state.b_modes.R
-            response_group["b_Z"]   = state.b_modes.Z
+            response_group["b_R"] = state.b_modes.R
+            response_group["b_Z"] = state.b_modes.Z
             response_group["b_phi"] = state.b_modes.phi
         end
 
@@ -195,34 +202,44 @@ function write_outputs_to_HDF5(
         coupling_group = haskey(pe_group, "SingularCoupling") ? pe_group["SingularCoupling"] : create_group(pe_group, "SingularCoupling")
 
         # Coupling matrices [n_rational × numpert_total]
-        !isempty(state.C_resonant_area_weighted_field)   && (coupling_group["C_resonant_area_weighted_field"]   = state.C_resonant_area_weighted_field)
+        !isempty(state.C_resonant_area_weighted_field) && (coupling_group["C_resonant_area_weighted_field"] = state.C_resonant_area_weighted_field)
         !isempty(state.C_resonant_current) && (coupling_group["C_resonant_current"] = state.C_resonant_current)
-        !isempty(state.C_island_width_sq)  && (coupling_group["C_island_width_sq"]  = state.C_island_width_sq)
+        !isempty(state.C_island_width_sq) && (coupling_group["C_island_width_sq"] = state.C_island_width_sq)
         !isempty(state.C_penetrated_area_weighted_field) && (coupling_group["C_penetrated_area_weighted_field"] = state.C_penetrated_area_weighted_field)
-        !isempty(state.C_delta_prime)      && (coupling_group["C_Delta_prime"]      = state.C_delta_prime)
+        !isempty(state.C_delta_prime) && (coupling_group["C_Delta_prime"] = state.C_delta_prime)
 
         # Applied resonant vectors [n_rational]
-        !isempty(state.resonant_area_weighted_field)     && (coupling_group["resonant_area_weighted_field"]     = state.resonant_area_weighted_field)
-        !isempty(state.resonant_current)   && (coupling_group["resonant_current"]   = state.resonant_current)
-        !isempty(state.island_width_sq)    && (coupling_group["island_width_sq"]    = state.island_width_sq)
-        !isempty(state.penetrated_area_weighted_field)   && (coupling_group["penetrated_area_weighted_field"] = state.penetrated_area_weighted_field)
-        !isempty(state.delta_prime)        && (coupling_group["Delta_prime"]        = state.delta_prime)
-        !isempty(state.forcing_solution_weights)         && (coupling_group["forcing_solution_weights"] = state.forcing_solution_weights)
+        !isempty(state.resonant_area_weighted_field) && (coupling_group["resonant_area_weighted_field"] = state.resonant_area_weighted_field)
+        !isempty(state.resonant_current) && (coupling_group["resonant_current"] = state.resonant_current)
+        !isempty(state.island_width_sq) && (coupling_group["island_width_sq"] = state.island_width_sq)
+        !isempty(state.penetrated_area_weighted_field) && (coupling_group["penetrated_area_weighted_field"] = state.penetrated_area_weighted_field)
+        !isempty(state.delta_prime) && (coupling_group["Delta_prime"] = state.delta_prime)
+        !isempty(state.forcing_solution_weights) && (coupling_group["forcing_solution_weights"] = state.forcing_solution_weights)
         !isempty(state.rational_area) && (coupling_group["rational_area"] = state.rational_area)
-        !isempty(state.island_half_width)  && (coupling_group["island_half_width"]  = state.island_half_width)
+        !isempty(state.island_half_width) && (coupling_group["island_half_width"] = state.island_half_width)
         !isempty(state.chirikov_parameter) && (coupling_group["chirikov_parameter"] = state.chirikov_parameter)
 
         # Metadata [n_rational]
-        !isempty(state.rational_psi)       && (coupling_group["rational_psi"]       = state.rational_psi)
-        !isempty(state.rational_q)         && (coupling_group["rational_q"]         = state.rational_q)
-        !isempty(state.rational_m_res)     && (coupling_group["rational_m"]     = state.rational_m_res)
-        !isempty(state.rational_n)         && (coupling_group["rational_n"]         = state.rational_n)
+        !isempty(state.rational_psi) && (coupling_group["rational_psi"] = state.rational_psi)
+        !isempty(state.rational_q) && (coupling_group["rational_q"] = state.rational_q)
+        !isempty(state.rational_m_res) && (coupling_group["rational_m"] = state.rational_m_res)
+        !isempty(state.rational_n) && (coupling_group["rational_n"] = state.rational_n)
+
+        # Dominant resonant-coupling modes (SVD of the b̃-space coupling matrix over the retained rows)
+        if !isempty(state.dominant_singular_values)
+            dominant_group = haskey(coupling_group, "DominantMode") ? coupling_group["DominantMode"] : create_group(coupling_group, "DominantMode")
+            dominant_group["singular_values"] = state.dominant_singular_values
+            dominant_group["right_singular_vectors"] = state.dominant_right_singular_vectors
+            dominant_group["left_singular_vectors"] = state.dominant_left_singular_vectors
+            dominant_group["rational_index"] = state.dominant_rational_index
+            !isempty(state.dominant_forcing_overlap) && (dominant_group["forcing_overlap"] = state.dominant_forcing_overlap)
+        end
 
         # Energies
         energy_group = haskey(pe_group, "Energies") ? pe_group["Energies"] : create_group(pe_group, "Energies")
-        energy_group["vacuum_energy"]   = state.vacuum_energy
-        energy_group["surface_energy"]  = state.surface_energy
-        energy_group["plasma_energy"]   = state.plasma_energy
+        energy_group["vacuum_energy"] = state.vacuum_energy
+        energy_group["surface_energy"] = state.surface_energy
+        energy_group["plasma_energy"] = state.plasma_energy
         energy_group["toroidal_torque"] = state.toroidal_torque
 
         annotate_pe!(pe_group)
@@ -261,7 +278,8 @@ const PE_H5_ANNOTATIONS = [
     "Response/xi_cov_psi" => (; long_name="covariant radial displacement ξ_ψ = ξ·e_ψ", units="m^2", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
     "Response/xi_cov_theta" => (; long_name="covariant poloidal displacement ξ_θ = ξ·e_θ", units="m^2", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
     "Response/xi_cov_zeta" => (; long_name="covariant toroidal displacement ξ_ζ = ξ·e_ζ", units="m^2", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
-    "Response/xi_clebsch_psi" => (; long_name="Clebsch displacement component ξ^ψ (PENTRC input, gpout_xclebsch convention)", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
+    "Response/xi_clebsch_psi" =>
+        (; long_name="Clebsch displacement component ξ^ψ (PENTRC input, gpout_xclebsch convention)", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
     "Response/dxi_clebsch_psidpsi" =>
         (; long_name="regularized ψ_N derivative of ξ^ψ (× singfac²/(singfac²+reg_spot²))", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
     "Response/xi_clebsch_alpha" =>
@@ -342,6 +360,17 @@ const PE_H5_ANNOTATIONS = [
     "SingularCoupling/rational_n" =>
         (; long_name="resonant toroidal mode number n at each rational surface",
             dims=("surface",), attach=(1 => "SingularCoupling/rational_psi", 1 => "SingularCoupling/rational_q")),
+    "SingularCoupling/DominantMode/singular_values" =>
+        (; long_name="singular values σ (descending) of the applied-b̃ → resonant-field coupling matrix over the retained rational surfaces", dims=("rank",)),
+    "SingularCoupling/DominantMode/right_singular_vectors" =>
+        (; long_name="right singular vectors V: applied root-area-weighted field spectra ranked by resonant drive; overlap of b̃ with mode k is dot(V[:,k], b̃)",
+            dims=("mode", "rank")),
+    "SingularCoupling/DominantMode/left_singular_vectors" =>
+        (; long_name="left singular vectors U: resonant area-weighted field patterns over the retained rational surfaces", dims=("surface_retained", "rank")),
+    "SingularCoupling/DominantMode/rational_index" =>
+        (; long_name="1-based index into the SingularCoupling rational_* arrays of each rational surface retained in the SVD window", dims=("surface_retained",)),
+    "SingularCoupling/DominantMode/forcing_overlap" =>
+        (; long_name="coefficient of the applied forcing b̃_x on each singular mode, Vᴴ·b̃_x", units="T", dims=("rank",)),
     "Energies/vacuum_energy" => (; long_name="perturbed vacuum energy", units="J"),
     "Energies/surface_energy" => (; long_name="perturbed surface energy", units="J"),
     "Energies/plasma_energy" => (; long_name="perturbed plasma energy", units="J"),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ else
     include("./runtests_parallel_integration.jl")
     include("./runtests_result_struct.jl")
     include("./runtests_solve_api.jl")
+    include("./runtests_dominant_coupling.jl")
     include("./runtests_sing.jl")
     include("./runtests_innerlayer.jl")
     include("./runtests_tj_analytic.jl")

--- a/test/runtests_dominant_coupling.jl
+++ b/test/runtests_dominant_coupling.jl
@@ -1,0 +1,123 @@
+using HDF5
+using TOML
+using LinearAlgebra
+
+# The resonant-coupling analysis API: the pure windowed SVD on a hand-built matrix, then a real
+# perturbed-equilibrium run checked three ways — the stored run summary against the applied
+# resonant field, the in-memory and gpec.h5 constructions of ResonantCoupling against each
+# other, and the forcing-mode normalization path against the run's own b̃ spectrum.
+include("h5_metadata_check.jl")
+
+@testset "dominant coupling" begin
+    GPEC = GeneralizedPerturbedEquilibrium
+    PE = GPEC.PerturbedEquilibrium
+
+    @testset "window restriction and SVD identities on a synthetic matrix" begin
+        rational_psi = [0.2, 0.5, 0.8]
+        C = ComplexF64[1 2im 0 1 0 0; 0 3 1im 0 2 0; 1 0 0 4 0 1im]
+
+        dom = PE.dominant_coupling(C, rational_psi; psi_low=0.4, psi_high=1.0)
+        @test dom isa PE.DominantCoupling
+        @test dom.rational_index == [2, 3]
+        @test length(dom.singular_values) == 2
+        @test issorted(dom.singular_values; rev=true)
+        @test all(>(0), dom.singular_values)
+        @test size(dom.right_singular_vectors) == (6, 2)
+        @test size(dom.left_singular_vectors) == (2, 2)
+
+        U, σ, V = dom.left_singular_vectors, dom.singular_values, dom.right_singular_vectors
+        @test U * Diagonal(σ) * V' ≈ C[2:3, :]
+        @test V' * V ≈ I
+        # Driving the plasma with a singular vector returns σ times its resonant pattern, and the
+        # overlap convention picks that vector out with unit coefficient.
+        @test C[2:3, :] * V[:, 1] ≈ σ[1] .* U[:, 1]
+        @test PE.coupling_overlap(dom, V[:, 1]) ≈ [1, 0] atol = 1e-12
+
+        # The full window reproduces the plain SVD; an empty window is an error.
+        full = PE.dominant_coupling(C, rational_psi)
+        @test full.rational_index == [1, 2, 3]
+        @test full.singular_values ≈ svd(C).S
+        @test_throws ArgumentError PE.dominant_coupling(C, rational_psi; psi_low=0.9)
+        @test_throws DimensionMismatch PE.dominant_coupling(C, rational_psi[1:2])
+    end
+
+    @testset "perturbed-equilibrium run: summary, ResonantCoupling, and normalization" begin
+        template = joinpath(@__DIR__, "test_data", "regression_solovev_ideal_example")
+        forcing = joinpath(@__DIR__, "..", "examples", "Solovev_ideal_example", "forcing.dat")
+
+        mktempdir() do dir
+            for name in readdir(template)
+                cp(joinpath(template, name), joinpath(dir, name))
+            end
+            cp(forcing, joinpath(dir, "forcing.dat"))
+            toml_path = joinpath(dir, "gpec.toml")
+            inputs = TOML.parsefile(toml_path)
+            inputs["ForceFreeStates"]["write_outputs_to_HDF5"] = true
+            inputs["ForcingTerms"] = Dict{String,Any}("forcing_data_file" => "forcing.dat", "forcing_data_format" => "ascii")
+            inputs["PerturbedEquilibrium"] = Dict{String,Any}(
+                "compute_response" => true, "compute_singular_coupling" => true,
+                "verbose" => false, "write_outputs_to_HDF5" => true)
+            open(io -> TOML.print(io, inputs), toml_path, "w")
+
+            run = GPEC.main([dir])
+            pe, ffs = run.pe, run.ffs
+            h5path = joinpath(dir, "gpec.h5")
+
+            # Run summary: the full-window decomposition, rebuilt into the stored applied resonant
+            # field (which the writer evaluates before conforming the matrix to b̃ space).
+            @test !isempty(pe.dominant_singular_values)
+            rank = length(pe.dominant_singular_values)
+            rows = pe.dominant_rational_index
+            @test rows == 1:length(pe.rational_psi)
+            @test issorted(pe.dominant_singular_values; rev=true)
+            V, σ, U = pe.dominant_right_singular_vectors, pe.dominant_singular_values, pe.dominant_left_singular_vectors
+            @test size(V) == (length(pe.forcing_b_rootarea), rank)
+            @test size(U) == (length(rows), rank)
+            @test pe.dominant_forcing_overlap[1] ≈ dot(V[:, 1], pe.forcing_b_rootarea)
+            @test U * (σ .* pe.dominant_forcing_overlap) ≈ pe.resonant_area_weighted_field[rows] rtol = 1e-8
+
+            # The same ResonantCoupling from memory and from the file.
+            rc = PE.ResonantCoupling(pe, ffs)
+            rc_h5 = PE.ResonantCoupling(h5path)
+            @test rc_h5.C ≈ rc.C
+            @test rc_h5.rational_psi == rc.rational_psi
+            @test rc_h5.m_modes == rc.m_modes && rc_h5.n_modes == rc.n_modes
+            @test rc_h5.flux_conform ≈ rc.flux_conform
+            @test rc.m_modes[1] == ffs.mlow && rc.m_modes[end] == ffs.mhigh
+
+            # Normalization: the run's own unit-norm forcing modes, pushed through rootarea_field,
+            # reproduce the run's b̃ spectrum, and their overlaps reproduce the summary.
+            modes = h5open(h5path, "r") do h5
+                g = h5["PerturbedEquilibrium/ForcingModes"]
+                [GPEC.ForcingTerms.ForcingMode(; n, m, amplitude) for (n, m, amplitude) in zip(read(g["n"]), read(g["m"]), read(g["amplitude"]))]
+            end
+            b̃ = PE.rootarea_field(rc, modes)
+            @test b̃ ≈ pe.forcing_b_rootarea rtol = 1e-10
+            dom = PE.dominant_coupling(rc)
+            @test dom.singular_values ≈ σ
+            @test abs.(PE.coupling_overlap(dom, rc, modes)) ≈ abs.(pe.dominant_forcing_overlap) rtol = 1e-8
+
+            # Windowing is a post-hoc choice on the same object.
+            if length(rc.rational_psi) >= 2
+                lo = rc.rational_psi[2]
+                dom_w = PE.dominant_coupling(rc; psi_low=lo)
+                @test dom_w.rational_index == findall(>=(lo), rc.rational_psi)
+                @test dom_w.singular_values ≈ svd(rc.C[dom_w.rational_index, :]).S
+            end
+            @test_throws DimensionMismatch PE.rootarea_field(rc, ComplexF64[1, 2])
+
+            # Without the response step the conform operator is rebuilt from the equilibrium.
+            pe.rootarea_to_area_weight = zeros(ComplexF64, 0, 0)
+            @test PE.ResonantCoupling(pe, ffs).flux_conform ≈ rc.flux_conform
+
+            h5open(h5path, "r") do h5
+                g = h5["PerturbedEquilibrium/SingularCoupling/DominantMode"]
+                @test read(g["singular_values"]) ≈ σ
+                @test read(g["right_singular_vectors"]) ≈ V
+                @test read(g["rational_index"]) == rows
+                @test read(g["forcing_overlap"]) ≈ pe.dominant_forcing_overlap
+                @test isempty(_collect_metadata_violations(h5))
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Release note

- **Audience:** users
- **Numerical impact:** none _(harness @ 42d752a1)_
- **Migration:** none

You can now take the dominant resonant-coupling mode of a perturbed-equilibrium run and project any applied coil spectrum onto it — from the run in memory or from its `gpec.h5` — without re-running: `ResonantCoupling` bundles the singular-coupling matrix with its labels and the b̃ normalization, `dominant_coupling` does the windowed SVD on demand, and `rootarea_field`/`coupling_overlap` handle the mode ordering, the `R⁻¹` conform, and the conjugation so users never touch them. The run itself gained no input knobs; it always writes the full coupling matrix plus a full-window summary under `PerturbedEquilibrium/SingularCoupling/DominantMode/`.

## Regression report

```
Regression Report: diiid_n1
=================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
Ref 2: local  @ local (2026-09-11)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
-------------------------------------------------------------------------------------------------
Quantity                                      develop          local            Diff       Status
-------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01     0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05     0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00    0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00     0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01     0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]        0.0e+00    OK    
ODE steps (saved)                             2576             2576             0.0e+00    OK    
ODE steps (total)                             4572             4572             0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00     0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00     0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02     0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00     0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01     0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01     0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01     0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01     0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01     0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01     0.0e+00    OK    
# singular surfaces                           5                5                0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]         0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]         0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01     0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01     0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00     0.0e+00    OK    
mpert                                         35               35               0.0e+00    OK    
npert                                         1                1                0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00     0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01     0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00     0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00     0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...  identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...  identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...  identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...  identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...  identical  OK    
island half-widths                            [5 elem]         [5 elem]         0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]         0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04     0.0e+00    OK    
dominant-coupling singular values             N/A              [5 elem]         N/A        N/A   
|forcing overlap with dominant mode|          N/A              3.284975e-02     N/A        N/A   
PE plasma energy                              3.422677e+00     3.422677e+00     0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00     0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00     0.0e+00    OK    
PE toroidal torque                            5.087465e-02     5.087465e-02     0.0e+00    OK    
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01     0.0e+00    OK    
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02     0.0e+00    OK    
Runtime (s)                                   295.4s           313.4s                      --    
resonant area-weighted field b^r              [5 elem]         [5 elem]         0.0e+00    OK    
=================================================================================================
Summary: 47 unchanged, 2 missing/N/A
```

The two `N/A` rows are the new tracked quantities (absent on `develop` by construction); every pre-existing quantity is unchanged.

## Notes for reviewers

- **Basis.** The SVD acts on `C_resonant_area_weighted_field` *after* the conform at `SingularCoupling.jl` that makes it act on the root-area-weighted field b̃, so the singular values are coordinate-invariant and `rootarea_field` must apply `R⁻¹ = (S·A)⁻¹` to unit-norm `Φ_x` before any projection. The test pins this: the run's own unit-norm forcing modes pushed through `rootarea_field` reproduce `forcing_b_rootarea` to 1e-10, and `U·(σ ⊙ Vᴴb̃_x)` reproduces the stored applied resonant field to 1e-8.
- **Convention.** `coupling_overlap(dom, b̃) = Vᴴ·b̃`, i.e. `dot(V[:,k], b̃)` with `dot` conjugating `V`. Singular vectors carry an arbitrary global phase, so the harness tracks `|overlap|` and the singular values, never the complex vectors.
- **Why no ψ window in the TOML.** A windowed output would tempt full re-runs to change the window; the window is an argument of `dominant_coupling` and the file always carries the full matrix.
- `ResonantCoupling(state, ffs)` rebuilds the conform operator from the equilibrium when `compute_response = false` (covered by the test); `ResonantCoupling(h5path)` requires the response step's stored operator and errors clearly otherwise.
- This is the first of a series migrating an error-field tolerance Monte Carlo tool (an OMFIT project) into the repo as an `ErrorFields` module; that module will consume exactly this chain in memory.

cc @matt-pharr — you may want to follow this series, since it builds directly on the b̃ conform work.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu




**Update (2026-09-17, f43dd785):** the dominant-mode SVD now defaults to the core window `ψ_N ≤ 0.9` (`CORE_PSI_HIGH`, exported), for the run summary under `SingularCoupling/DominantMode/` and for every analysis built on it; other windows remain an analysis choice on the same `ResonantCoupling`. Rational surfaces near the edge couple strongly to any applied field and would dominate the decomposition, while the locking physics the overlap feeds concerns the core. Harness `diiid_n1` develop vs f43dd785: 47 unchanged, the two new quantities (now over the three core surfaces) N/A on develop. The stacked PRs pick this up by merge.
