### PR TITLE
ForcingTerms - REFACTOR - Evaluate forcing modes per coil set on a shared boundary grid

### DIFF
--- a/docs/src/forcing_terms.md
+++ b/docs/src/forcing_terms.md
@@ -60,7 +60,7 @@ amplitudes directly — no conversion is applied.
 
 Required datasets:
 - `n`: integer array of toroidal mode numbers
-- `m`: integer array of poloidal mode numbers  
+- `m`: integer array of poloidal mode numbers
 - `amplitude_real`: float array of real parts
 - `amplitude_imag`: float array of imaginary parts (optional)
 
@@ -89,6 +89,17 @@ The coil pipeline:
 2. `compute_biot_savart_boundary!`: compute B at all grid points via Biot-Savart law
 3. `project_normal_flux!`: compute Phi_x = 2π×R×(B_R ∂Z/∂θ_norm − B_Z ∂R/∂θ_norm)
 4. `fourier_decompose_bn`: Fourier decompose to get bmn in unit-norm (= Phi_x) convention
+
+Steps 2–4 are linear in the coils, so a `CoilForcingGrid` (step 1 plus the observation-point
+layout, built once per equilibrium and `n`) can be reused to evaluate coil sets one at a time
+with `coil_forcing_modes`; the per-set spectra sum to the assembly's. Use this when many coil
+variants must be compared against one plasma — moved or re-wound coils, or one coil at a time —
+without re-sampling the boundary:
+
+```julia
+forcing_grid = CoilForcingGrid(equil, cfg, n; psi=ffs.psilim)
+spectra = [coil_forcing_modes(cs, forcing_grid, n, m_low, m_high) for cs in coil_sets]
+```
 
 The toroidal angle for each observation point at SFL grid coordinate (θ_i, ζ_j) is:
 ```

--- a/src/ForcingTerms/CoilFourier.jl
+++ b/src/ForcingTerms/CoilFourier.jl
@@ -6,10 +6,12 @@ suitable for the perturbed equilibrium pipeline.
 
 ## Pipeline
 - `sample_boundary_grid` — evaluate (R, Z) and unit-norm metric on the plasma boundary
+- `CoilForcingGrid` — the boundary grid with its observation points laid out, shared by every coil evaluation
 - `compute_biot_savart_boundary!` (BiotSavart.jl) — compute B at all grid points
 - `project_normal_flux!` — compute flux Φ_x = 2π×R×(B_R ∂Z/∂θ − B_Z ∂R/∂θ)
 - `fourier_decompose_bn` — 2D Fourier decompose to get bmn amplitudes
-- `compute_coil_forcing_modes!` — top-level entry point combining all steps
+- `coil_forcing_modes` — Biot-Savart → projection → decomposition for any coil set(s) on a `CoilForcingGrid`
+- `compute_coil_forcing_modes!` — top-level entry point combining all steps for a whole assembly
 """
 
 using FastInterpolations: cubic_interp, PeriodicBC, DerivOp
@@ -107,7 +109,7 @@ For positive-helicity machines (Bt > 0, Ip > 0 → helicity = +1): phi decreases
 function sample_boundary_grid(equil::Equilibrium.PlasmaEquilibrium, mtheta::Int, nzeta::Int;
     psi::Float64=equil.rzphi_xs[end])
     # Build uniform theta grid (same convention as equil.rzphi_ys, but potentially finer)
-    theta_grid = range(0; length=mtheta, step=1.0/mtheta)
+    theta_grid = range(0; length=mtheta, step=1.0 / mtheta)
 
     R_arr = zeros(mtheta)
     Z_arr = zeros(mtheta)
@@ -139,7 +141,7 @@ function sample_boundary_grid(equil::Equilibrium.PlasmaEquilibrium, mtheta::Int,
     bt_sign = !isnothing(equil.params.bt_sign) ? equil.params.bt_sign : 1
     ip_sign = !isnothing(equil.params.crnt) ? Int(sign(equil.params.crnt)) : 1
     helicity = bt_sign * ip_sign
-    phi_grid = collect(range(0; length=nzeta, step=(-helicity * 2π/nzeta)))
+    phi_grid = collect(range(0; length=nzeta, step=(-helicity * 2π / nzeta)))
 
     # Toroidal angle offset ν(ψ, θ_SFL): in SFL coordinates the physical toroidal angle at
     # grid point (θ_SFL, ζ_SFL) is  φ_phys = -helicity*(2π*ζ_SFL + ν(ψ,θ_SFL)).
@@ -241,18 +243,95 @@ function fourier_decompose_bn(
 end
 
 """
-    compute_coil_forcing_modes!(forcing_modes, coil_sets, equil, cfg, n, m_low, m_high; verbose)
+    CoilForcingGrid
 
-Top-level entry point: compute Fourier mode amplitudes of the normal magnetic
-flux from all coil sets on the plasma boundary.
+The plasma-boundary sampling that every coil-field evaluation for one equilibrium and
+toroidal mode number shares: the `BoundaryGrid` at the control surface and its observation
+points laid out in cylindrical `(R, φ, Z)`. Build it once and evaluate any number of coil
+sets against it with [`coil_forcing_modes`](@ref).
 
-## Pipeline
+## Fields
 
-  - Build boundary grid at (mtheta × nzeta) resolution, with helicity from `equil.params`
-  - Lay out observation points in (R, φ, Z) for all (θ, ζ) combinations
-  - Run threaded Biot-Savart summation over all coil sets (matches Fortran `field_bs_psi`)
-  - Project B field onto plasma boundary normal flux (`project_normal_flux!`)
-  - 2D Fourier decompose to get bmn amplitudes for mode range
+  - `grid::BoundaryGrid` - boundary geometry and unit-norm metric
+  - `obs_R`, `obs_phi`, `obs_Z` - observation points `[mtheta × nzeta]`, θ-major, with the
+    SFL toroidal offset applied
+"""
+struct CoilForcingGrid
+    grid::BoundaryGrid
+    obs_R::Vector{Float64}
+    obs_phi::Vector{Float64}
+    obs_Z::Vector{Float64}
+end
+
+"""
+    CoilForcingGrid(equil, cfg, n; psi=equil.rzphi_xs[end])
+
+Sample the control surface `psi` at `cfg.mtheta_coil × nzeta` points, with `nzeta` taken
+from `cfg.nzeta_coil` or `NZETA_POINTS_PER_PERIOD` per toroidal period of `n`. Pass
+`psi = psilim` whenever a solve is at hand (see `sample_boundary_grid`).
+"""
+function CoilForcingGrid(equil::Equilibrium.PlasmaEquilibrium, cfg::CoilConfig, n::Int; psi::Float64=equil.rzphi_xs[end])
+    nzeta = cfg.nzeta_coil > 0 ? cfg.nzeta_coil : NZETA_POINTS_PER_PERIOD * max(1, abs(n))
+    grid = sample_boundary_grid(equil, cfg.mtheta_coil, nzeta; psi)
+
+    # Lay out observation points: (theta_i, zeta_j) → cylindrical (R, phi, Z)
+    nobs = grid.mtheta * grid.nzeta
+    obs_R = zeros(nobs)
+    obs_phi = zeros(nobs)
+    obs_Z = zeros(nobs)
+    for j in 1:grid.nzeta
+        for i in 1:grid.mtheta
+            idx = i + (j - 1) * grid.mtheta
+            obs_R[idx] = grid.R[i]
+            obs_phi[idx] = grid.phi_grid[j] + grid.phi_offset[i]
+            obs_Z[idx] = grid.Z[i]
+        end
+    end
+    return CoilForcingGrid(grid, obs_R, obs_phi, obs_Z)
+end
+
+"""
+    coil_forcing_modes(coil_sets, forcing_grid::CoilForcingGrid, n, m_low, m_high; verbose=false) -> Vector{ForcingMode}
+
+Fourier mode amplitudes, in the unit-norm `Φ_x` convention, of the normal flux that
+`coil_sets` — a `Vector{CoilSet}` or a single `CoilSet` — drive on the boundary sampled by
+`forcing_grid`: threaded Biot-Savart at every observation point, projection onto the boundary
+normal, then the 2D decomposition for toroidal mode `n` and `m_low:m_high`. The field is
+linear in the coils, so evaluating sets one at a time on the same grid gives each set's own
+spectrum, and the sum of those is the spectrum of the assembly.
+"""
+function coil_forcing_modes(
+    coil_sets::Vector{CoilSet},
+    forcing_grid::CoilForcingGrid,
+    n::Int,
+    m_low::Int,
+    m_high::Int;
+    verbose::Bool=false
+)
+    nobs = length(forcing_grid.obs_R)
+    B_R = zeros(nobs)
+    B_phi = zeros(nobs)
+    B_Z = zeros(nobs)
+    compute_biot_savart_boundary!(B_R, B_phi, B_Z, forcing_grid.obs_R, forcing_grid.obs_phi, forcing_grid.obs_Z, coil_sets)
+
+    verbose && @info "  Max |B_R| = $(maximum(abs, B_R)) T, Max |B_Z| = $(maximum(abs, B_Z)) T"
+
+    bn = zeros(forcing_grid.grid.mtheta, forcing_grid.grid.nzeta)
+    project_normal_flux!(bn, B_R, B_Z, forcing_grid.grid)
+
+    verbose && @info "  Max |bn| = $(maximum(abs, bn)) T·m²"
+
+    return fourier_decompose_bn(bn, forcing_grid.grid, n, m_low, m_high)
+end
+
+coil_forcing_modes(coil_set::CoilSet, forcing_grid::CoilForcingGrid, args...; kwargs...) = coil_forcing_modes([coil_set], forcing_grid, args...; kwargs...)
+
+"""
+    compute_coil_forcing_modes!(forcing_modes, coil_sets, equil, cfg, n, m_low, m_high; psi, verbose)
+
+Top-level entry point: compute Fourier mode amplitudes of the normal magnetic flux from all
+coil sets on the plasma boundary — a [`CoilForcingGrid`](@ref) at `psi` followed by
+[`coil_forcing_modes`](@ref) over the whole assembly in one Biot-Savart pass.
 
 Output amplitudes are in unit-norm convention (= Fortran `Phi_x`).
 No normalization conversion is needed when using these modes with `compute_plasma_response!`.
@@ -270,41 +349,10 @@ function compute_coil_forcing_modes!(
     psi::Float64=equil.rzphi_xs[end],   # outermost computed surface (psihigh), not ψ_N=1 — see sample_boundary_grid
     verbose::Bool=false
 )
-    nzeta = cfg.nzeta_coil > 0 ? cfg.nzeta_coil : NZETA_POINTS_PER_PERIOD * max(1, abs(n))
-    mtheta = cfg.mtheta_coil
+    forcing_grid = CoilForcingGrid(equil, cfg, n; psi)
+    verbose && @info "Computing coil forcing modes: mtheta=$(forcing_grid.grid.mtheta), nzeta=$(forcing_grid.grid.nzeta), n=$n, m=$m_low:$m_high, psi=$psi"
 
-    verbose && @info "Computing coil forcing modes: mtheta=$mtheta, nzeta=$nzeta, n=$n, m=$m_low:$m_high, psi=$psi"
-
-    grid = sample_boundary_grid(equil, mtheta, nzeta; psi)
-
-    # Lay out observation points: (theta_i, zeta_j) → cylindrical (R, phi, Z)
-    nobs = mtheta * nzeta
-    obs_R = zeros(nobs)
-    obs_phi = zeros(nobs)
-    obs_Z = zeros(nobs)
-
-    for j in 1:nzeta
-        for i in 1:mtheta
-            idx = i + (j - 1) * mtheta
-            obs_R[idx] = grid.R[i]
-            obs_phi[idx] = grid.phi_grid[j] + grid.phi_offset[i]
-            obs_Z[idx] = grid.Z[i]
-        end
-    end
-
-    B_R = zeros(nobs)
-    B_phi = zeros(nobs)
-    B_Z = zeros(nobs)
-    compute_biot_savart_boundary!(B_R, B_phi, B_Z, obs_R, obs_phi, obs_Z, coil_sets)
-
-    verbose && @info "  Max |B_R| = $(maximum(abs, B_R)) T, Max |B_Z| = $(maximum(abs, B_Z)) T"
-
-    bn = zeros(mtheta, nzeta)
-    project_normal_flux!(bn, B_R, B_Z, grid)
-
-    verbose && @info "  Max |bn| = $(maximum(abs, bn)) T·m²"
-
-    modes = fourier_decompose_bn(bn, grid, n, m_low, m_high)
+    modes = coil_forcing_modes(coil_sets, forcing_grid, n, m_low, m_high; verbose)
 
     empty!(forcing_modes)
     append!(forcing_modes, modes)
@@ -407,5 +455,6 @@ end
 
 export BoundaryGrid, sample_boundary_grid
 export project_normal_flux!, fourier_decompose_bn
+export CoilForcingGrid, coil_forcing_modes
 export compute_coil_forcing_modes!
 export convert_forcing_normalization!

--- a/test/runtests_coils.jl
+++ b/test/runtests_coils.jl
@@ -299,6 +299,20 @@ end
     # Dominant mode should be in the resonant range for DIII-D geometry
     dominant_m = forcing_modes[argmax(amplitudes)].m
     @test m_low <= dominant_m <= m_high
+
+    # Per-set evaluation on one shared grid: the assembly through the shared path is the same
+    # numbers as the top-level entry point, and the field's linearity in the coils makes the
+    # per-set spectra sum to it.
+    forcing_grid = ForcingTerms.CoilForcingGrid(equil, cfg, n_test)
+    @test length(forcing_grid.obs_R) == cfg.mtheta_coil * cfg.nzeta_coil
+    both = ForcingTerms.coil_forcing_modes([il_set, iu_set], forcing_grid, n_test, m_low, m_high)
+    @test [m.amplitude for m in both] == [m.amplitude for m in forcing_modes]
+    il_modes = ForcingTerms.coil_forcing_modes(il_set, forcing_grid, n_test, m_low, m_high)
+    iu_modes = ForcingTerms.coil_forcing_modes(iu_set, forcing_grid, n_test, m_low, m_high)
+    @test [m.m for m in il_modes] == [m.m for m in forcing_modes]
+    summed = [a.amplitude + b.amplitude for (a, b) in zip(il_modes, iu_modes)]
+    @test summed ≈ [m.amplitude for m in forcing_modes] rtol = 1e-12
+    @test maximum(abs.(getfield.(il_modes, :amplitude))) > 1e-6
 end
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Release note

- **Audience:** developers
- **Numerical impact:** none _(harness @ 5aaf242b)_
- **Migration:** none

The coil-field pipeline can now evaluate coil sets one at a time against a plasma boundary that is sampled once: `CoilForcingGrid` holds the boundary grid and its observation points for one equilibrium and toroidal mode number, and `coil_forcing_modes` runs Biot-Savart, the normal projection, and the Fourier decomposition for any coil set or sets on it. Because the field is linear in the coils, per-set spectra sum to the assembly's. `compute_coil_forcing_modes!` is unchanged in behaviour — it is now these two calls over the whole assembly in one pass.

## Regression report

```
Regression Report: diiid_n1
=================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
Ref 2: local  @ local (2026-09-11)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
-------------------------------------------------------------------------------------------------
Quantity                                      develop          local            Diff       Status
-------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01     0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05     0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00    0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00     0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01     0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]        0.0e+00    OK    
ODE steps (saved)                             2576             2576             0.0e+00    OK    
ODE steps (total)                             4572             4572             0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00     0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00     0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02     0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00     0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01     0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01     0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01     0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01     0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01     0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01     0.0e+00    OK    
# singular surfaces                           5                5                0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]         0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]         0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01     0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01     0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00     0.0e+00    OK    
mpert                                         35               35               0.0e+00    OK    
npert                                         1                1                0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00     0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01     0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00     0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00     0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...  identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...  identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...  identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...  identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...  identical  OK    
island half-widths                            [5 elem]         [5 elem]         0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]         0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04     0.0e+00    OK    
PE plasma energy                              3.422677e+00     3.422677e+00     0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00     0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00     0.0e+00    OK    
PE toroidal torque                            5.087465e-02     5.087465e-02     0.0e+00    OK    
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01     0.0e+00    OK    
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02     0.0e+00    OK    
Runtime (s)                                   295.4s           290.3s                      --    
resonant area-weighted field b^r              [5 elem]         [5 elem]         0.0e+00    OK    
=================================================================================================
Summary: 47 unchanged
```

## Notes for reviewers

- The assembly path is deliberately kept as a single Biot-Savart pass over all sets (not a sum of per-set results), so its output is bit-identical to `develop` — asserted in `runtests_coils.jl` (`==`, not `≈`). The per-set sum is asserted at `rtol = 1e-12` (summation order differs).
- The Fourier basis is still rebuilt inside `fourier_decompose_bn` per call; caching it on `CoilForcingGrid` is a possible follow-up if profiling of the many-coil-variant use case shows it matters (Biot-Savart dominates today).
- Motivation: the upcoming `ErrorFields` module perturbs each coil set individually (rigid shift/tilt finite differences) and needs each set's own spectrum on the same grid — `O(ncoil)` evaluations of one set instead of `O(ncoil²)` full-assembly recomputations.

cc @matt-pharr — you may want to follow this series.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu
