### PR TITLE
ErrorFields - FEATURE - Add per-coil dominant-mode overlap and sensitivities

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -98,6 +98,7 @@ Splines are provided by the external `FastInterpolations` package rather than by
        - Island half-widths and Chirikov parameters
        - Green's functions at interior flux surfaces
        - Surface inductance for singular surfaces
+     - `ResonantCoupling.jl` - `ResonantCoupling` (in-memory or from gpec.h5): windowed SVD for the dominant applied-field mode, and the normalization/overlap helpers that project coil spectra onto it
      - `Utils.jl` - Helper functions
    - Status: Core plasma response and singular coupling calculations implemented; active area of development
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -118,9 +118,14 @@ Splines are provided by the external `FastInterpolations` package rather than by
     - Neoclassical toroidal viscosity (NTV) torque and kinetic energy contributions
     - Reads kinetic profiles configured under `[KineticForces]`
 
+11. **ErrorFields** (`src/ErrorFields/`) - Error-field sensitivity to coil misalignment
+    - `Sensitivity.jl` - central-difference linearization of every coil set's control-surface spectrum with respect to its rigid shifts and tilts, on one shared boundary grid
+    - `sensitivity_table` projects that linearization onto any windowed dominant mode post hoc (in memory or from `gpec.h5`); consumes `PerturbedEquilibrium.ResonantCoupling` and `ForcingTerms.coil_forcing_modes`
+    - Configured under `[ErrorFields]`; writes `ErrorFields/CoilSensitivities/`
+
 ### Post-processing
 
-11. **Analysis** (`src/Analysis/`) - Plotting and post-processing
+12. **Analysis** (`src/Analysis/`) - Plotting and post-processing
     - Submodules mirror the physics modules they visualize, so their names shadow them
     - Not part of the solve path; consumes `gpec.h5`
 
@@ -184,7 +189,7 @@ The complete GPEC analysis pipeline:
 
 5. **Output**:
    - All results saved to single HDF5 file (default: `gpec.h5`)
-   - Top-level HDF5 groups: `Info/`, `Input/`, `Equilibrium/`, `ForceFreeStates/`, `LocalStability/`, `SingularSurfaces/`, `PerturbedEquilibrium/`, `KineticForces/`, `Tearing/`, `SurfaceGeometries/` (see `docs/development/hdf5-conventions.md`)
+   - Top-level HDF5 groups: `Info/`, `Input/`, `Equilibrium/`, `ForceFreeStates/`, `LocalStability/`, `SingularSurfaces/`, `PerturbedEquilibrium/`, `KineticForces/`, `ErrorFields/`, `Tearing/`, `SurfaceGeometries/` (see `docs/development/hdf5-conventions.md`)
 
 ## Key Data Structures
 
@@ -229,5 +234,6 @@ GeneralizedPerturbedEquilibrium
 ├── Vacuum (uses Splines, Equilibrium, Utilities)
 ├── ForcingTerms (data I/O)
 ├── ForceFreeStates (uses Equilibrium, Vacuum, Splines)
-└── PerturbedEquilibrium (uses ForceFreeStates, Vacuum, ForcingTerms, Utilities)
+├── PerturbedEquilibrium (uses ForceFreeStates, Vacuum, ForcingTerms, Utilities)
+└── ErrorFields (uses PerturbedEquilibrium, ForcingTerms, Equilibrium, Utilities)
 ```

--- a/docs/development/hdf5-conventions.md
+++ b/docs/development/hdf5-conventions.md
@@ -33,7 +33,7 @@ These rules govern `gpec.h5` (and any future GPEC-produced HDF5 output); harness
 
 ## Schema
 
-Top level (10 groups):
+Top level (11 groups):
 
 | Group | Contents |
 |---|---|
@@ -45,6 +45,7 @@ Top level (10 groups):
 | `SingularSurfaces/` | Per-rational-surface data: `rational_psi`/`rational_q`/`rational_m`/`rational_n`, GGJ coefficients, `Delta_prime_matrix`/`Delta_prime_raw`/`Delta_coil`/`pest3_A`/`pest3_B`/`pest3_Gamma` (Riccati or Galerkin alike), `Kinetic/` |
 | `PerturbedEquilibrium/` | `ForcingModes/`, `Response/`, `ResponseMatrices/`, `SingularCoupling/`, `Energies/`, control-surface spectra |
 | `KineticForces/` | `<method>/` (torque/energy profiles, `EnergyIntegrals/`, `KineticMatrices/`); multi-ion runs add `PerSpecies/<species>/<method>/` with the same per-method layout, summing to the top-level total |
+| `ErrorFields/` | `CoilSensitivities/` (per-coil-set control-surface spectra and their rigid shift/tilt derivatives, `DominantMode/` full-window projection) |
 | `Tearing/` | `PerSurface/` (+ `DpMatrix/`), `Roots/`, `LayerWidths/`, `Diagnostics/{ValidRoots,Poles,FilteredRoots}`, `Scan/Surface_<k>/` |
 | `SurfaceGeometries/` | `{Plasma,Wall}/{x,y,z}` point clouds |
 

--- a/docs/development/naming.md
+++ b/docs/development/naming.md
@@ -57,6 +57,7 @@ Modules, with the abbreviation to use in prose:
 |---|---|---|
 | `Analysis` | — | `src/Analysis/` |
 | `Equilibrium` | EQUIL | `src/Equilibrium/` |
+| `ErrorFields` | EF | `src/ErrorFields/` |
 | `ForceFreeStates` | FFS | `src/ForceFreeStates/` |
 | `ForcingTerms` | FT | `src/ForcingTerms/` |
 | `HDF5Schema` | — | `src/HDF5Schema.jl` |

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -37,6 +37,7 @@ makedocs(;
             "KineticForces" => "kinetic_forces.md",
             "Forcing Terms" => "forcing_terms.md",
             "Perturbed Equilibrium" => "perturbed_equilibrium.md",
+            "Error Fields" => "error_fields.md",
             "Tearing" => "inner_layer.md",
             "Analysis" => "analysis.md",
             "Utilities" => "utilities.md"

--- a/docs/src/error_fields.md
+++ b/docs/src/error_fields.md
@@ -57,6 +57,14 @@ curvature diagnostic per tap, the current pattern the spectra were evaluated at,
 its shift and tilt sensitivities, their direction-averaged in-plane magnitudes, and the in-plane
 shift and tilt that would cancel `delta_nominal`).
 
+`examples/DIIID-like_error_field_example/` is a complete case: the DIII-D-like equilibrium with
+the C-coil as the nominal n = 1 source and the eighteen DIII-D F coils added as single-filament
+hoops at the centroids of their winding packs (from OpenFUSIONToolkit's TokaMaker
+`DIIID_geom.json`). An axisymmetric hoop drives no n = 1 field as built, so each F coil's
+error-field content is entirely its sensitivity to misalignment; `analyze_example.jl` ranks the
+coils by error field per millimetre of shift and per tenth of a degree of tilt, over all
+rational surfaces and over the edge only.
+
 The tilt pivot matters for multi-filament winding packs: `"conductor"` rotates each filament
 about its own arc-length centre, the Fortran `coil_read` convention inherited by the OMFIT
 tolerance tool, while `"set"` rotates the pack rigidly about its common centre, which is what

--- a/docs/src/error_fields.md
+++ b/docs/src/error_fields.md
@@ -1,0 +1,109 @@
+# ErrorFields Module
+
+The `ErrorFields` module quantifies how sensitive a perturbed equilibrium's resonant drive is
+to the placement of each coil set. It is the foundation of an error-field tolerance
+assessment: once one plasma solve exists, the question *"how much resonant field does a
+misaligned coil produce?"* is linear in the coil's motion, so the module linearizes it once
+and everything downstream (tolerance Monte Carlo, locking risk, allowable-tolerance scans)
+becomes linear algebra on a small table.
+
+## What is computed
+
+For every named coil set of a coil-forced run, the module evaluates the root-area-weighted
+control-surface spectrum ``\tilde{b}`` of the set as built and its central-difference
+derivatives with respect to the six rigid-body degrees of freedom: Cartesian shifts
+``(\Delta x, \Delta y, \Delta z)`` in metres and rotations ``(\theta_x, \theta_y, \theta_z)``
+about the machine axes in degrees. The spectra are placed on the run's ``(m, n)`` ordering and
+conformed with the control-surface operator, so they are exactly the vectors the resonant
+coupling matrix and its singular vectors act on
+(see [Dominant resonant-coupling mode](perturbed_equilibrium.md#Dominant-resonant-coupling-mode)).
+
+The overlap of a coil set with singular mode ``k`` of the coupling matrix, normalized by the
+axis toroidal field, is the dimensionless
+
+```math
+\delta = \frac{V_k^{\mathrm{H}}\,\tilde{b}}{B_{T0}},
+```
+
+and because the projection is linear, the derivatives of ``\tilde{b}`` project to the
+derivatives of ``\delta``. A rigid shift ``(\Delta x, \Delta y)`` therefore moves the overlap
+by ``S_x \Delta x + S_y \Delta y`` with complex ``S_x = \partial\delta/\partial\Delta x`` and
+``S_y = \partial\delta/\partial\Delta y``, which is exact for any coil shape; for an
+axisymmetric coil ``S_y = \pm i S_x`` and the response reduces to a single magnitude with a
+free phase, the model the OMFIT tolerance tool used.
+
+The stored primitive is the linearization of the spectrum, not a scalar, so the resonant
+surfaces retained, the singular mode, and the normalization are all post-hoc choices.
+
+## Running it
+
+Add an `[ErrorFields]` section to a deck whose `[ForcingTerms]` uses
+`forcing_data_format = "coil"` and whose `[PerturbedEquilibrium]` computes the singular
+coupling:
+
+```toml
+[ErrorFields]
+fd_step_shift_m = 1e-3          # Central-difference step for the rigid shifts [m]
+fd_step_tilt_deg = 0.1          # Central-difference step for the rigid tilts [degrees]
+rotation_center = "conductor"   # Tilt pivot: each conductor's own centre ("conductor") or the whole set's ("set")
+write_outputs_to_HDF5 = true    # Write ErrorFields/CoilSensitivities/ to the output file
+verbose = false                 # Log per-coil-set progress and linearity diagnostics
+```
+
+The stage runs after the perturbed equilibrium and writes `ErrorFields/CoilSensitivities/`:
+the spectra `nominal_field`, `shift_sensitivity`, `tilt_sensitivity`, a finite-difference
+curvature diagnostic per tap, the current pattern the spectra were evaluated at, and a
+`DominantMode/` summary projected onto the run's full-window dominant mode (`delta_nominal`,
+its shift and tilt sensitivities, their direction-averaged in-plane magnitudes, and the in-plane
+shift and tilt that would cancel `delta_nominal`).
+
+The tilt pivot matters for multi-filament winding packs: `"conductor"` rotates each filament
+about its own arc-length centre, the Fortran `coil_read` convention inherited by the OMFIT
+tolerance tool, while `"set"` rotates the pack rigidly about its common centre, which is what
+an engineering axis-line tolerance constrains. Single-conductor sets give identical results
+either way.
+
+## Analysis after the run
+
+Window the coupling to any range of rational surfaces and project onto any singular mode
+without re-running anything, from memory or from the file:
+
+```julia
+using GeneralizedPerturbedEquilibrium
+EF = GeneralizedPerturbedEquilibrium.ErrorFields
+
+# From the file: the coupling is rebuilt, windowed to 0.5 ≤ ψ_N ≤ 1, and projected onto mode 1
+table = EF.sensitivity_table("gpec.h5"; psi_low=0.5)
+table.delta_nominal            # complex overlap of each coil set
+table.shift_rms                # direction-averaged |∂δ/∂Δ| per metre of shift, per coil set
+table.tilt[1, :]               # ∂δ/∂θx per degree, per coil set
+
+# In memory, from the run's returned state (no I/O)
+rc  = PerturbedEquilibrium.ResonantCoupling(run.pe, run.ffs)
+dom = PerturbedEquilibrium.dominant_coupling(rc; psi_low=0.5)
+table = EF.sensitivity_table(run.coil_sensitivities, dom; mode=1)
+```
+
+To assess a *new* coil design against an existing run — a moved or re-wound coil — sweep the
+new geometry on the stored solve's own control surface. The equilibrium is rebuilt from the
+file; no plasma solve is repeated:
+
+```julia
+new_sets = ForcingTerms.load_coil_sets(cfg, 1)   # any CoilSet vector
+sens  = EF.compute_coil_sensitivities("gpec.h5", new_sets; rotation_center="set")
+table = EF.sensitivity_table(sens, PerturbedEquilibrium.dominant_coupling(PerturbedEquilibrium.ResonantCoupling("gpec.h5")))
+```
+
+A coil set's spectrum is proportional to its currents, so the table is specific to the current
+pattern it was evaluated with; `peak_current` and `winding_multiplier` are stored so a user can
+renormalize per ampere-turn when comparing designs.
+
+## API Reference
+
+```@autodocs
+Modules = [GeneralizedPerturbedEquilibrium.ErrorFields]
+```
+
+```@docs
+GeneralizedPerturbedEquilibrium.equilibrium_from_h5
+```

--- a/docs/src/forcing_terms.md
+++ b/docs/src/forcing_terms.md
@@ -60,7 +60,7 @@ amplitudes directly — no conversion is applied.
 
 Required datasets:
 - `n`: integer array of toroidal mode numbers
-- `m`: integer array of poloidal mode numbers  
+- `m`: integer array of poloidal mode numbers
 - `amplitude_real`: float array of real parts
 - `amplitude_imag`: float array of imaginary parts (optional)
 
@@ -89,6 +89,17 @@ The coil pipeline:
 2. `compute_biot_savart_boundary!`: compute B at all grid points via Biot-Savart law
 3. `project_normal_flux!`: compute Phi_x = 2π×R×(B_R ∂Z/∂θ_norm − B_Z ∂R/∂θ_norm)
 4. `fourier_decompose_bn`: Fourier decompose to get bmn in unit-norm (= Phi_x) convention
+
+Steps 2–4 are linear in the coils, so a `CoilForcingGrid` (step 1 plus the observation-point
+layout, built once per equilibrium and `n`) can be reused to evaluate coil sets one at a time
+with `coil_forcing_modes`; the per-set spectra sum to the assembly's. Use this when many coil
+variants must be compared against one plasma — moved or re-wound coils, or one coil at a time —
+without re-sampling the boundary:
+
+```julia
+forcing_grid = CoilForcingGrid(equil, cfg, n; psi=ffs.psilim)
+spectra = [coil_forcing_modes(cs, forcing_grid, n, m_low, m_high) for cs in coil_sets]
+```
 
 The toroidal angle for each observation point at SFL grid coordinate (θ_i, ζ_j) is:
 ```

--- a/docs/src/perturbed_equilibrium.md
+++ b/docs/src/perturbed_equilibrium.md
@@ -17,6 +17,49 @@ GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.compute_perturbed_equilibri
 GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.write_outputs_to_HDF5
 ```
 
+## Dominant resonant-coupling mode
+
+The singular-coupling matrix `C_resonant_area_weighted_field` maps an applied
+root-area-weighted field spectrum `b̃` on the control surface to the resonant field at each
+rational surface. Its singular-value decomposition over a chosen set of rational surfaces
+ranks the applied spectra by how strongly they drive resonant field there: the first right
+singular vector is the **dominant mode**, the spectrum the plasma is most sensitive to, and the
+singular values are coordinate-invariant.
+
+The run always writes the full coupling matrix, so the surface window is an analysis choice
+made afterwards — never a reason to re-run. A `ResonantCoupling` bundles the matrix with the
+labels and normalization needed to evaluate arbitrary applied spectra against it, and is built
+the same way from a finished run in memory or from its `gpec.h5`:
+
+```julia
+using GeneralizedPerturbedEquilibrium.PerturbedEquilibrium
+
+rc = ResonantCoupling("gpec.h5")                 # post hoc; or ResonantCoupling(pe_state, ffs) in memory
+dom = dominant_coupling(rc; psi_low=0.3, psi_high=0.95)   # SVD over the surfaces in the window
+
+b̃ = rootarea_field(rc, coil_modes)               # unit-norm forcing modes → root-area-weighted field
+c = coupling_overlap(dom, b̃)                     # Vᴴ·b̃: c[1] is the overlap with the dominant mode
+dom.singular_values[1] * abs(c[1])               # resonant field the dominant mode drives
+```
+
+`rootarea_field` takes care of the mode ordering and the `R⁻¹` conform between the unit-norm
+convention the forcing loaders and coil integration produce and the b̃ basis the matrix acts on;
+`coupling_overlap` takes care of the conjugation. Singular vectors carry an arbitrary global
+phase, so compare `abs` of overlaps across runs, not the complex value.
+
+As a summary the run also stores the full-window decomposition under
+`PerturbedEquilibrium/SingularCoupling/DominantMode/`, with `forcing_overlap` holding the run's
+own forcing coefficients `Vᴴ·b̃_x`.
+
+```@docs
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.ResonantCoupling
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.DominantCoupling
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.dominant_coupling
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.rootarea_field
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.coupling_overlap
+GeneralizedPerturbedEquilibrium.PerturbedEquilibrium.compute_dominant_coupling!
+```
+
 ## Plotting per-surface results against ψ or q
 
 `SingularCoupling/` quantities are indexed by rational-surface **index**, not by q: with

--- a/docs/src/workflow.md
+++ b/docs/src/workflow.md
@@ -165,6 +165,7 @@ Setting `force_termination = true` in any section stops the pipeline after that 
 Example configuration files are provided in:
 - `examples/Solov'ev_ideal_example/gpec.toml`
 - `examples/DIIID-like_ideal_example/gpec.toml`
+- `examples/DIIID-like_error_field_example/gpec.toml` (coil-forced run with the `[ErrorFields]` sensitivity stage)
 
 ---
 

--- a/examples/DIIID-like_error_field_example/analyze_example.jl
+++ b/examples/DIIID-like_error_field_example/analyze_example.jl
@@ -1,0 +1,61 @@
+using Pkg;
+Pkg.activate(joinpath(@__DIR__, "../.."))
+using GeneralizedPerturbedEquilibrium, Plots, Printf
+using GeneralizedPerturbedEquilibrium: PerturbedEquilibrium, ErrorFields
+isinteractive() ? plotlyjs() : gr()
+
+h5path = joinpath(@__DIR__, "gpec.h5")
+
+# The run stored every coil set's spectrum linearization. Project it onto the dominant
+# resonant-coupling mode twice — over all rational surfaces and over the edge only — to see
+# which coils matter and how much that ranking depends on the window (an analysis choice).
+rc = PerturbedEquilibrium.ResonantCoupling(h5path)
+sens = ErrorFields.CoilSensitivities(h5path)
+full = ErrorFields.sensitivity_table(sens, PerturbedEquilibrium.dominant_coupling(rc))
+edge = ErrorFields.sensitivity_table(sens, PerturbedEquilibrium.dominant_coupling(rc; psi_low=0.7))
+
+names = full.coil_names
+fcoils = findall(startswith("F"), names)
+
+println("coil       |δ_nom|    |∂δ/∂Δ| per mm   |∂δ/∂θ| per 0.1°   curvature")
+for (j, nm) in enumerate(names)
+    @printf("%-8s %10.3e   %12.3e   %14.3e   %9.1e\n", nm, abs(full.delta_nominal[j]), 1e-3 * full.shift_rms[j],
+        0.1 * full.tilt_rms[j], max(maximum(sens.shift_linearity_residual[:, j]), maximum(sens.tilt_linearity_residual[:, j])))
+end
+
+# Error field per millimetre of in-plane shift and per 0.1° of tilt, F coils only. Axisymmetric
+# hoops have no nominal n=1 drive, so the sensitivities are their whole error-field story.
+p_shift = bar(names[fcoils], 1e-3 .* full.shift_rms[fcoils]; label="all rational surfaces", alpha=0.75,
+    ylabel="|∂δ/∂Δ| per mm", title="Dominant-mode error field per mm of F-coil shift", xrotation=45, xticks=(1:length(fcoils), names[fcoils]),
+    left_margin=12Plots.mm, bottom_margin=8Plots.mm, legend=:topright)
+bar!(p_shift, names[fcoils], 1e-3 .* edge.shift_rms[fcoils]; label="ψ_N ≥ 0.7", alpha=0.75)
+p_tilt = bar(names[fcoils], 0.1 .* full.tilt_rms[fcoils]; label="all rational surfaces", alpha=0.75,
+    ylabel="|∂δ/∂θ| per 0.1°", title="Dominant-mode error field per 0.1° of F-coil tilt", xrotation=45, xticks=(1:length(fcoils), names[fcoils]),
+    left_margin=12Plots.mm, bottom_margin=8Plots.mm, legend=:topright)
+bar!(p_tilt, names[fcoils], 0.1 .* edge.tilt_rms[fcoils]; label="ψ_N ≥ 0.7", alpha=0.75)
+p_sens = plot(p_shift, p_tilt; layout=(2, 1), size=(900, 700))
+display(p_sens)
+sens_path = joinpath(@__DIR__, "fcoil_sensitivities.png")
+Plots.savefig(p_sens, sens_path)
+println("Saved: ", abspath(sens_path))
+
+# Where the sensitivity lives in mode space: the spectrum derivative of the most and least
+# sensitive F coils under a 1 mm shift along x, against the C-coil's nominal spectrum.
+step_series(m, a) = (vcat(m[1] - 1, m, m[end] + 1), vcat(0.0, a, 0.0))
+m = sens.m_modes
+order = sortperm(full.shift_rms[fcoils]; rev=true)
+picks = [fcoils[order[1]], fcoils[order[end]]]
+p_spec = plot(; xlabel="poloidal mode m", ylabel="|b̃| [T]", yscale=:log10, legend=:topleft,
+    title="Root-area-weighted spectra: C-coil as built vs F coils shifted 1 mm in x",
+    left_margin=12Plots.mm, bottom_margin=6Plots.mm, size=(900, 420))
+c = findfirst(==("d3d_c"), names)   # file-based sets are named machine_name
+me, ae = step_series(m, max.(abs.(sens.nominal_field[:, c]), 1e-30))
+plot!(p_spec, me, ae; seriestype=:steppre, lw=2, label="C-coil nominal (1 kA)")
+for j in picks
+    me, ae = step_series(m, max.(1e-3 .* abs.(sens.shift_sensitivity[:, 1, j]), 1e-30))
+    plot!(p_spec, me, ae; seriestype=:steppre, lw=2, label="$(names[j]) ∂b̃/∂Δx · 1 mm")
+end
+display(p_spec)
+spec_path = joinpath(@__DIR__, "fcoil_spectra.png")
+Plots.savefig(p_spec, spec_path)
+println("Saved: ", abspath(spec_path))

--- a/examples/DIIID-like_error_field_example/gpec.toml
+++ b/examples/DIIID-like_error_field_example/gpec.toml
@@ -1,0 +1,210 @@
+# DIII-D-like H-mode equilibrium — n=1 error-field sensitivity of the poloidal-field coils.
+# Same free-boundary ideal solve as DIIID-like_ideal_example, with the DIII-D C-coil supplying
+# the nominal n=1 forcing and every F coil (F1A–F9B) added as a single-filament hoop at the
+# centroid of its winding pack, from OpenFUSIONToolkit's TokaMaker DIIID_geom.json. An
+# axisymmetric hoop drives no n=1 field as built, so each F coil's error-field content is
+# entirely its sensitivity to misalignment: the [ErrorFields] stage linearizes every coil set's
+# resonant drive with respect to rigid shifts and tilts, and analyze_example.jl ranks them.
+
+[Equilibrium]
+eq_filename = "../DIIID-like_ideal_example/TkMkr_D3Dlike_Hmode.geqdsk" # Path to equilibrium file
+eq_type = "efit"               # Type of the input 2D equilibrium file
+jac_type = "hamada"            # Coordinate system (hamada, pest, boozer, equal_arc, park, custom)
+grid_type = "auto"             # Radial grid packing type ("auto" = two-pass measured-curvature grid)
+psilow = 1e-4                  # Lower limit of normalized poloidal flux
+psihigh = 0.995                # Upper limit of normalized poloidal flux (captures q=6 at this Ip)
+mpsi = 0                       # Number of radial grid intervals (0 = two-pass auto grid from psi_accuracy)
+psi_accuracy = 0.001           # Target relative accuracy of splined profile derivatives for the auto grid
+mtheta = 256                   # Number of poloidal grid points
+newq0 = 0                      # Target on-axis safety factor q(0) (0 = use input value, -1 = flip axis extrapolation)
+etol = 1e-10                   # Error tolerance for equilibrium solver
+force_termination = false      # Terminate after equilibrium setup (skip stability calculations)
+
+[Wall]
+shape = "nowall"               # Wall shape (nowall, conformal, elliptical, dee, mod_dee, filepath)
+a = 0.2415                     # Distance from plasma (conformal) or shape parameter
+aw = 0.05                      # Half-thickness parameter for Dee-shaped walls
+bw = 1.5                       # Elongation parameter for wall shapes
+cw = 0                         # Offset of wall center from major radius
+dw = 0.5                       # Triangularity parameter for wall shapes
+tw = 0.05                      # Sharpness of wall corners (try 0.05 as initial value)
+equal_arc_wall = true          # Equal arc length distribution of nodes on wall
+
+[ForceFreeStates]
+local_stability_flag = true    # Perform local stability analysis (Mercier and ballooning) across the ψ profile
+vac_flag = true                # Compute plasma, vacuum, and total energies for free-boundary modes
+
+psiedge = 0.99                 # Edge dW(ψ) diagnostic scan band [psiedge, psilim]; set ≥ psilim to disable
+qlow = 1.02                    # Integration initiated at q determined by min(q0, qlow)
+qhigh = 1e3                    # Integration terminated at q limit determined by min(qa, qhigh)
+sing_start = 0                 # Start integration at the sing_start'th rational from the axis (psilow)
+
+nn_low = 1                     # Smallest toroidal mode number to include
+nn_high = 1                    # Largest toroidal mode number to include
+delta_mlow = 8                 # Expands lower bound of Fourier harmonics
+delta_mhigh = 8                # Expands upper bound of Fourier harmonics
+mthvac = 512                   # Number of points used in splines over poloidal angle at the plasma-vacuum interface
+
+kinetic_source = "fixed"       # Kinetic matrix source: "fixed" test matrices, or "calculated" from the kinetic NTV model
+kinetic_factor = 0.0           # Scaling of kinetic matrices (0 = ideal path; >0 enables kinetic mode)
+eulerlagrange_tolerance = 1e-10 # Relative tolerance for ODE integration of Euler-Lagrange equations
+save_interval = 3              # Save every Nth ODE step (1=all). Always saves near rational surfaces.
+singfac_min = 1e-4             # Fractional distance from rational q at which ideal jump enforced
+ucrit = 1e4                    # Column-norm threshold that triggers solution renormalization
+
+# Integrator selection and domain truncation (see ForceFreeStatesControl docstring for details)
+integrator            = "forward" # Integration formalism: "forward" (dense ξ, needed for [PerturbedEquilibrium]/kinetic), "riccati" (chunked propagator BVP, unlocks the singular-surface Δ′ matrix), or "galerkin" (RDCON outer-region singular Galerkin Δ′, with the optional RPEC inner-layer match)
+set_psilim_via_dmlim  = true   # Truncate at (last_rational_q + dmlim)/n — TRUE for diverted equilibria (q → ∞ at separatrix)
+dmlim                 = 0.2    # Truncate integration at (last_rational_q + dmlim)/n (used when set_psilim_via_dmlim = true)
+
+[ForcingTerms]
+forcing_data_format = "coil"            # Format: "ascii", "hdf5", or "coil" (Biot-Savart from 3D wires)
+machine = "d3d"                         # Geometry prefix; resolves to bundled coil_geometries/d3d_*.dat
+mtheta_coil = 480                       # Poloidal grid for boundary B·n̂ evaluation
+nzeta_coil = 32                         # Toroidal grid (0 = auto = 32·n)
+
+[[ForcingTerms.coil_set]]
+name = "c"                              # Coil set; resolves to coil_geometries/d3d_c.dat (DIII-D C-coil, 6 coils): the nominal n=1 source
+currents = [1000.0, 500.0, -500.0, -1000.0, -500.0, 500.0]  # n=1 cosine phasing, 1 kA peak [A]
+
+[[ForcingTerms.coil_set]]
+name = "F1A"                            # DIII-D F coil F1A: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 0.8608                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = 0.1683                         # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F2A"                            # DIII-D F coil F2A: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 0.8614                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = 0.5081                         # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F3A"                            # DIII-D F coil F3A: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 0.8628                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = 0.8491                         # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F4A"                            # DIII-D F coil F4A: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 0.8611                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = 1.1899                         # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F5A"                            # DIII-D F coil F5A: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 1.0041                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = 1.5169                         # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F6A"                            # DIII-D F coil F6A: 55-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 2.6124                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = 0.4376                         # Hoop height: centroid Z of the pack cross-section [m]
+currents = [55000.0]                    # 1 kA per turn × 55 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F7A"                            # DIII-D F coil F7A: 55-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 2.3733                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = 1.1171                         # Hoop height: centroid Z of the pack cross-section [m]
+currents = [55000.0]                    # 1 kA per turn × 55 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F8A"                            # DIII-D F coil F8A: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 1.2518                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = 1.6019                         # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F9A"                            # DIII-D F coil F9A: 55-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 1.6890                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = 1.5874                         # Hoop height: centroid Z of the pack cross-section [m]
+currents = [55000.0]                    # 1 kA per turn × 55 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F1B"                            # DIII-D F coil F1B: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 0.8608                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = -0.1737                        # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F2B"                            # DIII-D F coil F2B: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 0.8607                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = -0.5135                        # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F3B"                            # DIII-D F coil F3B: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 0.8610                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = -0.8543                        # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F4B"                            # DIII-D F coil F4B: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 0.8630                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = -1.1957                        # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F5B"                            # DIII-D F coil F5B: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 1.0025                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = -1.5169                        # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F6B"                            # DIII-D F coil F6B: 55-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 2.6124                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = -0.4376                        # Hoop height: centroid Z of the pack cross-section [m]
+currents = [55000.0]                    # 1 kA per turn × 55 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F7B"                            # DIII-D F coil F7B: 55-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 2.3834                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = -1.1171                        # Hoop height: centroid Z of the pack cross-section [m]
+currents = [55000.0]                    # 1 kA per turn × 55 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F8B"                            # DIII-D F coil F8B: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 1.2524                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = -1.6027                        # Hoop height: centroid Z of the pack cross-section [m]
+currents = [58000.0]                    # 1 kA per turn × 58 turns; sensitivities scale linearly with current [A]
+
+[[ForcingTerms.coil_set]]
+name = "F9B"                            # DIII-D F coil F9B: 55-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
+source = "pf_hoop"                      # Single-filament horizontal hoop approximation of the winding pack
+radius = 1.6889                         # Hoop major radius: centroid R of the pack cross-section [m]
+height = -1.5780                        # Hoop height: centroid Z of the pack cross-section [m]
+currents = [55000.0]                    # 1 kA per turn × 55 turns; sensitivities scale linearly with current [A]
+
+[PerturbedEquilibrium]
+fixed_boundary = false                  # Use fixed boundary conditions
+output_eigenmodes = true                # Output eigenmode fields as b-fields
+compute_response = true                 # Compute plasma response to forcing
+compute_singular_coupling = true        # Compute singular layer coupling metrics
+verbose = false                         # Enable verbose logging
+write_outputs_to_HDF5 = true            # Write perturbed equilibrium outputs to HDF5
+reg_spot = 0.05                         # Regularization width for singular surfaces (0 = disabled)
+
+[ErrorFields]
+fd_step_shift_m = 1e-3                  # Central-difference step for the rigid shifts [m]
+fd_step_tilt_deg = 0.1                  # Central-difference step for the rigid tilts [degrees]
+rotation_center = "conductor"           # Tilt pivot: each conductor's own centre ("conductor") or the whole set's ("set")
+write_outputs_to_HDF5 = true            # Write ErrorFields/CoilSensitivities/ to the output file
+verbose = true                          # Log per-coil-set progress and linearity diagnostics

--- a/examples/DIIID-like_error_field_example/run_example.jl
+++ b/examples/DIIID-like_error_field_example/run_example.jl
@@ -1,0 +1,4 @@
+using Pkg;
+Pkg.activate(joinpath(@__DIR__, "../.."))
+using GeneralizedPerturbedEquilibrium
+GeneralizedPerturbedEquilibrium.main([dirname(@__FILE__)])

--- a/examples/DIIID-like_ideal_example/gpec.toml
+++ b/examples/DIIID-like_ideal_example/gpec.toml
@@ -73,6 +73,13 @@ verbose = true                          # Enable verbose logging
 write_outputs_to_HDF5 = true            # Write perturbed equilibrium outputs to HDF5
 reg_spot = 0.05                         # Regularization width for singular surfaces (0 = disabled)
 
+[ErrorFields]
+fd_step_shift_m = 1e-3                  # Central-difference step for the rigid shifts [m]
+fd_step_tilt_deg = 0.1                  # Central-difference step for the rigid tilts [degrees]
+rotation_center = "conductor"           # Tilt pivot: each conductor's own centre ("conductor") or the whole set's ("set")
+write_outputs_to_HDF5 = true            # Write ErrorFields/CoilSensitivities/ to the output file
+verbose = true                          # Log per-coil-set progress and linearity diagnostics
+
 [KineticForces]
 kinetic_file = "TkMkr_D3Dlike_Hmode_kinetic.h5"  # GPEC HDF5 kinetic schema (psi,n_i,n_e,T_i,T_e,omega_E,+chi_e,chi_phi). Legacy .gpeckf/.kin still readable.
 nn = 1                                  # Toroidal mode number (matches nn_low/nn_high)

--- a/regression-harness/cases/diiid_n1.toml
+++ b/regression-harness/cases/diiid_n1.toml
@@ -303,6 +303,25 @@ extract = "all_complex"
 label = "resonant area-weighted field b^r"
 noise_threshold = 1e-8
 
+# Dominant resonant-coupling mode: singular values of the b̃-space coupling matrix over every
+# rational surface (coordinate-invariant), and the applied forcing's magnitude on the dominant
+# mode. Singular vectors carry an arbitrary phase, so only the magnitude is tracked.
+[quantities.dominant_singular_values]
+h5path = "PerturbedEquilibrium/SingularCoupling/DominantMode/singular_values"
+type = "real_vector"
+extract = "all_real"
+label = "dominant-coupling singular values"
+noise_threshold = 1e-8
+order = 84
+
+[quantities.dominant_forcing_overlap]
+h5path = "PerturbedEquilibrium/SingularCoupling/DominantMode/forcing_overlap"
+type = "complex_vector"
+extract = "abs_first"
+label = "|forcing overlap with dominant mode|"
+noise_threshold = 1e-8
+order = 85
+
 # Perturbed equilibrium: energies
 [quantities.pe_plasma_energy]
 h5path = "PerturbedEquilibrium/Energies/plasma_energy"

--- a/regression-harness/cases/diiid_n1.toml
+++ b/regression-harness/cases/diiid_n1.toml
@@ -422,6 +422,34 @@ label = "ballooning Delta' profile (checksum)"
 noise_threshold = 0
 order = 74
 
+# Error fields — per-coil-set overlap with the full-window dominant mode and its rigid shift/tilt
+# sensitivities. Singular vectors carry an arbitrary phase, so only magnitudes are tracked; the
+# in-plane components of a whole n=1-phased array vanish by symmetry, so the norms track the
+# vertical shift and axial tilt that survive.
+[quantities.ef_delta_nominal]
+h5path = "ErrorFields/CoilSensitivities/DominantMode/delta_nominal"
+type = "complex_vector"
+extract = "abs_first"
+label = "|delta_nominal| of coil set 1"
+noise_threshold = 1e-10
+order = 86
+
+[quantities.ef_shift_sensitivity]
+h5path = "ErrorFields/CoilSensitivities/DominantMode/shift_sensitivity"
+type = "complex_vector"
+extract = "norm"
+label = "||ddelta/d(shift)|| over coil sets"
+noise_threshold = 1e-10
+order = 87
+
+[quantities.ef_tilt_sensitivity]
+h5path = "ErrorFields/CoilSensitivities/DominantMode/tilt_sensitivity"
+type = "complex_vector"
+extract = "norm"
+label = "||ddelta/d(tilt)|| over coil sets"
+noise_threshold = 1e-10
+order = 88
+
 # Runtime
 [quantities.runtime]
 h5path = ""

--- a/src/ErrorFields/ErrorFields.jl
+++ b/src/ErrorFields/ErrorFields.jl
@@ -1,0 +1,44 @@
+module ErrorFields
+
+"""
+ErrorFields - Error-field sensitivity of a perturbed equilibrium to coil misalignment
+
+Given one perturbed-equilibrium solve and its coil sets, the module linearizes the resonant
+drive of each named coil set with respect to its rigid-body degrees of freedom, so that any
+tolerance question downstream (Monte Carlo over manufacturing tolerances, locking risk,
+allowable-tolerance scans) reduces to cheap linear algebra on a small table instead of a new
+plasma solve or a new Biot-Savart integration.
+
+## Module Structure
+
+- `ErrorFieldsStructs.jl`: `ErrorFieldsControl` (the `[ErrorFields]` TOML section),
+  `CoilSensitivities` (the cached linearization: nominal spectra and their derivatives),
+  `SensitivityTable` (that linearization projected onto one dominant coupling mode)
+- `Sensitivity.jl`: `compute_coil_sensitivities` (central-difference sweep of every rigid
+  shift and tilt of every coil set on one shared boundary grid), `sensitivity_table`
+- `Output.jl`: HDF5 writer under `ErrorFields/CoilSensitivities/` and the matching reader
+
+The stored primitive is the derivative of each coil set's root-area-weighted control-surface
+spectrum b̃, not a scalar: the overlap with any dominant mode is linear in b̃, so the ψ_N window,
+the mode index, and the field normalization stay post-hoc analysis choices.
+"""
+
+using LinearAlgebra
+using HDF5
+using Printf
+
+import ..Equilibrium
+import ..ForcingTerms
+import ..ForcingTerms: CoilSet, CoilSetConfig, CoilConfig, ForcingMode, CoilForcingGrid, coil_forcing_modes, apply_transforms
+import ..PerturbedEquilibrium
+import ..PerturbedEquilibrium: ResonantCoupling, DominantCoupling, dominant_coupling, rootarea_field, coupling_overlap
+import ..Utilities
+
+include("ErrorFieldsStructs.jl")
+include("Sensitivity.jl")
+include("Output.jl")
+
+export ErrorFieldsControl, CoilSensitivities, SensitivityTable
+export compute_coil_sensitivities, sensitivity_table, cancelling_offset
+
+end # module ErrorFields

--- a/src/ErrorFields/ErrorFieldsStructs.jl
+++ b/src/ErrorFields/ErrorFieldsStructs.jl
@@ -1,0 +1,107 @@
+"""
+    ErrorFieldsControl
+
+Control parameters for the `[ErrorFields]` TOML section. The sweep needs a coil-forced
+perturbed-equilibrium solve (`forcing_data_format = "coil"` with the singular-coupling step on);
+everything here concerns only how the coil linearization is taken and where it is written.
+Analysis choices (which resonant surfaces count, which singular mode, which normalization) are
+never inputs: the full spectra are stored and projected post hoc with [`sensitivity_table`](@ref).
+
+## Fields
+
+  - `fd_step_shift_m`: central-difference step for the rigid shifts, in metres
+  - `fd_step_tilt_deg`: central-difference step for the rigid tilts, in degrees
+  - `rotation_center`: pivot of the tilt taps — `"conductor"` rotates every conductor of a set
+    about its own arc-length centre (the Fortran `coil_read` convention the OMFIT tolerance tool
+    inherited), `"set"` rotates the whole set rigidly about its common arc-length centre (a
+    winding pack moving as one body, which is what an axis-line tolerance constrains)
+  - `output_filename`: HDF5 file the results are appended to; empty means the run's main output
+  - `write_outputs_to_HDF5`: write `ErrorFields/CoilSensitivities/` when true
+  - `verbose`: log per-coil-set progress and the linearity diagnostics
+"""
+Base.@kwdef struct ErrorFieldsControl
+    fd_step_shift_m::Float64 = 1e-3
+    fd_step_tilt_deg::Float64 = 0.1
+    rotation_center::String = "conductor"
+    output_filename::String = ""
+    write_outputs_to_HDF5::Bool = true
+    verbose::Bool = false
+end
+
+"""
+    CoilSensitivities
+
+Linearization of each coil set's control-surface spectrum with respect to its six rigid-body
+degrees of freedom, on the (m, n) column ordering of the [`ResonantCoupling`](@ref) it was built
+against. Spectra are root-area-weighted fields b̃ in tesla, the vector the coupling matrix and
+its singular vectors act on, so projecting any of them onto a mode is one inner product.
+
+Shifts are Cartesian translations of the whole set; tilts are rotations about the machine
+x, y, z axes through the pivot selected by `ErrorFieldsControl.rotation_center`. A coil set's
+spectrum is proportional to its currents, so the table is specific to the current pattern it
+was evaluated with; `peak_current` and `winding_multiplier` let a user renormalize per ampere-turn.
+
+## Fields
+
+  - `coil_names`: name of each coil set `[ncoil_set]`
+  - `m_modes`, `n_modes`: poloidal and toroidal mode number of each spectrum entry `[numpert_total]`
+  - `b_t0`: toroidal field magnitude on axis, tesla — the normalization that makes the overlap a
+    dimensionless δ
+  - `nominal_field`: b̃ of each set as built, tesla `[numpert_total × ncoil_set]`
+  - `shift_sensitivity`: ∂b̃/∂(Δx, Δy, Δz), tesla per metre `[numpert_total × 3 × ncoil_set]`
+  - `tilt_sensitivity`: ∂b̃/∂(θx, θy, θz), tesla per degree `[numpert_total × 3 × ncoil_set]`
+  - `shift_linearity_residual`, `tilt_linearity_residual`: ‖b̃(+h) + b̃(−h) − 2b̃(0)‖ relative to
+    ‖b̃(+h) − b̃(−h)‖ for each tap, a window-independent measure of how linear the response is at
+    the step taken `[3 × ncoil_set]`
+  - `peak_current`: largest conductor current magnitude of each set, amperes `[ncoil_set]`
+  - `winding_multiplier`: turns per conductor element of each set `[ncoil_set]`
+"""
+struct CoilSensitivities
+    coil_names::Vector{String}
+    m_modes::Vector{Int}
+    n_modes::Vector{Int}
+    b_t0::Float64
+    nominal_field::Matrix{ComplexF64}
+    shift_sensitivity::Array{ComplexF64,3}
+    tilt_sensitivity::Array{ComplexF64,3}
+    shift_linearity_residual::Matrix{Float64}
+    tilt_linearity_residual::Matrix{Float64}
+    peak_current::Vector{Float64}
+    winding_multiplier::Vector{Float64}
+end
+
+"""
+    SensitivityTable
+
+A [`CoilSensitivities`](@ref) projected onto one singular mode of a [`DominantCoupling`](@ref)
+and normalized by the axis toroidal field: the dimensionless overlap δ of each coil set and its
+derivatives, which is all a tolerance Monte Carlo consumes. Built by [`sensitivity_table`](@ref).
+
+With `S = (S_x, S_y)` the in-plane shift sensitivities, a rigid shift `(Δx, Δy)` moves the overlap
+by `S_x·Δx + S_y·Δy`; the same holds for the tilts. Singular vectors carry an arbitrary phase, so
+only magnitudes and relative phases within one table are meaningful.
+
+## Fields
+
+  - `coil_names`: name of each coil set `[ncoil_set]`
+  - `mode`: index of the singular mode projected onto (1 is the dominant mode)
+  - `delta_nominal`: overlap of each set as built `[ncoil_set]`
+  - `shift`: ∂δ/∂(Δx, Δy, Δz), per metre `[3 × ncoil_set]`
+  - `tilt`: ∂δ/∂(θx, θy, θz), per degree `[3 × ncoil_set]`
+  - `shift_rms`, `tilt_rms`: direction-averaged in-plane magnitude `√((|S_x|² + |S_y|²)/2)` of the
+    shift and tilt sensitivities `[ncoil_set]` — the single-number sensitivity the OMFIT tool used
+  - `cancelling_shift`: the in-plane shift `(Δx, Δy)` that cancels `delta_nominal`, metres
+    `[2 × ncoil_set]`, see [`cancelling_offset`](@ref)
+  - `cancelling_tilt`: the in-plane tilt `(θx, θy)` that cancels `delta_nominal`, degrees `[2 × ncoil_set]`
+"""
+struct SensitivityTable
+    coil_names::Vector{String}
+    mode::Int
+    delta_nominal::Vector{ComplexF64}
+    shift::Matrix{ComplexF64}
+    tilt::Matrix{ComplexF64}
+    shift_rms::Vector{Float64}
+    tilt_rms::Vector{Float64}
+    cancelling_shift::Matrix{Float64}
+    cancelling_tilt::Matrix{Float64}
+end

--- a/src/ErrorFields/ErrorFieldsStructs.jl
+++ b/src/ErrorFields/ErrorFieldsStructs.jl
@@ -50,8 +50,9 @@ was evaluated with; `peak_current` and `winding_multiplier` let a user renormali
   - `nominal_field`: b̃ of each set as built, tesla `[numpert_total × ncoil_set]`
   - `shift_sensitivity`: ∂b̃/∂(Δx, Δy, Δz), tesla per metre `[numpert_total × 3 × ncoil_set]`
   - `tilt_sensitivity`: ∂b̃/∂(θx, θy, θz), tesla per degree `[numpert_total × 3 × ncoil_set]`
-  - `shift_linearity_residual`, `tilt_linearity_residual`: ‖b̃(+h) + b̃(−h) − 2b̃(0)‖ relative to
-    ‖b̃(+h) − b̃(−h)‖ for each tap, a window-independent measure of how linear the response is at
+  - `shift_linearity_residual`, `tilt_linearity_residual`: ‖b̃(+h) + b̃(−h) − 2b̃(0)‖ of each tap
+    relative to the set's largest first difference ‖b̃(+h) − b̃(−h)‖ over all six taps, a
+    window-independent measure of how much second-order response the linearization drops at
     the step taken `[3 × ncoil_set]`
   - `peak_current`: largest conductor current magnitude of each set, amperes `[ncoil_set]`
   - `winding_multiplier`: turns per conductor element of each set `[ncoil_set]`

--- a/src/ErrorFields/Output.jl
+++ b/src/ErrorFields/Output.jl
@@ -15,8 +15,10 @@ const EF_H5_ANNOTATIONS = [
     "nominal_field" => (; long_name="root-area-weighted control-surface field b̃ of each coil set as built", units="T", dims=("mode", "coil_set")),
     "shift_sensitivity" => (; long_name="∂b̃/∂(Δx, Δy, Δz) of each coil set under a rigid Cartesian shift", units="T/m", dims=("mode", "axis", "coil_set")),
     "tilt_sensitivity" => (; long_name="∂b̃/∂(θx, θy, θz) of each coil set under a rigid rotation about the machine axes", units="T/deg", dims=("mode", "axis", "coil_set")),
-    "shift_linearity_residual" => (; long_name="finite-difference curvature ‖b̃(+h)+b̃(−h)−2b̃(0)‖/‖b̃(+h)−b̃(−h)‖ of each shift tap", dims=("axis", "coil_set")),
-    "tilt_linearity_residual" => (; long_name="finite-difference curvature ‖b̃(+h)+b̃(−h)−2b̃(0)‖/‖b̃(+h)−b̃(−h)‖ of each tilt tap", dims=("axis", "coil_set")),
+    "shift_linearity_residual" =>
+        (; long_name="finite-difference curvature ‖b̃(+h)+b̃(−h)−2b̃(0)‖ of each shift tap relative to the set's largest first difference", dims=("axis", "coil_set")),
+    "tilt_linearity_residual" =>
+        (; long_name="finite-difference curvature ‖b̃(+h)+b̃(−h)−2b̃(0)‖ of each tilt tap relative to the set's largest first difference", dims=("axis", "coil_set")),
     "peak_current" => (; long_name="largest conductor current magnitude of each coil set at which the spectra were evaluated", units="A"),
     "winding_multiplier" => (; long_name="turns per conductor element of each coil set"),
     "DominantMode/delta_nominal" => (; long_name="overlap δ = Vᴴ₁·b̃ / B_T0 of each coil set with the full-window dominant mode"),

--- a/src/ErrorFields/Output.jl
+++ b/src/ErrorFields/Output.jl
@@ -1,0 +1,85 @@
+"""
+    Output
+
+HDF5 output for the ErrorFields coil linearization, under `ErrorFields/CoilSensitivities/`,
+and the reader that rebuilds a `CoilSensitivities` from it.
+"""
+
+const _H5_GROUP = "ErrorFields/CoilSensitivities"
+
+# Metadata table for ErrorFields/CoilSensitivities/ (paths relative to the group). Spectra are
+# root-area-weighted control-surface fields b̃ on the Info/mn_index ordering; the DominantMode/
+# summary is the full-window mode-1 projection, the windowed table being a post-hoc analysis.
+const EF_H5_ANNOTATIONS = [
+    "coil_name" => (; long_name="name of each coil set"),
+    "nominal_field" => (; long_name="root-area-weighted control-surface field b̃ of each coil set as built", units="T", dims=("mode", "coil_set")),
+    "shift_sensitivity" => (; long_name="∂b̃/∂(Δx, Δy, Δz) of each coil set under a rigid Cartesian shift", units="T/m", dims=("mode", "axis", "coil_set")),
+    "tilt_sensitivity" => (; long_name="∂b̃/∂(θx, θy, θz) of each coil set under a rigid rotation about the machine axes", units="T/deg", dims=("mode", "axis", "coil_set")),
+    "shift_linearity_residual" => (; long_name="finite-difference curvature ‖b̃(+h)+b̃(−h)−2b̃(0)‖/‖b̃(+h)−b̃(−h)‖ of each shift tap", dims=("axis", "coil_set")),
+    "tilt_linearity_residual" => (; long_name="finite-difference curvature ‖b̃(+h)+b̃(−h)−2b̃(0)‖/‖b̃(+h)−b̃(−h)‖ of each tilt tap", dims=("axis", "coil_set")),
+    "peak_current" => (; long_name="largest conductor current magnitude of each coil set at which the spectra were evaluated", units="A"),
+    "winding_multiplier" => (; long_name="turns per conductor element of each coil set"),
+    "DominantMode/delta_nominal" => (; long_name="overlap δ = Vᴴ₁·b̃ / B_T0 of each coil set with the full-window dominant mode"),
+    "DominantMode/shift_sensitivity" => (; long_name="∂δ/∂(Δx, Δy, Δz) on the full-window dominant mode", units="1/m", dims=("axis", "coil_set")),
+    "DominantMode/tilt_sensitivity" => (; long_name="∂δ/∂(θx, θy, θz) on the full-window dominant mode", units="1/deg", dims=("axis", "coil_set")),
+    "DominantMode/shift_rms" => (; long_name="direction-averaged in-plane shift sensitivity √((|∂δ/∂Δx|²+|∂δ/∂Δy|²)/2)", units="1/m"),
+    "DominantMode/tilt_rms" => (; long_name="direction-averaged in-plane tilt sensitivity √((|∂δ/∂θx|²+|∂δ/∂θy|²)/2)", units="1/deg"),
+    "DominantMode/cancelling_shift" => (; long_name="in-plane shift (Δx, Δy) that cancels delta_nominal to linear order", units="m", dims=("axis", "coil_set")),
+    "DominantMode/cancelling_tilt" => (; long_name="in-plane tilt (θx, θy) that cancels delta_nominal to linear order", units="deg", dims=("axis", "coil_set"))
+]
+
+"""
+    write_to_hdf5!(h5file::HDF5.File, sens::CoilSensitivities, dom::DominantCoupling)
+
+Write the coil linearization to `ErrorFields/CoilSensitivities/` — the spectra and their
+derivatives, plus a `DominantMode/` summary projected onto mode 1 of `dom` (the run's
+full-window decomposition). An existing group is replaced. The mode labels are the file's
+`Info/mn_index` and the field normalization its `Equilibrium/B_T_axis`, neither duplicated here.
+"""
+function write_to_hdf5!(h5file::HDF5.File, sens::CoilSensitivities, dom::DominantCoupling)
+    haskey(h5file, _H5_GROUP) && delete_object(h5file, _H5_GROUP)
+    g = create_group(h5file, _H5_GROUP)
+    g["coil_name"] = sens.coil_names
+    g["nominal_field"] = sens.nominal_field
+    g["shift_sensitivity"] = sens.shift_sensitivity
+    g["tilt_sensitivity"] = sens.tilt_sensitivity
+    g["shift_linearity_residual"] = sens.shift_linearity_residual
+    g["tilt_linearity_residual"] = sens.tilt_linearity_residual
+    g["peak_current"] = sens.peak_current
+    g["winding_multiplier"] = sens.winding_multiplier
+
+    table = sensitivity_table(sens, dom; mode=1)
+    d = create_group(g, "DominantMode")
+    d["delta_nominal"] = table.delta_nominal
+    d["shift_sensitivity"] = table.shift
+    d["tilt_sensitivity"] = table.tilt
+    d["shift_rms"] = table.shift_rms
+    d["tilt_rms"] = table.tilt_rms
+    d["cancelling_shift"] = table.cancelling_shift
+    d["cancelling_tilt"] = table.cancelling_tilt
+
+    Utilities.HDF5Annotations.annotate!(g, EF_H5_ANNOTATIONS)
+    return g
+end
+
+"""
+    CoilSensitivities(h5path::AbstractString)
+
+Read the coil linearization back from a `gpec.h5` written with an `[ErrorFields]` section, with
+the mode labels from `Info/mn_index` and the normalization field from `Equilibrium/B_T_axis`.
+"""
+function CoilSensitivities(h5path::AbstractString)
+    h5open(h5path, "r") do f
+        haskey(f, _H5_GROUP) || throw(ArgumentError("$h5path has no $_H5_GROUP group (run with an [ErrorFields] section)"))
+        haskey(f, "Info/mn_index") || throw(ArgumentError("$h5path has no Info/mn_index mode labels"))
+        haskey(f, "Equilibrium/B_T_axis") || throw(ArgumentError("$h5path has no Equilibrium/B_T_axis"))
+        g = f[_H5_GROUP]
+        mn = read(f["Info/mn_index"])
+        return CoilSensitivities(
+            read(g["coil_name"]), mn[:, 1], mn[:, 2], Float64(read(f["Equilibrium/B_T_axis"])),
+            read(g["nominal_field"]), read(g["shift_sensitivity"]), read(g["tilt_sensitivity"]),
+            read(g["shift_linearity_residual"]), read(g["tilt_linearity_residual"]),
+            read(g["peak_current"]), read(g["winding_multiplier"])
+        )
+    end
+end

--- a/src/ErrorFields/Sensitivity.jl
+++ b/src/ErrorFields/Sensitivity.jl
@@ -1,0 +1,193 @@
+"""
+    compute_coil_sensitivities(coil_sets, rc, equil, cfg, ctrl=ErrorFieldsControl(); psi, b_t0) -> CoilSensitivities
+
+Linearize the control-surface spectrum of every coil set in `coil_sets` with respect to its six
+rigid-body degrees of freedom, by central differences of the Biot-Savart spectrum on the surface
+`psi` (the solve's integration limit, `ffs.psilim`) sampled once per toroidal mode of `rc`.
+The nominal spectrum is evaluated too, so the sum over sets reproduces the run's forcing when
+these are the run's coils.
+
+Shift taps translate the whole set rigidly; tilt taps rotate it about the pivot named by
+`ctrl.rotation_center`, in degrees. `cfg` supplies the boundary-grid resolution, `b_t0` the
+axis toroidal field (tesla) stored for the δ normalization. Errors on a set carrying no
+current, whose linearization would vanish identically.
+
+The spectra are placed on `rc`'s (m, n) ordering and conformed to root-area-weighted field with
+[`rootarea_field`](@ref), so [`coupling_overlap`](@ref) applies to them directly. Post-hoc use
+from a `gpec.h5` goes through the `compute_coil_sensitivities(h5path, coil_sets; kwargs...)`
+method.
+"""
+function compute_coil_sensitivities(
+    coil_sets::Vector{CoilSet},
+    rc::ResonantCoupling,
+    equil::Equilibrium.PlasmaEquilibrium,
+    cfg::CoilConfig,
+    ctrl::ErrorFieldsControl=ErrorFieldsControl();
+    psi::Float64,
+    b_t0::Float64
+)
+    isempty(coil_sets) && throw(ArgumentError("compute_coil_sensitivities: no coil sets given"))
+    ctrl.rotation_center in ("conductor", "set") ||
+        throw(ArgumentError("rotation_center must be \"conductor\" or \"set\" (got \"$(ctrl.rotation_center)\")"))
+    (ctrl.fd_step_shift_m > 0 && ctrl.fd_step_tilt_deg > 0) ||
+        throw(ArgumentError("finite-difference steps must be positive (got $(ctrl.fd_step_shift_m) m, $(ctrl.fd_step_tilt_deg) deg)"))
+    b_t0 > 0 || throw(ArgumentError("b_t0 must be a positive field magnitude (got $b_t0)"))
+    for cs in coil_sets
+        all(iszero, cs.currents) &&
+            throw(ArgumentError("coil set \"$(cs.name)\" carries no current; its spectrum and sensitivities would vanish identically"))
+    end
+
+    N = length(rc.m_modes)
+    nset = length(coil_sets)
+    m_low, m_high = extrema(rc.m_modes)
+    grids = [(n, CoilForcingGrid(equil, cfg, n; psi)) for n in sort(unique(rc.n_modes))]
+
+    # One Biot-Savart pass per coil-set geometry, every toroidal mode on its own grid, placed
+    # and conformed to b̃ on rc's column ordering.
+    function spectrum(cs::CoilSet)
+        modes = ForcingMode[]
+        for (n, grid) in grids
+            append!(modes, coil_forcing_modes(cs, grid, n, m_low, m_high))
+        end
+        return rootarea_field(rc, modes)
+    end
+
+    nominal = zeros(ComplexF64, N, nset)
+    shift = zeros(ComplexF64, N, 3, nset)
+    tilt = zeros(ComplexF64, N, 3, nset)
+    shift_resid = zeros(3, nset)
+    tilt_resid = zeros(3, nset)
+    h_shift = ctrl.fd_step_shift_m
+    h_tilt = ctrl.fd_step_tilt_deg
+
+    for (j, cs) in enumerate(coil_sets)
+        t_start = time()
+        b0 = spectrum(cs)
+        nominal[:, j] = b0
+        pivot = ctrl.rotation_center == "set" ? _set_center(cs) : nothing
+
+        first_norm = zeros(3, 2)
+        second_norm = zeros(3, 2)
+        for axis in 1:3, (kind, h, out) in ((:shift, h_shift, shift), (:tilt, h_tilt, tilt))
+            plus = spectrum(_rigidly_perturbed(cs, kind, axis, h, pivot))
+            minus = spectrum(_rigidly_perturbed(cs, kind, axis, -h, pivot))
+            out[:, axis, j] = (plus .- minus) ./ (2h)
+            col = kind === :shift ? 1 : 2
+            first_norm[axis, col] = norm(plus .- minus)
+            second_norm[axis, col] = norm(plus .+ minus .- 2 .* b0)
+        end
+
+        # A tap the set cannot feel (a vertical shift of an axisymmetric hoop at n ≥ 1) has a
+        # first difference at round-off; measure its curvature against the set's largest tap
+        # instead of dividing noise by noise.
+        floor = 1e-6 * maximum(first_norm)
+        resid = floor > 0 ? second_norm ./ max.(first_norm, floor) : zeros(3, 2)
+        shift_resid[:, j] = resid[:, 1]
+        tilt_resid[:, j] = resid[:, 2]
+
+        worst = maximum(resid)
+        worst > 1e-2 &&
+            @warn "Coil set \"$(cs.name)\": finite-difference curvature $(@sprintf("%.2e", worst)) of the first difference; reduce fd_step_shift_m / fd_step_tilt_deg"
+        ctrl.verbose &&
+            @info "  $(cs.name): |b̃| = $(@sprintf("%.3e", norm(b0))) T, max |∂b̃/∂x| = $(@sprintf("%.3e", maximum(norm, eachslice(shift[:, :, j]; dims=2)))) T/m, " *
+                  "max |∂b̃/∂θ| = $(@sprintf("%.3e", maximum(norm, eachslice(tilt[:, :, j]; dims=2)))) T/deg, curvature $(@sprintf("%.1e", worst)) ($(@sprintf("%.2f", time() - t_start)) s)"
+    end
+
+    return CoilSensitivities(
+        [cs.name for cs in coil_sets], copy(rc.m_modes), copy(rc.n_modes), b_t0,
+        nominal, shift, tilt, shift_resid, tilt_resid,
+        [maximum(abs, cs.currents) for cs in coil_sets], [cs.nw for cs in coil_sets]
+    )
+end
+
+"""
+    _rigidly_perturbed(cs, kind, axis, h, pivot) -> CoilSet
+
+The coil set moved rigidly by `h` along one degree of freedom: `kind = :shift` translates every
+conductor by `h` metres along `axis` (x, y, z); `kind = :tilt` rotates every conductor by `h`
+degrees about `axis` through `pivot`, or about its own arc-length centre when `pivot === nothing`.
+Both go through `apply_transforms` with the toroidal modulation that makes the motion rigid
+(`n_tilt = 0` for the shift, `n_tilt = 1` for the tilt).
+"""
+function _rigidly_perturbed(cs::CoilSet, kind::Symbol, axis::Int, h::Real, pivot)
+    per_conductor = fill(Float64(h), cs.ncoil)
+    component(a) = a == axis ? per_conductor : Float64[]
+    if kind === :shift
+        cfg = CoilSetConfig(; shiftx=component(1), shifty=component(2), shiftz=component(3))
+        return apply_transforms(cs, cfg; n_tilt=0)
+    end
+    nom(i) = pivot === nothing ? Float64[] : fill(pivot[i], cs.ncoil)
+    cfg = CoilSetConfig(; tiltx=component(1), tilty=component(2), tiltz=component(3),
+        xnom=nom(1), ynom=nom(2), znom=nom(3), tilt_in_meters=false)
+    return apply_transforms(cs, cfg; n_tilt=1)
+end
+
+"""
+    _set_center(cs::CoilSet) -> (x0, y0, z0)
+
+Arc-length-weighted centre of the whole coil set, over every conductor and strand: the pivot of
+a rigid tilt of a multi-filament winding pack.
+"""
+function _set_center(cs::CoilSet)
+    total = 0.0
+    cx = cy = cz = 0.0
+    for j in 1:cs.ncoil, k in 1:cs.s, l in 1:(cs.nsec-1)
+        dl = hypot(cs.x[j, k, l+1] - cs.x[j, k, l], cs.y[j, k, l+1] - cs.y[j, k, l], cs.z[j, k, l+1] - cs.z[j, k, l])
+        cx += dl * (cs.x[j, k, l] + cs.x[j, k, l+1]) / 2
+        cy += dl * (cs.y[j, k, l] + cs.y[j, k, l+1]) / 2
+        cz += dl * (cs.z[j, k, l] + cs.z[j, k, l+1]) / 2
+        total += dl
+    end
+    total > 0 || return (0.0, 0.0, 0.0)
+    return (cx / total, cy / total, cz / total)
+end
+
+"""
+    sensitivity_table(sens::CoilSensitivities, dom::DominantCoupling; mode=1) -> SensitivityTable
+    sensitivity_table(h5path; psi_low=0.0, psi_high=1.0, mode=1) -> SensitivityTable
+
+Project a coil linearization onto singular mode `mode` of `dom` and normalize by the axis
+toroidal field: `δ = dot(V[:, mode], b̃) / B_T0` for the nominal spectrum and each derivative,
+the dimensionless overlap and its sensitivities per coil set. The window and mode are analysis
+choices, so re-evaluate freely on the same `sens`; the file form rebuilds the coupling from
+`gpec.h5`, windows it to `psi_low ≤ ψ_N ≤ psi_high`, and reads the stored linearization.
+"""
+function sensitivity_table(sens::CoilSensitivities, dom::DominantCoupling; mode::Int=1)
+    1 <= mode <= length(dom.singular_values) ||
+        throw(ArgumentError("mode $mode is outside the $(length(dom.singular_values)) singular modes of the decomposition"))
+    size(dom.right_singular_vectors, 1) == length(sens.m_modes) ||
+        throw(DimensionMismatch("the decomposition acts on $(size(dom.right_singular_vectors, 1)) modes but the sensitivities carry $(length(sens.m_modes))"))
+    v = dom.right_singular_vectors[:, mode]
+    project(b̃) = dot(v, b̃) / sens.b_t0
+    nset = length(sens.coil_names)
+
+    delta_nominal = [project(view(sens.nominal_field, :, j)) for j in 1:nset]
+    shift = [project(view(sens.shift_sensitivity, :, a, j)) for a in 1:3, j in 1:nset]
+    tilt = [project(view(sens.tilt_sensitivity, :, a, j)) for a in 1:3, j in 1:nset]
+    inplane_rms(S) = [sqrt((abs2(S[1, j]) + abs2(S[2, j])) / 2) for j in 1:nset]
+    cancelling(S) = [cancelling_offset(delta_nominal[j], S[1, j], S[2, j])[i] for i in 1:2, j in 1:nset]
+
+    return SensitivityTable(copy(sens.coil_names), mode, delta_nominal, shift, tilt,
+        inplane_rms(shift), inplane_rms(tilt), cancelling(shift), cancelling(tilt))
+end
+
+function sensitivity_table(h5path::AbstractString; psi_low::Real=0.0, psi_high::Real=1.0, mode::Int=1)
+    rc = ResonantCoupling(h5path)
+    dom = dominant_coupling(rc; psi_low, psi_high)
+    return sensitivity_table(CoilSensitivities(h5path), dom; mode)
+end
+
+"""
+    cancelling_offset(δ_nominal, S_x, S_y) -> (Δx, Δy)
+
+The real in-plane displacement that cancels a coil set's nominal overlap to linear order,
+`S_x·Δx + S_y·Δy = −δ_nominal`, as the least-squares solution of the 2×2 real system on the
+real and imaginary parts. For an axisymmetric set, where `S_y = ±i·S_x`, this is the complex
+offset `−δ_nominal / S_x` split into its components. A degenerate pair (`S_x` and `S_y` real
+multiples of each other) returns the minimum-norm solution.
+"""
+function cancelling_offset(δ_nominal::Number, S_x::Number, S_y::Number)
+    A = [real(S_x) real(S_y); imag(S_x) imag(S_y)]
+    Δ = pinv(A) * [-real(δ_nominal), -imag(δ_nominal)]
+    return (Δ[1], Δ[2])
+end

--- a/src/ErrorFields/Sensitivity.jl
+++ b/src/ErrorFields/Sensitivity.jl
@@ -77,11 +77,12 @@ function compute_coil_sensitivities(
             second_norm[axis, col] = norm(plus .+ minus .- 2 .* b0)
         end
 
-        # A tap the set cannot feel (a vertical shift of an axisymmetric hoop at n ≥ 1) has a
-        # first difference at round-off; measure its curvature against the set's largest tap
-        # instead of dividing noise by noise.
-        floor = 1e-6 * maximum(first_norm)
-        resid = floor > 0 ? second_norm ./ max.(first_norm, floor) : zeros(3, 2)
+        # Curvature relative to the set's largest linear response: a tap whose first difference
+        # vanishes by symmetry (a vertical shift of an axisymmetric hoop, an in-plane shift of an
+        # n=1-phased array) still has a genuine second-order response, which only matters if it
+        # is comparable to the linear terms the tolerance model keeps.
+        scale = maximum(first_norm)
+        resid = scale > 0 ? second_norm ./ scale : zeros(3, 2)
         shift_resid[:, j] = resid[:, 1]
         tilt_resid[:, j] = resid[:, 2]
 

--- a/src/ForcingTerms/CoilFourier.jl
+++ b/src/ForcingTerms/CoilFourier.jl
@@ -6,10 +6,12 @@ suitable for the perturbed equilibrium pipeline.
 
 ## Pipeline
 - `sample_boundary_grid` — evaluate (R, Z) and unit-norm metric on the plasma boundary
+- `CoilForcingGrid` — the boundary grid with its observation points laid out, shared by every coil evaluation
 - `compute_biot_savart_boundary!` (BiotSavart.jl) — compute B at all grid points
 - `project_normal_flux!` — compute flux Φ_x = 2π×R×(B_R ∂Z/∂θ − B_Z ∂R/∂θ)
 - `fourier_decompose_bn` — 2D Fourier decompose to get bmn amplitudes
-- `compute_coil_forcing_modes!` — top-level entry point combining all steps
+- `coil_forcing_modes` — Biot-Savart → projection → decomposition for any coil set(s) on a `CoilForcingGrid`
+- `compute_coil_forcing_modes!` — top-level entry point combining all steps for a whole assembly
 """
 
 using FastInterpolations: cubic_interp, PeriodicBC, DerivOp
@@ -107,7 +109,7 @@ For positive-helicity machines (Bt > 0, Ip > 0 → helicity = +1): phi decreases
 function sample_boundary_grid(equil::Equilibrium.PlasmaEquilibrium, mtheta::Int, nzeta::Int;
     psi::Float64=equil.rzphi_xs[end])
     # Build uniform theta grid (same convention as equil.rzphi_ys, but potentially finer)
-    theta_grid = range(0; length=mtheta, step=1.0/mtheta)
+    theta_grid = range(0; length=mtheta, step=1.0 / mtheta)
 
     R_arr = zeros(mtheta)
     Z_arr = zeros(mtheta)
@@ -139,7 +141,7 @@ function sample_boundary_grid(equil::Equilibrium.PlasmaEquilibrium, mtheta::Int,
     bt_sign = !isnothing(equil.params.bt_sign) ? equil.params.bt_sign : 1
     ip_sign = !isnothing(equil.params.crnt) ? Int(sign(equil.params.crnt)) : 1
     helicity = bt_sign * ip_sign
-    phi_grid = collect(range(0; length=nzeta, step=(-helicity * 2π/nzeta)))
+    phi_grid = collect(range(0; length=nzeta, step=(-helicity * 2π / nzeta)))
 
     # Toroidal angle offset ν(ψ, θ_SFL): in SFL coordinates the physical toroidal angle at
     # grid point (θ_SFL, ζ_SFL) is  φ_phys = -helicity*(2π*ζ_SFL + ν(ψ,θ_SFL)).
@@ -241,18 +243,95 @@ function fourier_decompose_bn(
 end
 
 """
-    compute_coil_forcing_modes!(forcing_modes, coil_sets, equil, cfg, n, m_low, m_high; verbose)
+    CoilForcingGrid
 
-Top-level entry point: compute Fourier mode amplitudes of the normal magnetic
-flux from all coil sets on the plasma boundary.
+The plasma-boundary sampling that every coil-field evaluation for one equilibrium and
+toroidal mode number shares: the `BoundaryGrid` at the control surface and its observation
+points laid out in cylindrical `(R, φ, Z)`. Build it once and evaluate any number of coil
+sets against it with [`coil_forcing_modes`](@ref).
 
-## Pipeline
+## Fields
 
-  - Build boundary grid at (mtheta × nzeta) resolution, with helicity from `equil.params`
-  - Lay out observation points in (R, φ, Z) for all (θ, ζ) combinations
-  - Run threaded Biot-Savart summation over all coil sets (matches Fortran `field_bs_psi`)
-  - Project B field onto plasma boundary normal flux (`project_normal_flux!`)
-  - 2D Fourier decompose to get bmn amplitudes for mode range
+  - `grid::BoundaryGrid` - boundary geometry and unit-norm metric
+  - `obs_R`, `obs_phi`, `obs_Z` - observation points `[mtheta × nzeta]`, θ-major, with the
+    SFL toroidal offset applied
+"""
+struct CoilForcingGrid
+    grid::BoundaryGrid
+    obs_R::Vector{Float64}
+    obs_phi::Vector{Float64}
+    obs_Z::Vector{Float64}
+end
+
+"""
+    CoilForcingGrid(equil, cfg, n; psi=equil.rzphi_xs[end])
+
+Sample the control surface `psi` at `cfg.mtheta_coil × nzeta` points, with `nzeta` taken
+from `cfg.nzeta_coil` or `NZETA_POINTS_PER_PERIOD` per toroidal period of `n`. Pass
+`psi = psilim` whenever a solve is at hand (see `sample_boundary_grid`).
+"""
+function CoilForcingGrid(equil::Equilibrium.PlasmaEquilibrium, cfg::CoilConfig, n::Int; psi::Float64=equil.rzphi_xs[end])
+    nzeta = cfg.nzeta_coil > 0 ? cfg.nzeta_coil : NZETA_POINTS_PER_PERIOD * max(1, abs(n))
+    grid = sample_boundary_grid(equil, cfg.mtheta_coil, nzeta; psi)
+
+    # Lay out observation points: (theta_i, zeta_j) → cylindrical (R, phi, Z)
+    nobs = grid.mtheta * grid.nzeta
+    obs_R = zeros(nobs)
+    obs_phi = zeros(nobs)
+    obs_Z = zeros(nobs)
+    for j in 1:grid.nzeta
+        for i in 1:grid.mtheta
+            idx = i + (j - 1) * grid.mtheta
+            obs_R[idx] = grid.R[i]
+            obs_phi[idx] = grid.phi_grid[j] + grid.phi_offset[i]
+            obs_Z[idx] = grid.Z[i]
+        end
+    end
+    return CoilForcingGrid(grid, obs_R, obs_phi, obs_Z)
+end
+
+"""
+    coil_forcing_modes(coil_sets, forcing_grid::CoilForcingGrid, n, m_low, m_high; verbose=false) -> Vector{ForcingMode}
+
+Fourier mode amplitudes, in the unit-norm `Φ_x` convention, of the normal flux that
+`coil_sets` — a `Vector{CoilSet}` or a single `CoilSet` — drive on the boundary sampled by
+`forcing_grid`: threaded Biot-Savart at every observation point, projection onto the boundary
+normal, then the 2D decomposition for toroidal mode `n` and `m_low:m_high`. The field is
+linear in the coils, so evaluating sets one at a time on the same grid gives each set's own
+spectrum, and the sum of those is the spectrum of the assembly.
+"""
+function coil_forcing_modes(
+    coil_sets::Vector{CoilSet},
+    forcing_grid::CoilForcingGrid,
+    n::Int,
+    m_low::Int,
+    m_high::Int;
+    verbose::Bool=false
+)
+    nobs = length(forcing_grid.obs_R)
+    B_R = zeros(nobs)
+    B_phi = zeros(nobs)
+    B_Z = zeros(nobs)
+    compute_biot_savart_boundary!(B_R, B_phi, B_Z, forcing_grid.obs_R, forcing_grid.obs_phi, forcing_grid.obs_Z, coil_sets)
+
+    verbose && @info "  Max |B_R| = $(maximum(abs, B_R)) T, Max |B_Z| = $(maximum(abs, B_Z)) T"
+
+    bn = zeros(forcing_grid.grid.mtheta, forcing_grid.grid.nzeta)
+    project_normal_flux!(bn, B_R, B_Z, forcing_grid.grid)
+
+    verbose && @info "  Max |bn| = $(maximum(abs, bn)) T·m²"
+
+    return fourier_decompose_bn(bn, forcing_grid.grid, n, m_low, m_high)
+end
+
+coil_forcing_modes(coil_set::CoilSet, forcing_grid::CoilForcingGrid, args...; kwargs...) = coil_forcing_modes([coil_set], forcing_grid, args...; kwargs...)
+
+"""
+    compute_coil_forcing_modes!(forcing_modes, coil_sets, equil, cfg, n, m_low, m_high; psi, verbose)
+
+Top-level entry point: compute Fourier mode amplitudes of the normal magnetic flux from all
+coil sets on the plasma boundary — a [`CoilForcingGrid`](@ref) at `psi` followed by
+[`coil_forcing_modes`](@ref) over the whole assembly in one Biot-Savart pass.
 
 Output amplitudes are in unit-norm convention (= Fortran `Phi_x`).
 No normalization conversion is needed when using these modes with `compute_plasma_response!`.
@@ -270,41 +349,10 @@ function compute_coil_forcing_modes!(
     psi::Float64=equil.rzphi_xs[end],   # outermost computed surface (psihigh), not ψ_N=1 — see sample_boundary_grid
     verbose::Bool=false
 )
-    nzeta = cfg.nzeta_coil > 0 ? cfg.nzeta_coil : NZETA_POINTS_PER_PERIOD * max(1, abs(n))
-    mtheta = cfg.mtheta_coil
+    forcing_grid = CoilForcingGrid(equil, cfg, n; psi)
+    verbose && @info "Computing coil forcing modes: mtheta=$(forcing_grid.grid.mtheta), nzeta=$(forcing_grid.grid.nzeta), n=$n, m=$m_low:$m_high, psi=$psi"
 
-    verbose && @info "Computing coil forcing modes: mtheta=$mtheta, nzeta=$nzeta, n=$n, m=$m_low:$m_high, psi=$psi"
-
-    grid = sample_boundary_grid(equil, mtheta, nzeta; psi)
-
-    # Lay out observation points: (theta_i, zeta_j) → cylindrical (R, phi, Z)
-    nobs = mtheta * nzeta
-    obs_R = zeros(nobs)
-    obs_phi = zeros(nobs)
-    obs_Z = zeros(nobs)
-
-    for j in 1:nzeta
-        for i in 1:mtheta
-            idx = i + (j - 1) * mtheta
-            obs_R[idx] = grid.R[i]
-            obs_phi[idx] = grid.phi_grid[j] + grid.phi_offset[i]
-            obs_Z[idx] = grid.Z[i]
-        end
-    end
-
-    B_R = zeros(nobs)
-    B_phi = zeros(nobs)
-    B_Z = zeros(nobs)
-    compute_biot_savart_boundary!(B_R, B_phi, B_Z, obs_R, obs_phi, obs_Z, coil_sets)
-
-    verbose && @info "  Max |B_R| = $(maximum(abs, B_R)) T, Max |B_Z| = $(maximum(abs, B_Z)) T"
-
-    bn = zeros(mtheta, nzeta)
-    project_normal_flux!(bn, B_R, B_Z, grid)
-
-    verbose && @info "  Max |bn| = $(maximum(abs, bn)) T·m²"
-
-    modes = fourier_decompose_bn(bn, grid, n, m_low, m_high)
+    modes = coil_forcing_modes(coil_sets, forcing_grid, n, m_low, m_high; verbose)
 
     empty!(forcing_modes)
     append!(forcing_modes, modes)
@@ -407,5 +455,6 @@ end
 
 export BoundaryGrid, sample_boundary_grid
 export project_normal_flux!, fourier_decompose_bn
+export CoilForcingGrid, coil_forcing_modes
 export compute_coil_forcing_modes!
 export convert_forcing_normalization!

--- a/src/GeneralizedPerturbedEquilibrium.jl
+++ b/src/GeneralizedPerturbedEquilibrium.jl
@@ -62,6 +62,10 @@ include("KineticForces/KineticForces.jl")
 import .KineticForces as KineticForces
 export KineticForces
 
+include("ErrorFields/ErrorFields.jl")
+import .ErrorFields as ErrorFields
+export ErrorFields
+
 include("Analysis/Analysis.jl")
 import .Analysis as Analysis
 export Analysis
@@ -85,8 +89,8 @@ using .Equilibrium: PlasmaEquilibrium
 using .ForcingTerms: RMPField
 
 const _DEPRECATED_FFS_KEYS = ("mer_flag", "force_wv_symmetry", "ode_flag", "cyl_flag", "mat_flag", "reform_eq_with_psilim",
-                              "use_riccati", "use_parallel", "parallel_threads", "populate_dense_xi",
-                              "gal_flag")
+    "use_riccati", "use_parallel", "parallel_threads", "populate_dense_xi",
+    "gal_flag")
 const _DEPRECATED_EQUIL_KEYS = ("power_bp", "power_b", "power_r", "power_rc")
 
 # Drop deprecated keys from a parsed gpec.toml section so legacy files keep parsing
@@ -262,12 +266,14 @@ function main_from_inputs(
     if ctrl.force_termination
         slayer_result = run_slayer_stage(ffs_result, inputs, nothing)
         @info "\n$_BANNER\n  GPEC completed successfully in $(@sprintf("%.3f", time() - total_start)) s\n$_BANNER"
-        return (; ffs=ffs_result, pe=nothing, slayer=slayer_result)
+        return (; ffs=ffs_result, pe=nothing, slayer=slayer_result, coil_sensitivities=nothing)
     end
 
     pe_state = run_perturbed_equilibrium(ffs_result, inputs, forcing_modes_snapshot, preloaded_coil_sets)
 
     run_kinetic_forces(inputs, ffs_result, pe_state, kf_ctrl, kinetic_profiles, kf_species)
+
+    coil_sensitivities = run_error_fields(inputs, ffs_result, pe_state, preloaded_coil_sets)
 
     # SLAYER runs after PE so it appends to the PE output file; it falls back to the
     # ForceFreeStates file when PE did not run.
@@ -286,7 +292,7 @@ function main_from_inputs(
 
     # TODO: Do not allow perturbed equilibrium calculations if zero crossings are found
 
-    return (; ffs=ffs_result, pe=pe_state, slayer=slayer_result)
+    return (; ffs=ffs_result, pe=pe_state, slayer=slayer_result, coil_sensitivities)
 
 end
 
@@ -740,10 +746,10 @@ runs are TOML-driven this cycle: `kinetic_factor > 0` needs the `[KineticForces]
 and errors here.
 
 ```julia
-eq   = PlasmaEquilibrium("input.geqdsk"; jac_type="hamada")
+eq = PlasmaEquilibrium("input.geqdsk"; jac_type="hamada")
 prob = EulerLagrangeProblem(eq; nn=1, delta_mlow=8, delta_mhigh=8, vac_flag=true)
-ffs  = solve(prob, Riccati())
-ffs  = solve(eq, Riccati(); nn=1, vac_flag=true)   # equivalent one-line form
+ffs = solve(prob, Riccati())
+ffs = solve(eq, Riccati(); nn=1, vac_flag=true)   # equivalent one-line form
 ```
 """
 function solve(prob::EulerLagrangeProblem, alg::ForceFreeStates.AbstractIntegrator)
@@ -819,19 +825,7 @@ function run_perturbed_equilibrium(
     # Check for PerturbedEquilibrium section and run if present
     pe_state = nothing
     if "PerturbedEquilibrium" in keys(inputs)
-        # Read ForcingTerms control parameters
-        if "ForcingTerms" in keys(inputs)
-            forcing_raw = inputs["ForcingTerms"]
-            # [[ForcingTerms.coil_set]] becomes a Vector{Dict} — must be excluded from
-            # kwarg splatting and passed as the explicit coil_sets_raw keyword
-            coil_sets_raw = Vector{Dict{String,Any}}(get(forcing_raw, "coil_set", Dict{String,Any}[]))
-            scalar_forcing = filter(p -> p.first != "coil_set", forcing_raw)
-            ft_ctrl = ForcingTerms.ForcingTermsControl(;
-                (Symbol(k) => v for (k, v) in scalar_forcing)..., coil_sets_raw=coil_sets_raw
-            )
-        else
-            ft_ctrl = ForcingTerms.ForcingTermsControl()  # Use defaults
-        end
+        ft_ctrl = forcing_terms_control(inputs)
 
         # The deck's forcing block is an unscaled RMPField, so the TOML path and the
         # scripting API share one stage.
@@ -981,6 +975,66 @@ function run_kinetic_forces(
     @info "KineticForces completed in $(@sprintf("%.3f", time() - kf_start)) s"
 
     return nothing
+end
+
+"""
+    forcing_terms_control(inputs) -> ForcingTermsControl
+
+The `[ForcingTerms]` section of a parsed deck as a control struct, defaults when absent. The
+`[[ForcingTerms.coil_set]]` array of tables is passed through as `coil_sets_raw` rather than
+splatted with the scalar keys.
+"""
+function forcing_terms_control(inputs::Dict{String,Any})
+    "ForcingTerms" in keys(inputs) || return ForcingTerms.ForcingTermsControl()
+    forcing_raw = inputs["ForcingTerms"]
+    coil_sets_raw = Vector{Dict{String,Any}}(get(forcing_raw, "coil_set", Dict{String,Any}[]))
+    scalar_forcing = filter(p -> p.first != "coil_set", forcing_raw)
+    return ForcingTerms.ForcingTermsControl(; (Symbol(k) => v for (k, v) in scalar_forcing)..., coil_sets_raw=coil_sets_raw)
+end
+
+"""
+    run_error_fields(inputs, result, pe_state, preloaded_coil_sets) -> CoilSensitivities or nothing
+
+Linearize every coil set's resonant drive with respect to its rigid shifts and tilts and write
+`ErrorFields/CoilSensitivities/` when the deck carries an `[ErrorFields]` section. Needs the
+perturbed-equilibrium state's singular-coupling matrix and coil-format forcing, and errors
+otherwise: a deck asking for error-field sensitivities without them is a misconfiguration, not a
+case to skip silently. Coil geometry is rebuilt from the deck unless a replay injected it.
+"""
+function run_error_fields(
+    inputs::Dict{String,Any},
+    result::ForceFreeStatesResult,
+    pe_state,
+    preloaded_coil_sets::Union{Nothing,Vector{ForcingTerms.CoilSet}}
+)
+    ("ErrorFields" in keys(inputs)) || return nothing
+
+    @info "\n  ErrorFields\n$_SECTION"
+    ef_start = time()
+
+    ef_ctrl = ErrorFields.ErrorFieldsControl(; (Symbol(k) => v for (k, v) in inputs["ErrorFields"])...)
+    pe_state === nothing && error("[ErrorFields] needs a [PerturbedEquilibrium] section with compute_singular_coupling = true")
+    ft_ctrl = forcing_terms_control(inputs)
+    ft_ctrl.forcing_data_format == "coil" ||
+        error("[ErrorFields] linearizes coil geometry, so [ForcingTerms] must use forcing_data_format = \"coil\" (got \"$(ft_ctrl.forcing_data_format)\")")
+
+    cfg = ForcingTerms.CoilConfig(ft_ctrl)
+    coil_sets = preloaded_coil_sets === nothing ? ForcingTerms.load_coil_sets(cfg, result.nlow; equil=result.equil) : preloaded_coil_sets
+    rc = PerturbedEquilibrium.ResonantCoupling(pe_state, result)
+    sens = ErrorFields.compute_coil_sensitivities(coil_sets, rc, result.equil, cfg, ef_ctrl;
+        psi=result.psilim, b_t0=result.equil.params.bt0)
+
+    if ef_ctrl.write_outputs_to_HDF5
+        output_file = isempty(ef_ctrl.output_filename) ? result.control.HDF5_filename : ef_ctrl.output_filename
+        h5open(joinpath(result.dir_path, output_file), "cw") do h5file
+            ErrorFields.write_to_hdf5!(h5file, sens, PerturbedEquilibrium.dominant_coupling(rc))
+        end
+        @info "Results written to $output_file"
+    end
+
+    @info "ErrorFields completed in $(@sprintf("%.3f", time() - ef_start)) s"
+
+    return sens
 end
 
 """

--- a/src/PerturbedEquilibrium/PerturbedEquilibrium.jl
+++ b/src/PerturbedEquilibrium/PerturbedEquilibrium.jl
@@ -25,6 +25,7 @@ include("ResponseMatrices.jl")
 include("FieldReconstruction.jl")
 include("Response.jl")
 include("SingularCoupling.jl")
+include("ResonantCoupling.jl")
 include("Utils.jl")
 
 # Export main types
@@ -36,6 +37,7 @@ export ForcingMode
 # Export main functions
 export compute_perturbed_equilibrium
 export write_outputs_to_HDF5
+export ResonantCoupling, DominantCoupling, dominant_coupling, rootarea_field, coupling_overlap
 
 """
     compute_perturbed_equilibrium(ffs, forcing, ctrl, intr)::PerturbedEquilibriumState
@@ -100,6 +102,7 @@ function compute_perturbed_equilibrium(
        ForceFreeStates.require(ffs, :free_boundary, "singular coupling calculation") &&
        ForceFreeStates.require_solution(ffs, "singular coupling calculation")
         compute_singular_coupling_metrics!(state, equil, solution, mthvac, ffs, intr, ctrl, mats)
+        compute_dominant_coupling!(state, ctrl)
     end
 
     # Step 4: Output eigenmode fields (integrated into HDF5 output)

--- a/src/PerturbedEquilibrium/PerturbedEquilibriumStructs.jl
+++ b/src/PerturbedEquilibrium/PerturbedEquilibriumStructs.jl
@@ -26,7 +26,9 @@ Medium Priority (defer for MWE):
   - `singular_point_method::String` - Method for singular point treatment (default: "standard")
 
 Regularization:
-    # High Priority (MWE)
+
+# High Priority (MWE)
+
   - `reg_spot::Float64` - Regularization width for singular surface smoothing (default: 0.05). Set to 0 to disable. Must be ≥ 0.
 """
 @kwdef struct PerturbedEquilibriumControl
@@ -119,8 +121,19 @@ Metadata [n_rational] — identifies each (surface, n) row:
 
   - `rational_psi`, `rational_q`, `rational_m_res`, `rational_n`, `rational_surface_idx`
 
+Dominant resonant-coupling modes — the run summary SVD `U·diag(σ)·Vᴴ` of
+`C_resonant_area_weighted_field` over every resonant row (window post hoc with `dominant_coupling`
+on a `ResonantCoupling`):
+
+  - `dominant_singular_values` - σ, descending [rank]
+  - `dominant_right_singular_vectors` - V, applied-b̃ spectra ranked by resonant drive [numpert_total × rank]
+  - `dominant_left_singular_vectors` - U, resonant-field patterns over the retained surfaces [n_retained × rank]
+  - `dominant_rational_index` - rows of the `rational_*` arrays retained in the window [n_retained]
+  - `dominant_forcing_overlap` - Vᴴ·b̃_x, the applied forcing's coefficient on each mode [rank]
+
 Control-surface forcing/response spectra [numpert_total], in the three Pharr (2026) field
 representations (all tesla; no flux/weber is stored):
+
   - `forcing_b`/`response_b` - bare normal field b (Σ⁻¹·b̃)
   - `forcing_b_rootarea`/`response_b_rootarea` - root-area-weighted field b̃ (coordinate-invariant)
   - `forcing_b_area`/`response_b_area` - area-weighted field b̄ (= S·b̃; flux is Φ = A·b̄)
@@ -186,19 +199,26 @@ well-conditioned flux-space inductances L, Λ:
     rational_n::Vector{Int} = Int[]
     rational_surface_idx::Vector{Int} = Int[]
 
+    # Dominant resonant-coupling modes: SVD of C_resonant_area_weighted_field over the retained rows
+    dominant_singular_values::Vector{Float64} = Float64[]
+    dominant_right_singular_vectors::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # V [numpert_total × rank]
+    dominant_left_singular_vectors::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)   # U [n_retained × rank]
+    dominant_rational_index::Vector{Int} = Int[]                                  # retained rows of rational_*
+    dominant_forcing_overlap::Vector{ComplexF64} = ComplexF64[]                    # Vᴴ·b̃_x [rank]
+
     # Control-surface forcing/response spectra in the three weightings of field representations [numpert_total], tesla
-    forcing_b::Vector{ComplexF64}           = ComplexF64[]  # bare normal field b (forcing Φ_x)
-    forcing_b_rootarea::Vector{ComplexF64}  = ComplexF64[]  # root-area-weighted field b̃ (coordinate-invariant)
-    forcing_b_area::Vector{ComplexF64}      = ComplexF64[]  # area-weighted field b̄
-    response_b::Vector{ComplexF64}          = ComplexF64[]  # bare normal field b (response Φ_tot = P·Φ_x)
+    forcing_b::Vector{ComplexF64} = ComplexF64[]  # bare normal field b (forcing Φ_x)
+    forcing_b_rootarea::Vector{ComplexF64} = ComplexF64[]  # root-area-weighted field b̃ (coordinate-invariant)
+    forcing_b_area::Vector{ComplexF64} = ComplexF64[]  # area-weighted field b̄
+    response_b::Vector{ComplexF64} = ComplexF64[]  # bare normal field b (response Φ_tot = P·Φ_x)
     response_b_rootarea::Vector{ComplexF64} = ComplexF64[]  # root-area-weighted field b̃
-    response_b_area::Vector{ComplexF64}     = ComplexF64[]  # area-weighted field b̄
+    response_b_area::Vector{ComplexF64} = ComplexF64[]  # area-weighted field b̄
 
     # Control surface matrices [numpert_total × numpert_total], root-area-weighted field (b̃) space
-    plasma_inductance::Matrix{ComplexF64}  = zeros(ComplexF64, 0, 0)  # Λ̃ (field space)
+    plasma_inductance::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # Λ̃ (field space)
     surface_inductance::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # L̃ (field space)
-    permeability::Matrix{ComplexF64}       = zeros(ComplexF64, 0, 0)  # P̃ = R⁻¹·Λ·L⁻¹·R
-    reluctance::Matrix{ComplexF64}         = zeros(ComplexF64, 0, 0)  # ϱ̃ = R†·L⁻¹·(Λ−L)·L⁻¹·R
+    permeability::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # P̃ = R⁻¹·Λ·L⁻¹·R
+    reluctance::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # ϱ̃ = R†·L⁻¹·(Λ−L)·L⁻¹·R
     rootarea_to_area_weight::Matrix{ComplexF64} = zeros(ComplexF64, 0, 0)  # S = Σ/√A at psilim: b̃→b̄ recovery operator
     surface_area::Float64 = 0.0  # scalar control-surface area A = ∫J|∇ψ|dθ (flux: Φ = A·b̄; conform R = S·A)
 

--- a/src/PerturbedEquilibrium/ResonantCoupling.jl
+++ b/src/PerturbedEquilibrium/ResonantCoupling.jl
@@ -1,0 +1,176 @@
+"""
+    ResonantCoupling
+
+Everything needed to project an applied control-surface field onto the resonant responses of a
+perturbed-equilibrium solve, detached from the run that produced it. Build it in memory from a
+`PerturbedEquilibriumState` and its `ForceFreeStatesResult`, or post hoc from a `gpec.h5`; then
+window and decompose it with [`dominant_coupling`](@ref) and evaluate coil spectra with
+[`rootarea_field`](@ref) and [`coupling_overlap`](@ref) as often as needed without re-running.
+
+## Fields
+
+  - `C::Matrix{ComplexF64}` - coupling from the applied root-area-weighted field b̃ to the resonant
+    area-weighted field, one row per resonant (surface, n) pair `[n_rational × numpert_total]`
+  - `rational_psi`, `rational_q`, `rational_m`, `rational_n` - row labels `[n_rational]`
+  - `m_modes`, `n_modes` - column labels: the poloidal and toroidal mode number of each entry of an
+    applied spectrum `[numpert_total]`
+  - `flux_conform::Matrix{ComplexF64}` - `R = S·A`, mapping b̃ to the unit-norm flux the forcing
+    loaders and coil integration produce, `Φ_x = R·b̃` `[numpert_total × numpert_total]`
+"""
+struct ResonantCoupling
+    C::Matrix{ComplexF64}
+    rational_psi::Vector{Float64}
+    rational_q::Vector{Float64}
+    rational_m::Vector{Int}
+    rational_n::Vector{Int}
+    m_modes::Vector{Int}
+    n_modes::Vector{Int}
+    flux_conform::Matrix{ComplexF64}
+end
+
+"""
+    ResonantCoupling(state::PerturbedEquilibriumState, ffs::ForceFreeStatesResult)
+
+In-memory construction from a solve: the coupling matrix and row labels come from `state`, the
+column ordering from `ffs`, and the conform operator from `state` when the response step ran or
+from the equilibrium otherwise. Errors when `state` carries no singular-coupling matrix.
+"""
+function ResonantCoupling(state::PerturbedEquilibriumState, ffs::ForceFreeStatesResult)
+    isempty(state.C_resonant_area_weighted_field) &&
+        throw(ArgumentError("the perturbed-equilibrium state carries no singular-coupling matrix (compute_singular_coupling off, or no resonant surfaces)"))
+    flux_conform = if isempty(state.rootarea_to_area_weight)
+        S, A = build_control_surface_rootarea_to_area_weight(ffs.equil, ffs)
+        S .* A
+    else
+        state.rootarea_to_area_weight .* state.surface_area
+    end
+    N = ffs.numpert_total
+    m_modes = [(i - 1) % ffs.mpert + ffs.mlow for i in 1:N]
+    n_modes = [(i - 1) ÷ ffs.mpert + ffs.nlow for i in 1:N]
+    return ResonantCoupling(state.C_resonant_area_weighted_field, state.rational_psi, state.rational_q,
+        state.rational_m_res, state.rational_n, m_modes, n_modes, flux_conform)
+end
+
+"""
+    ResonantCoupling(h5path::AbstractString)
+
+Post-hoc construction from a `gpec.h5` written with both the response and singular-coupling
+steps enabled: reads `PerturbedEquilibrium/SingularCoupling/`, the stored conform operator under
+`PerturbedEquilibrium/ResponseMatrices/`, and the column labels from `Info/mn_index`.
+"""
+function ResonantCoupling(h5path::AbstractString)
+    h5open(h5path, "r") do f
+        haskey(f, "PerturbedEquilibrium/SingularCoupling/C_resonant_area_weighted_field") ||
+            throw(ArgumentError("$h5path has no singular-coupling matrix"))
+        haskey(f, "PerturbedEquilibrium/ResponseMatrices/rootarea_to_area_weight_operator") ||
+            throw(ArgumentError("$h5path has no control-surface conform operator (run with compute_response = true)"))
+        haskey(f, "Info/mn_index") || throw(ArgumentError("$h5path has no Info/mn_index mode labels"))
+        sc = f["PerturbedEquilibrium/SingularCoupling"]
+        mn = read(f["Info/mn_index"])
+        S = read(f["PerturbedEquilibrium/ResponseMatrices/rootarea_to_area_weight_operator"])
+        A = read(f["PerturbedEquilibrium/ResponseMatrices/surface_area"])
+        return ResonantCoupling(read(sc["C_resonant_area_weighted_field"]), read(sc["rational_psi"]), read(sc["rational_q"]),
+            read(sc["rational_m"]), read(sc["rational_n"]), mn[:, 1], mn[:, 2], S .* A)
+    end
+end
+
+"""
+    rootarea_field(rc::ResonantCoupling, modes) -> Vector{ComplexF64}
+
+Root-area-weighted control-surface field b̃ of an applied spectrum given in the unit-norm
+(Φ_x) convention — what the forcing-file loaders and the coil integration produce. `modes` is a
+`Vector{ForcingMode}`, placed on `rc`'s (m, n) column ordering (modes outside the basis are
+ignored), or an already-ordered amplitude vector. The result is conformed with R⁻¹
+(`Φ_x = R·b̃`) and is the vector the coupling matrix and its singular vectors act on.
+"""
+function rootarea_field(rc::ResonantCoupling, modes::AbstractVector{ForcingMode})
+    flux = zeros(ComplexF64, length(rc.m_modes))
+    for mode in modes
+        j = findfirst(k -> rc.m_modes[k] == mode.m && rc.n_modes[k] == mode.n, eachindex(rc.m_modes))
+        j === nothing || (flux[j] += mode.amplitude)
+    end
+    return rootarea_field(rc, flux)
+end
+
+function rootarea_field(rc::ResonantCoupling, flux::AbstractVector{<:Number})
+    length(flux) == length(rc.m_modes) || throw(DimensionMismatch("applied spectrum has $(length(flux)) entries; the basis has $(length(rc.m_modes))"))
+    return rc.flux_conform \ Vector{ComplexF64}(flux)
+end
+
+"""
+    DominantCoupling
+
+Singular-value decomposition `U·diag(σ)·Vᴴ` of a resonant coupling matrix over a set of retained
+rational surfaces, produced by [`dominant_coupling`](@ref).
+
+## Fields
+
+  - `singular_values` - σ, descending `[rank]`
+  - `right_singular_vectors` - V: applied-b̃ spectra ranked by resonant drive `[numpert_total × rank]`
+  - `left_singular_vectors` - U: resonant-field patterns over the retained surfaces `[n_retained × rank]`
+  - `rational_index` - rows of the coupling matrix (and its `rational_*` labels) that were retained `[n_retained]`
+"""
+struct DominantCoupling
+    singular_values::Vector{Float64}
+    right_singular_vectors::Matrix{ComplexF64}
+    left_singular_vectors::Matrix{ComplexF64}
+    rational_index::Vector{Int}
+end
+
+"""
+    dominant_coupling(rc::ResonantCoupling; psi_low=0.0, psi_high=1.0) -> DominantCoupling
+    dominant_coupling(C, rational_psi; psi_low=0.0, psi_high=1.0) -> DominantCoupling
+
+Singular-value decomposition of the resonant coupling matrix restricted to the rational
+surfaces with `psi_low ≤ ψ_N ≤ psi_high`. With `C_w = U·diag(σ)·Vᴴ` on the retained rows, the
+right singular vectors `V[:, k]` are the applied-field spectra ordered by how strongly they drive
+resonant field inside the window, and the singular values are coordinate-invariant. The overlap
+of an applied spectrum `b̃` with mode `k` is `dot(V[:, k], b̃)` — see [`coupling_overlap`](@ref) —
+and the resonant field it drives is `σ[k]` times that coefficient; `k = 1` is the dominant mode
+[Park 2007b]. The window is an analysis choice, so re-evaluate it freely on the same `rc`.
+
+Throws `ArgumentError` when the window contains no rational surface.
+"""
+function dominant_coupling(C::AbstractMatrix{ComplexF64}, rational_psi::AbstractVector{<:Real}; psi_low::Real=0.0, psi_high::Real=1.0)
+    size(C, 1) == length(rational_psi) ||
+        throw(DimensionMismatch("C has $(size(C, 1)) rows but rational_psi has $(length(rational_psi)) entries"))
+    rational_index = findall(ψ -> psi_low <= ψ <= psi_high, rational_psi)
+    isempty(rational_index) && throw(ArgumentError("no rational surfaces with ψ_N in [$psi_low, $psi_high]"))
+    F = svd(C[rational_index, :])
+    return DominantCoupling(F.S, Matrix(F.V), Matrix(F.U), rational_index)
+end
+
+dominant_coupling(rc::ResonantCoupling; kwargs...) = dominant_coupling(rc.C, rc.rational_psi; kwargs...)
+
+"""
+    coupling_overlap(dom::DominantCoupling, b̃) -> Vector{ComplexF64}
+    coupling_overlap(dom, rc::ResonantCoupling, modes) -> Vector{ComplexF64}
+
+Coefficients `Vᴴ·b̃` of an applied root-area-weighted field on the singular modes of `dom`; the
+first entry is the overlap with the dominant mode. `dom.singular_values .* coupling_overlap(dom, b̃)`
+is the resonant field each mode drives, with `dom.left_singular_vectors` giving its pattern over the
+retained surfaces. The second form conforms `modes` through [`rootarea_field`](@ref) first.
+"""
+coupling_overlap(dom::DominantCoupling, b̃::AbstractVector{<:Number}) = dom.right_singular_vectors' * b̃
+coupling_overlap(dom::DominantCoupling, rc::ResonantCoupling, modes) = coupling_overlap(dom, rootarea_field(rc, modes))
+
+"""
+    compute_dominant_coupling!(state, ctrl)
+
+Store the full-window dominant resonant-coupling decomposition of
+`state.C_resonant_area_weighted_field` on `state` as a run summary, with the applied forcing's
+coefficients on each mode when the response spectrum is available. Windowed analyses are done
+post hoc on a [`ResonantCoupling`](@ref). Returns without change when no coupling matrix exists.
+"""
+function compute_dominant_coupling!(state::PerturbedEquilibriumState, ctrl::PerturbedEquilibriumControl)
+    isempty(state.C_resonant_area_weighted_field) && return nothing
+    dom = dominant_coupling(state.C_resonant_area_weighted_field, state.rational_psi)
+    state.dominant_singular_values = dom.singular_values
+    state.dominant_right_singular_vectors = dom.right_singular_vectors
+    state.dominant_left_singular_vectors = dom.left_singular_vectors
+    state.dominant_rational_index = dom.rational_index
+    isempty(state.forcing_b_rootarea) || (state.dominant_forcing_overlap = coupling_overlap(dom, state.forcing_b_rootarea))
+    ctrl.verbose &&
+        @info "Dominant resonant coupling: $(length(dom.singular_values)) modes over $(length(dom.rational_index)) rational surfaces, σ₁ = $(@sprintf("%.3e", dom.singular_values[1]))"
+    return nothing
+end

--- a/src/PerturbedEquilibrium/Utils.jl
+++ b/src/PerturbedEquilibrium/Utils.jl
@@ -12,8 +12,9 @@ avoiding repeated index arithmetic throughout the code.
 ## Mode Indexing Convention
 
 For linear index i ∈ [1, numpert_total]:
-- m_modes[i] = (i-1) % mpert + mlow
-- n_modes[i] = (i-1) ÷ mpert + nlow
+
+  - m_modes[i] = (i-1) % mpert + mlow
+  - n_modes[i] = (i-1) ÷ mpert + nlow
 
 This matches the convention used in ForceFreeStates where modes are ordered as:
 (m1,n1), (m2,n1), ..., (mpert,n1), (m1,n2), (m2,n2), ..., (mpert,npert)
@@ -92,7 +93,13 @@ PerturbedEquilibrium/
 │   ├── rational_psi         # [n_rational] surface metadata
 │   ├── rational_q
 │   ├── rational_m
-│   └── rational_n
+│   ├── rational_n
+│   └── DominantMode/        # SVD U·diag(σ)·Vᴴ of C_resonant_area_weighted_field over the retained rational surfaces
+│       ├── singular_values          # σ, descending [rank]
+│       ├── right_singular_vectors   # V: applied-b̃ spectra ranked by resonant drive [numpert_total × rank]
+│       ├── left_singular_vectors    # U: resonant-field patterns over the retained surfaces [n_retained × rank]
+│       ├── rational_index           # rows of rational_* retained in the ψ_N window [n_retained]
+│       └── forcing_overlap          # Vᴴ·b̃_x, applied forcing's coefficient on each mode [rank]
 └── Energies/
     ├── vacuum_energy
     ├── surface_energy
@@ -110,47 +117,47 @@ function write_outputs_to_HDF5(
 
         # Forcing modes
         forcing_group = haskey(pe_group, "ForcingModes") ? pe_group["ForcingModes"] : create_group(pe_group, "ForcingModes")
-        forcing_group["n"]         = [mode.n for mode in intr.forcing_modes]
-        forcing_group["m"]         = [mode.m for mode in intr.forcing_modes]
+        forcing_group["n"] = [mode.n for mode in intr.forcing_modes]
+        forcing_group["m"] = [mode.m for mode in intr.forcing_modes]
         forcing_group["amplitude"] = [mode.amplitude for mode in intr.forcing_modes]
 
         # Control-surface forcing/response spectra in the three Pharr field representations
         # (all tesla; flux/weber is never stored). b̃ = root-area-weighted (coordinate-invariant).
-        !isempty(state.forcing_b)           && (pe_group["forcing_b"]            = state.forcing_b)
-        !isempty(state.forcing_b_rootarea)  && (pe_group["forcing_b_root_area"]  = state.forcing_b_rootarea)
-        !isempty(state.forcing_b_area)      && (pe_group["forcing_b_area"]       = state.forcing_b_area)
-        !isempty(state.response_b)          && (pe_group["response_b"]           = state.response_b)
+        !isempty(state.forcing_b) && (pe_group["forcing_b"] = state.forcing_b)
+        !isempty(state.forcing_b_rootarea) && (pe_group["forcing_b_root_area"] = state.forcing_b_rootarea)
+        !isempty(state.forcing_b_area) && (pe_group["forcing_b_area"] = state.forcing_b_area)
+        !isempty(state.response_b) && (pe_group["response_b"] = state.response_b)
         !isempty(state.response_b_rootarea) && (pe_group["response_b_root_area"] = state.response_b_rootarea)
-        !isempty(state.response_b_area)     && (pe_group["response_b_area"]      = state.response_b_area)
+        !isempty(state.response_b_area) && (pe_group["response_b_area"] = state.response_b_area)
 
         # Control surface matrices [numpert_total × numpert_total], in coordinate-invariant
         # root-area-weighted field (b̃) space. Recover the area-weighted field b̄ with the stored
         # operator S ≡ rootarea_to_area_weight (b̄ = S·b̃): e.g. L_b̄ = S·L̃·S†; recover flux with the
         # scalar surface_area A: Φ = A·b̄  (internally R = S·A, Φ = R·b̃). [Pharr 2026]
         mat_group = haskey(pe_group, "ResponseMatrices") ? pe_group["ResponseMatrices"] : create_group(pe_group, "ResponseMatrices")
-        !isempty(state.plasma_inductance)  && (mat_group["plasma_inductance"]  = state.plasma_inductance)
+        !isempty(state.plasma_inductance) && (mat_group["plasma_inductance"] = state.plasma_inductance)
         !isempty(state.surface_inductance) && (mat_group["surface_inductance"] = state.surface_inductance)
-        !isempty(state.permeability)       && (mat_group["permeability"]       = state.permeability)
-        !isempty(state.reluctance)         && (mat_group["reluctance"]         = state.reluctance)
+        !isempty(state.permeability) && (mat_group["permeability"] = state.permeability)
+        !isempty(state.reluctance) && (mat_group["reluctance"] = state.reluctance)
         !isempty(state.rootarea_to_area_weight) && (mat_group["rootarea_to_area_weight_operator"] = state.rootarea_to_area_weight)
-        (state.surface_area != 0.0)        && (mat_group["surface_area"]       = state.surface_area)
+        (state.surface_area != 0.0) && (mat_group["surface_area"] = state.surface_area)
 
         # Response fields (ComplexF64 directly)
         response_group = haskey(pe_group, "Response") ? pe_group["Response"] : create_group(pe_group, "Response")
         !isempty(state.psi_grid) && (response_group["psi"] = state.psi_grid)
         have_xi = !isnothing(state.xi_modes)
-        have_b  = have_xi && !isnothing(state.b_modes)
-        response_group["xi_psi"]    = have_xi ? state.xi_modes.psi      : ComplexF64[]
-        response_group["b_psi_area_weighted"]  = have_b  ? state.b_modes.b_psi_area_weighted : ComplexF64[]
-        response_group["Jb_theta"]   = have_b  ? state.b_modes.theta    : ComplexF64[]
-        response_group["Jb_zeta"]    = have_b  ? state.b_modes.zeta     : ComplexF64[]
-        response_group["b_n"]       = !isnothing(state.b_n_modes)  ? state.b_n_modes  : ComplexF64[]
-        response_group["xi_n"]      = !isnothing(state.xi_n_modes) ? state.xi_n_modes : ComplexF64[]
+        have_b = have_xi && !isnothing(state.b_modes)
+        response_group["xi_psi"] = have_xi ? state.xi_modes.psi : ComplexF64[]
+        response_group["b_psi_area_weighted"] = have_b ? state.b_modes.b_psi_area_weighted : ComplexF64[]
+        response_group["Jb_theta"] = have_b ? state.b_modes.theta : ComplexF64[]
+        response_group["Jb_zeta"] = have_b ? state.b_modes.zeta : ComplexF64[]
+        response_group["b_n"] = !isnothing(state.b_n_modes) ? state.b_n_modes : ComplexF64[]
+        response_group["xi_n"] = !isnothing(state.xi_n_modes) ? state.xi_n_modes : ComplexF64[]
 
         # Clebsch displacements for PENTRC (matches Fortran gpout_xclebsch)
         if have_xi
-            response_group["xi_clebsch_psi"]   = state.xi_modes.clebsch_psi
-            response_group["dxi_clebsch_psidpsi"]  = state.xi_modes.clebsch_psi1
+            response_group["xi_clebsch_psi"] = state.xi_modes.clebsch_psi
+            response_group["dxi_clebsch_psidpsi"] = state.xi_modes.clebsch_psi1
             response_group["xi_clebsch_alpha"] = state.xi_modes.clebsch_alpha
         end
 
@@ -158,36 +165,36 @@ function write_outputs_to_HDF5(
         if have_xi
             response_group["Jxi_psi"] = state.xi_modes.psi_J
             response_group["Jxi_theta"] = state.xi_modes.theta
-            response_group["Jxi_zeta"]  = state.xi_modes.zeta
+            response_group["Jxi_zeta"] = state.xi_modes.zeta
         end
 
         # Covariant components (from gpeq_cova)
         if have_xi
-            response_group["xi_cov_psi"]   = state.xi_modes.cova_psi
+            response_group["xi_cov_psi"] = state.xi_modes.cova_psi
             response_group["xi_cov_theta"] = state.xi_modes.cova_theta
-            response_group["xi_cov_zeta"]  = state.xi_modes.cova_zeta
+            response_group["xi_cov_zeta"] = state.xi_modes.cova_zeta
         end
         if have_xi
             response_group["Jxi_theta_reg"] = state.xi_modes.theta_reg
-            response_group["Jxi_zeta_reg"]  = state.xi_modes.zeta_reg
+            response_group["Jxi_zeta_reg"] = state.xi_modes.zeta_reg
         end
         if have_b
             response_group["Jb_theta_reg"] = state.b_modes.theta_reg
-            response_group["Jb_zeta_reg"]  = state.b_modes.zeta_reg
-            response_group["b_cov_psi"]   = state.b_modes.cova_psi
+            response_group["Jb_zeta_reg"] = state.b_modes.zeta_reg
+            response_group["b_cov_psi"] = state.b_modes.cova_psi
             response_group["b_cov_theta"] = state.b_modes.cova_theta
-            response_group["b_cov_zeta"]  = state.b_modes.cova_zeta
+            response_group["b_cov_zeta"] = state.b_modes.cova_zeta
         end
 
         # R,Z,φ cylindrical components in mode-space (from gpeq_rzphi)
         if have_xi
-            response_group["xi_R"]   = state.xi_modes.R
-            response_group["xi_Z"]   = state.xi_modes.Z
+            response_group["xi_R"] = state.xi_modes.R
+            response_group["xi_Z"] = state.xi_modes.Z
             response_group["xi_phi"] = state.xi_modes.phi
         end
         if have_b
-            response_group["b_R"]   = state.b_modes.R
-            response_group["b_Z"]   = state.b_modes.Z
+            response_group["b_R"] = state.b_modes.R
+            response_group["b_Z"] = state.b_modes.Z
             response_group["b_phi"] = state.b_modes.phi
         end
 
@@ -195,34 +202,44 @@ function write_outputs_to_HDF5(
         coupling_group = haskey(pe_group, "SingularCoupling") ? pe_group["SingularCoupling"] : create_group(pe_group, "SingularCoupling")
 
         # Coupling matrices [n_rational × numpert_total]
-        !isempty(state.C_resonant_area_weighted_field)   && (coupling_group["C_resonant_area_weighted_field"]   = state.C_resonant_area_weighted_field)
+        !isempty(state.C_resonant_area_weighted_field) && (coupling_group["C_resonant_area_weighted_field"] = state.C_resonant_area_weighted_field)
         !isempty(state.C_resonant_current) && (coupling_group["C_resonant_current"] = state.C_resonant_current)
-        !isempty(state.C_island_width_sq)  && (coupling_group["C_island_width_sq"]  = state.C_island_width_sq)
+        !isempty(state.C_island_width_sq) && (coupling_group["C_island_width_sq"] = state.C_island_width_sq)
         !isempty(state.C_penetrated_area_weighted_field) && (coupling_group["C_penetrated_area_weighted_field"] = state.C_penetrated_area_weighted_field)
-        !isempty(state.C_delta_prime)      && (coupling_group["C_Delta_prime"]      = state.C_delta_prime)
+        !isempty(state.C_delta_prime) && (coupling_group["C_Delta_prime"] = state.C_delta_prime)
 
         # Applied resonant vectors [n_rational]
-        !isempty(state.resonant_area_weighted_field)     && (coupling_group["resonant_area_weighted_field"]     = state.resonant_area_weighted_field)
-        !isempty(state.resonant_current)   && (coupling_group["resonant_current"]   = state.resonant_current)
-        !isempty(state.island_width_sq)    && (coupling_group["island_width_sq"]    = state.island_width_sq)
-        !isempty(state.penetrated_area_weighted_field)   && (coupling_group["penetrated_area_weighted_field"] = state.penetrated_area_weighted_field)
-        !isempty(state.delta_prime)        && (coupling_group["Delta_prime"]        = state.delta_prime)
-        !isempty(state.forcing_solution_weights)         && (coupling_group["forcing_solution_weights"] = state.forcing_solution_weights)
+        !isempty(state.resonant_area_weighted_field) && (coupling_group["resonant_area_weighted_field"] = state.resonant_area_weighted_field)
+        !isempty(state.resonant_current) && (coupling_group["resonant_current"] = state.resonant_current)
+        !isempty(state.island_width_sq) && (coupling_group["island_width_sq"] = state.island_width_sq)
+        !isempty(state.penetrated_area_weighted_field) && (coupling_group["penetrated_area_weighted_field"] = state.penetrated_area_weighted_field)
+        !isempty(state.delta_prime) && (coupling_group["Delta_prime"] = state.delta_prime)
+        !isempty(state.forcing_solution_weights) && (coupling_group["forcing_solution_weights"] = state.forcing_solution_weights)
         !isempty(state.rational_area) && (coupling_group["rational_area"] = state.rational_area)
-        !isempty(state.island_half_width)  && (coupling_group["island_half_width"]  = state.island_half_width)
+        !isempty(state.island_half_width) && (coupling_group["island_half_width"] = state.island_half_width)
         !isempty(state.chirikov_parameter) && (coupling_group["chirikov_parameter"] = state.chirikov_parameter)
 
         # Metadata [n_rational]
-        !isempty(state.rational_psi)       && (coupling_group["rational_psi"]       = state.rational_psi)
-        !isempty(state.rational_q)         && (coupling_group["rational_q"]         = state.rational_q)
-        !isempty(state.rational_m_res)     && (coupling_group["rational_m"]     = state.rational_m_res)
-        !isempty(state.rational_n)         && (coupling_group["rational_n"]         = state.rational_n)
+        !isempty(state.rational_psi) && (coupling_group["rational_psi"] = state.rational_psi)
+        !isempty(state.rational_q) && (coupling_group["rational_q"] = state.rational_q)
+        !isempty(state.rational_m_res) && (coupling_group["rational_m"] = state.rational_m_res)
+        !isempty(state.rational_n) && (coupling_group["rational_n"] = state.rational_n)
+
+        # Dominant resonant-coupling modes (SVD of the b̃-space coupling matrix over the retained rows)
+        if !isempty(state.dominant_singular_values)
+            dominant_group = haskey(coupling_group, "DominantMode") ? coupling_group["DominantMode"] : create_group(coupling_group, "DominantMode")
+            dominant_group["singular_values"] = state.dominant_singular_values
+            dominant_group["right_singular_vectors"] = state.dominant_right_singular_vectors
+            dominant_group["left_singular_vectors"] = state.dominant_left_singular_vectors
+            dominant_group["rational_index"] = state.dominant_rational_index
+            !isempty(state.dominant_forcing_overlap) && (dominant_group["forcing_overlap"] = state.dominant_forcing_overlap)
+        end
 
         # Energies
         energy_group = haskey(pe_group, "Energies") ? pe_group["Energies"] : create_group(pe_group, "Energies")
-        energy_group["vacuum_energy"]   = state.vacuum_energy
-        energy_group["surface_energy"]  = state.surface_energy
-        energy_group["plasma_energy"]   = state.plasma_energy
+        energy_group["vacuum_energy"] = state.vacuum_energy
+        energy_group["surface_energy"] = state.surface_energy
+        energy_group["plasma_energy"] = state.plasma_energy
         energy_group["toroidal_torque"] = state.toroidal_torque
 
         annotate_pe!(pe_group)
@@ -261,7 +278,8 @@ const PE_H5_ANNOTATIONS = [
     "Response/xi_cov_psi" => (; long_name="covariant radial displacement ξ_ψ = ξ·e_ψ", units="m^2", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
     "Response/xi_cov_theta" => (; long_name="covariant poloidal displacement ξ_θ = ξ·e_θ", units="m^2", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
     "Response/xi_cov_zeta" => (; long_name="covariant toroidal displacement ξ_ζ = ξ·e_ζ", units="m^2", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
-    "Response/xi_clebsch_psi" => (; long_name="Clebsch displacement component ξ^ψ (PENTRC input, gpout_xclebsch convention)", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
+    "Response/xi_clebsch_psi" =>
+        (; long_name="Clebsch displacement component ξ^ψ (PENTRC input, gpout_xclebsch convention)", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
     "Response/dxi_clebsch_psidpsi" =>
         (; long_name="regularized ψ_N derivative of ξ^ψ (× singfac²/(singfac²+reg_spot²))", dims=("psi", "mode"), attach=(1 => "Response/psi",)),
     "Response/xi_clebsch_alpha" =>
@@ -342,6 +360,17 @@ const PE_H5_ANNOTATIONS = [
     "SingularCoupling/rational_n" =>
         (; long_name="resonant toroidal mode number n at each rational surface",
             dims=("surface",), attach=(1 => "SingularCoupling/rational_psi", 1 => "SingularCoupling/rational_q")),
+    "SingularCoupling/DominantMode/singular_values" =>
+        (; long_name="singular values σ (descending) of the applied-b̃ → resonant-field coupling matrix over the retained rational surfaces", dims=("rank",)),
+    "SingularCoupling/DominantMode/right_singular_vectors" =>
+        (; long_name="right singular vectors V: applied root-area-weighted field spectra ranked by resonant drive; overlap of b̃ with mode k is dot(V[:,k], b̃)",
+            dims=("mode", "rank")),
+    "SingularCoupling/DominantMode/left_singular_vectors" =>
+        (; long_name="left singular vectors U: resonant area-weighted field patterns over the retained rational surfaces", dims=("surface_retained", "rank")),
+    "SingularCoupling/DominantMode/rational_index" =>
+        (; long_name="1-based index into the SingularCoupling rational_* arrays of each rational surface retained in the SVD window", dims=("surface_retained",)),
+    "SingularCoupling/DominantMode/forcing_overlap" =>
+        (; long_name="coefficient of the applied forcing b̃_x on each singular mode, Vᴴ·b̃_x", units="T", dims=("rank",)),
     "Energies/vacuum_energy" => (; long_name="perturbed vacuum energy", units="J"),
     "Energies/surface_energy" => (; long_name="perturbed surface energy", units="J"),
     "Energies/plasma_energy" => (; long_name="perturbed plasma energy", units="J"),

--- a/src/Rerun.jl
+++ b/src/Rerun.jl
@@ -37,7 +37,8 @@ function read_equilibrium_ingest(in_h5)
     haskey(in_h5, group_path) || return nothing
     group = in_h5[group_path]
     kind = read(group, "ingest_kind")
-    T = kind == "direct" ? Equilibrium.DirectIngest :
+    T =
+        kind == "direct" ? Equilibrium.DirectIngest :
         kind == "inverse" ? Equilibrium.InverseIngest :
         error("Unknown equilibrium ingest_kind in gpec.h5: $kind (expected \"direct\" or \"inverse\")")
     # Positional reconstruction: relies on the default constructor, so `fieldnames(T)` order
@@ -90,7 +91,7 @@ function parse_override_flag(expr::AbstractString)
         # Warn instead of silently stringifying a bare word, which would otherwise only fail
         # much later where the field expects a number/bool.
         @warn "Could not parse --override value as a TOML literal; storing it as a string. " *
-              "Quote it explicitly if a string was intended." key=lhs value=rhs error=e
+              "Quote it explicitly if a string was intended." key = lhs value = rhs error = e
         rhs
     end
 
@@ -266,14 +267,27 @@ function build_inputs_from_h5(args::Vector{String})
           "  source: $(abspath(source_h5))\n" *
           "  output: $(abspath(joinpath(output_dir, output_name)))\n$_BANNER"
 
+    eq_config, additional_input = rebuild_equilibrium_inputs(inputs, ingest, output_dir)
+
+    return inputs, eq_config, additional_input, output_dir, current_git, preloaded_forcing, preloaded_coils
+end
+
+"""
+    rebuild_equilibrium_inputs(inputs, ingest, output_dir) -> (eq_config, additional_input)
+
+The equilibrium configuration and the input `setup_equilibrium` consumes, rebuilt from a stored
+TOML `inputs` dict and the equilibrium `ingest` read from a `gpec.h5`. Analytic kinds regenerate
+from their TOML section; file-based kinds rebuild splines from the stored ingest. A file-based
+run with no ingest can only come from a pre-ingest `gpec.h5` and is an error. Mutates `inputs`
+only to drop deprecated equilibrium keys.
+"""
+function rebuild_equilibrium_inputs(inputs::Dict{String,Any}, ingest, output_dir::AbstractString)
     _drop_deprecated_keys!(inputs["Equilibrium"], _DEPRECATED_EQUIL_KEYS, "Equilibrium")
     # Clear eq_filename on a copy: unused on replay, a stale absolute path could mislead
     # downstream code, and `inputs` itself is re-serialized into the rerun's gpec_toml_raw.
     equil_dict = merge(inputs["Equilibrium"], Dict{String,Any}("eq_filename" => ""))
-    eq_config = Equilibrium.EquilibriumConfig(equil_dict, output_dir)
+    eq_config = Equilibrium.EquilibriumConfig(equil_dict, String(output_dir))
 
-    # Analytic kinds regenerate from their TOML section; file-based kinds rebuild splines from
-    # the stored ingest. A file-based run with no ingest can only come from a pre-ingest gpec.h5.
     additional_input = if haskey(Equilibrium.ANALYTIC_EQ, eq_config.eq_type)
         build_analytic_config(eq_config.eq_type, inputs)
     elseif ingest isa Equilibrium.DirectIngest
@@ -281,10 +295,56 @@ function build_inputs_from_h5(args::Vector{String})
     elseif ingest isa Equilibrium.InverseIngest
         Equilibrium.build_inverse_from_ingest(eq_config, ingest)
     else
-        error("gpec.h5 has no equilibrium ingest and eq_type=$(eq_config.eq_type) is not analytic — cannot replay. " *
-              "A file-based eq_type needs a stored ingest (pre-ingest snapshots lack one); a new analytic kind must be " *
-              "registered in Equilibrium.ANALYTIC_EQ.")
+        error(
+            "gpec.h5 has no equilibrium ingest and eq_type=$(eq_config.eq_type) is not analytic — cannot replay. " *
+            "A file-based eq_type needs a stored ingest (pre-ingest snapshots lack one); a new analytic kind must be " *
+            "registered in Equilibrium.ANALYTIC_EQ."
+        )
     end
+    return eq_config, additional_input
+end
 
-    return inputs, eq_config, additional_input, output_dir, current_git, preloaded_forcing, preloaded_coils
+"""
+    equilibrium_from_h5(h5path) -> (; equil, inputs, psilim)
+
+Rebuild the `PlasmaEquilibrium` of a finished run from its `gpec.h5` alone — the stored TOML
+and equilibrium ingest, through `setup_equilibrium` on the ψ_N grid the run ended with
+(`Equilibrium/Geometry/psi`) — without running any stage or writing anything. `inputs` is the
+parsed TOML the run used and `psilim` the control surface the solve integrated to
+(`Info/psilim`), so post-hoc analyses can evaluate new coil geometry on the surface the stored
+response matrices describe.
+
+Rebuilding on the stored grid reproduces the run's equilibrium exactly, including a two-pass
+run (`mpsi = 0`) that re-formed its equilibrium on a refined grid.
+"""
+function equilibrium_from_h5(h5path::AbstractString)
+    isfile(h5path) || error("HDF5 file not found: $h5path")
+    toml_raw, ingest, psilim, psi_nodes = h5open(h5path, "r") do f
+        haskey(f, "Input/gpec_toml_raw") || error("$h5path has no Input/gpec_toml_raw — produced by a pre-rerun version of GPEC")
+        haskey(f, "Info/psilim") || error("$h5path has no Info/psilim")
+        nodes = haskey(f, "Equilibrium/Geometry/psi") ? Vector{Float64}(read(f, "Equilibrium/Geometry/psi")) : nothing
+        read(f, "Input/gpec_toml_raw"), read_equilibrium_ingest(f), Float64(read(f, "Info/psilim")), nodes
+    end
+    inputs = TOML.parse(toml_raw)
+    eq_config, additional_input = rebuild_equilibrium_inputs(inputs, ingest, dirname(abspath(h5path)))
+    equil = Equilibrium.setup_equilibrium(eq_config, additional_input; override_psi_nodes=psi_nodes)
+    return (; equil, inputs, psilim)
+end
+
+"""
+    ErrorFields.compute_coil_sensitivities(h5path, coil_sets; kwargs...) -> CoilSensitivities
+
+Post-hoc coil linearization against a finished run: the resonant coupling and control-surface
+conform come from `gpec.h5` ([`PerturbedEquilibrium.ResonantCoupling`](@ref)), the equilibrium
+is rebuilt with [`equilibrium_from_h5`](@ref), and `coil_sets` — any geometry, not necessarily
+the run's — are swept on the run's own control surface. Keyword arguments are
+`ErrorFields.ErrorFieldsControl` fields; the boundary-grid resolution follows the run's
+`[ForcingTerms]` section when present. Nothing is written.
+"""
+function ErrorFields.compute_coil_sensitivities(h5path::AbstractString, coil_sets::Vector{ForcingTerms.CoilSet}; kwargs...)
+    ctrl = ErrorFields.ErrorFieldsControl(; kwargs...)
+    rc = PerturbedEquilibrium.ResonantCoupling(h5path)
+    equil, inputs, psilim = equilibrium_from_h5(h5path)
+    cfg = ForcingTerms.CoilConfig(forcing_terms_control(inputs))
+    return ErrorFields.compute_coil_sensitivities(coil_sets, rc, equil, cfg, ctrl; psi=psilim, b_t0=equil.params.bt0)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ else
     include("./runtests_result_struct.jl")
     include("./runtests_solve_api.jl")
     include("./runtests_dominant_coupling.jl")
+    include("./runtests_error_fields.jl")
     include("./runtests_sing.jl")
     include("./runtests_innerlayer.jl")
     include("./runtests_tj_analytic.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ else
     include("./runtests_parallel_integration.jl")
     include("./runtests_result_struct.jl")
     include("./runtests_solve_api.jl")
+    include("./runtests_dominant_coupling.jl")
     include("./runtests_sing.jl")
     include("./runtests_innerlayer.jl")
     include("./runtests_tj_analytic.jl")

--- a/test/runtests_coils.jl
+++ b/test/runtests_coils.jl
@@ -299,6 +299,20 @@ end
     # Dominant mode should be in the resonant range for DIII-D geometry
     dominant_m = forcing_modes[argmax(amplitudes)].m
     @test m_low <= dominant_m <= m_high
+
+    # Per-set evaluation on one shared grid: the assembly through the shared path is the same
+    # numbers as the top-level entry point, and the field's linearity in the coils makes the
+    # per-set spectra sum to it.
+    forcing_grid = ForcingTerms.CoilForcingGrid(equil, cfg, n_test)
+    @test length(forcing_grid.obs_R) == cfg.mtheta_coil * cfg.nzeta_coil
+    both = ForcingTerms.coil_forcing_modes([il_set, iu_set], forcing_grid, n_test, m_low, m_high)
+    @test [m.amplitude for m in both] == [m.amplitude for m in forcing_modes]
+    il_modes = ForcingTerms.coil_forcing_modes(il_set, forcing_grid, n_test, m_low, m_high)
+    iu_modes = ForcingTerms.coil_forcing_modes(iu_set, forcing_grid, n_test, m_low, m_high)
+    @test [m.m for m in il_modes] == [m.m for m in forcing_modes]
+    summed = [a.amplitude + b.amplitude for (a, b) in zip(il_modes, iu_modes)]
+    @test summed ≈ [m.amplitude for m in forcing_modes] rtol = 1e-12
+    @test maximum(abs.(getfield.(il_modes, :amplitude))) > 1e-6
 end
 
 # ---------------------------------------------------------------------------

--- a/test/runtests_dominant_coupling.jl
+++ b/test/runtests_dominant_coupling.jl
@@ -1,0 +1,123 @@
+using HDF5
+using TOML
+using LinearAlgebra
+
+# The resonant-coupling analysis API: the pure windowed SVD on a hand-built matrix, then a real
+# perturbed-equilibrium run checked three ways — the stored run summary against the applied
+# resonant field, the in-memory and gpec.h5 constructions of ResonantCoupling against each
+# other, and the forcing-mode normalization path against the run's own b̃ spectrum.
+include("h5_metadata_check.jl")
+
+@testset "dominant coupling" begin
+    GPEC = GeneralizedPerturbedEquilibrium
+    PE = GPEC.PerturbedEquilibrium
+
+    @testset "window restriction and SVD identities on a synthetic matrix" begin
+        rational_psi = [0.2, 0.5, 0.8]
+        C = ComplexF64[1 2im 0 1 0 0; 0 3 1im 0 2 0; 1 0 0 4 0 1im]
+
+        dom = PE.dominant_coupling(C, rational_psi; psi_low=0.4, psi_high=1.0)
+        @test dom isa PE.DominantCoupling
+        @test dom.rational_index == [2, 3]
+        @test length(dom.singular_values) == 2
+        @test issorted(dom.singular_values; rev=true)
+        @test all(>(0), dom.singular_values)
+        @test size(dom.right_singular_vectors) == (6, 2)
+        @test size(dom.left_singular_vectors) == (2, 2)
+
+        U, σ, V = dom.left_singular_vectors, dom.singular_values, dom.right_singular_vectors
+        @test U * Diagonal(σ) * V' ≈ C[2:3, :]
+        @test V' * V ≈ I
+        # Driving the plasma with a singular vector returns σ times its resonant pattern, and the
+        # overlap convention picks that vector out with unit coefficient.
+        @test C[2:3, :] * V[:, 1] ≈ σ[1] .* U[:, 1]
+        @test PE.coupling_overlap(dom, V[:, 1]) ≈ [1, 0] atol = 1e-12
+
+        # The full window reproduces the plain SVD; an empty window is an error.
+        full = PE.dominant_coupling(C, rational_psi)
+        @test full.rational_index == [1, 2, 3]
+        @test full.singular_values ≈ svd(C).S
+        @test_throws ArgumentError PE.dominant_coupling(C, rational_psi; psi_low=0.9)
+        @test_throws DimensionMismatch PE.dominant_coupling(C, rational_psi[1:2])
+    end
+
+    @testset "perturbed-equilibrium run: summary, ResonantCoupling, and normalization" begin
+        template = joinpath(@__DIR__, "test_data", "regression_solovev_ideal_example")
+        forcing = joinpath(@__DIR__, "..", "examples", "Solovev_ideal_example", "forcing.dat")
+
+        mktempdir() do dir
+            for name in readdir(template)
+                cp(joinpath(template, name), joinpath(dir, name))
+            end
+            cp(forcing, joinpath(dir, "forcing.dat"))
+            toml_path = joinpath(dir, "gpec.toml")
+            inputs = TOML.parsefile(toml_path)
+            inputs["ForceFreeStates"]["write_outputs_to_HDF5"] = true
+            inputs["ForcingTerms"] = Dict{String,Any}("forcing_data_file" => "forcing.dat", "forcing_data_format" => "ascii")
+            inputs["PerturbedEquilibrium"] = Dict{String,Any}(
+                "compute_response" => true, "compute_singular_coupling" => true,
+                "verbose" => false, "write_outputs_to_HDF5" => true)
+            open(io -> TOML.print(io, inputs), toml_path, "w")
+
+            run = GPEC.main([dir])
+            pe, ffs = run.pe, run.ffs
+            h5path = joinpath(dir, "gpec.h5")
+
+            # Run summary: the full-window decomposition, rebuilt into the stored applied resonant
+            # field (which the writer evaluates before conforming the matrix to b̃ space).
+            @test !isempty(pe.dominant_singular_values)
+            rank = length(pe.dominant_singular_values)
+            rows = pe.dominant_rational_index
+            @test rows == 1:length(pe.rational_psi)
+            @test issorted(pe.dominant_singular_values; rev=true)
+            V, σ, U = pe.dominant_right_singular_vectors, pe.dominant_singular_values, pe.dominant_left_singular_vectors
+            @test size(V) == (length(pe.forcing_b_rootarea), rank)
+            @test size(U) == (length(rows), rank)
+            @test pe.dominant_forcing_overlap[1] ≈ dot(V[:, 1], pe.forcing_b_rootarea)
+            @test U * (σ .* pe.dominant_forcing_overlap) ≈ pe.resonant_area_weighted_field[rows] rtol = 1e-8
+
+            # The same ResonantCoupling from memory and from the file.
+            rc = PE.ResonantCoupling(pe, ffs)
+            rc_h5 = PE.ResonantCoupling(h5path)
+            @test rc_h5.C ≈ rc.C
+            @test rc_h5.rational_psi == rc.rational_psi
+            @test rc_h5.m_modes == rc.m_modes && rc_h5.n_modes == rc.n_modes
+            @test rc_h5.flux_conform ≈ rc.flux_conform
+            @test rc.m_modes[1] == ffs.mlow && rc.m_modes[end] == ffs.mhigh
+
+            # Normalization: the run's own unit-norm forcing modes, pushed through rootarea_field,
+            # reproduce the run's b̃ spectrum, and their overlaps reproduce the summary.
+            modes = h5open(h5path, "r") do h5
+                g = h5["PerturbedEquilibrium/ForcingModes"]
+                [GPEC.ForcingTerms.ForcingMode(; n, m, amplitude) for (n, m, amplitude) in zip(read(g["n"]), read(g["m"]), read(g["amplitude"]))]
+            end
+            b̃ = PE.rootarea_field(rc, modes)
+            @test b̃ ≈ pe.forcing_b_rootarea rtol = 1e-10
+            dom = PE.dominant_coupling(rc)
+            @test dom.singular_values ≈ σ
+            @test abs.(PE.coupling_overlap(dom, rc, modes)) ≈ abs.(pe.dominant_forcing_overlap) rtol = 1e-8
+
+            # Windowing is a post-hoc choice on the same object.
+            if length(rc.rational_psi) >= 2
+                lo = rc.rational_psi[2]
+                dom_w = PE.dominant_coupling(rc; psi_low=lo)
+                @test dom_w.rational_index == findall(>=(lo), rc.rational_psi)
+                @test dom_w.singular_values ≈ svd(rc.C[dom_w.rational_index, :]).S
+            end
+            @test_throws DimensionMismatch PE.rootarea_field(rc, ComplexF64[1, 2])
+
+            # Without the response step the conform operator is rebuilt from the equilibrium.
+            pe.rootarea_to_area_weight = zeros(ComplexF64, 0, 0)
+            @test PE.ResonantCoupling(pe, ffs).flux_conform ≈ rc.flux_conform
+
+            h5open(h5path, "r") do h5
+                g = h5["PerturbedEquilibrium/SingularCoupling/DominantMode"]
+                @test read(g["singular_values"]) ≈ σ
+                @test read(g["right_singular_vectors"]) ≈ V
+                @test read(g["rational_index"]) == rows
+                @test read(g["forcing_overlap"]) ≈ pe.dominant_forcing_overlap
+                @test isempty(_collect_metadata_violations(h5))
+            end
+        end
+    end
+end

--- a/test/runtests_error_fields.jl
+++ b/test/runtests_error_fields.jl
@@ -1,0 +1,148 @@
+using HDF5
+using TOML
+using LinearAlgebra
+
+# The ErrorFields coil linearization: a closed-form check on the cancelling offset, then one
+# coil-forced Solovev run with an axisymmetric PF hoop (whose rigid-motion response is known
+# analytically) and a tilted one, checked in memory, through the HDF5 writer/reader, and
+# through the post-hoc gpec.h5 entry point that rebuilds the equilibrium from the file.
+include("h5_metadata_check.jl")
+
+@testset "error fields" begin
+    GPEC = GeneralizedPerturbedEquilibrium
+    PE = GPEC.PerturbedEquilibrium
+    EF = GPEC.ErrorFields
+    FT = GPEC.ForcingTerms
+
+    @testset "cancelling offset" begin
+        # General complex pair: the offset cancels the nominal overlap to round-off.
+        δ, Sx, Sy = 0.3 - 0.7im, 1.0 + 2.0im, -0.5 + 0.25im
+        Δx, Δy = EF.cancelling_offset(δ, Sx, Sy)
+        @test abs(δ + Sx * Δx + Sy * Δy) < 1e-14
+        # Axisymmetric pair S_y = i·S_x: the offset is the complex number −δ/S_x.
+        Δx, Δy = EF.cancelling_offset(δ, Sx, im * Sx)
+        @test Δx + im * Δy ≈ -δ / Sx
+        # Degenerate pair (real multiples): minimum-norm least squares, finite.
+        Δx, Δy = EF.cancelling_offset(1.0 + 0.0im, 1.0 + 0.0im, 2.0 + 0.0im)
+        @test isfinite(Δx) && isfinite(Δy)
+        @test 1.0 + Δx + 2Δy ≈ 0 atol = 1e-14
+    end
+
+    @testset "coil-forced Solovev run: identities, output, and post-hoc entry point" begin
+        template = joinpath(@__DIR__, "test_data", "regression_solovev_ideal_example")
+
+        mktempdir() do dir
+            for name in readdir(template)
+                cp(joinpath(template, name), joinpath(dir, name))
+            end
+            toml_path = joinpath(dir, "gpec.toml")
+            inputs = TOML.parsefile(toml_path)
+            inputs["ForceFreeStates"]["write_outputs_to_HDF5"] = true
+            # Two PF hoops outside the plasma (Solovev R ≈ 0.67–1.33 m): one tilted so the run has
+            # a nominal n=1 forcing, one axisymmetric so its rigid-motion response is known exactly.
+            inputs["ForcingTerms"] = Dict{String,Any}(
+                "forcing_data_format" => "coil", "mtheta_coil" => 240, "nzeta_coil" => 32,
+                "coil_set" => [
+                    Dict{String,Any}("name" => "hoop_tilted", "source" => "pf_hoop", "radius" => 1.5, "height" => 0.4, "currents" => [2.0e3], "tiltx" => [3.0]),
+                    Dict{String,Any}("name" => "hoop_axi", "source" => "pf_hoop", "radius" => 1.5, "height" => -0.4, "currents" => [2.0e3])
+                ])
+            inputs["PerturbedEquilibrium"] = Dict{String,Any}(
+                "compute_response" => true, "compute_singular_coupling" => true,
+                "verbose" => false, "write_outputs_to_HDF5" => true)
+            inputs["ErrorFields"] = Dict{String,Any}("verbose" => false)
+            open(io -> TOML.print(io, inputs), toml_path, "w")
+
+            res = GPEC.main([dir])
+            sens, pe, ffs = res.coil_sensitivities, res.pe, res.ffs
+            h5path = joinpath(dir, "gpec.h5")
+
+            @test sens isa EF.CoilSensitivities
+            @test sens.coil_names == ["hoop_tilted", "hoop_axi"]
+            N = ffs.numpert_total
+            @test size(sens.nominal_field) == (N, 2)
+            @test size(sens.shift_sensitivity) == (N, 3, 2)
+            @test size(sens.tilt_sensitivity) == (N, 3, 2)
+            @test sens.b_t0 == ffs.equil.params.bt0
+            @test sens.peak_current == [2.0e3, 2.0e3]
+            @test all(<(1e-2), sens.shift_linearity_residual)
+            @test all(<(1e-2), sens.tilt_linearity_residual)
+
+            # These coils are the run's forcing: the nominal spectra sum to the run's own b̃.
+            @test vec(sum(sens.nominal_field; dims=2)) ≈ pe.forcing_b_rootarea rtol = 1e-10
+
+            # Axisymmetric hoop at n = 1: no nominal drive; a vertical shift or a rotation about
+            # the machine axis changes nothing; a shift along y is the x shift rotated a quarter
+            # turn toroidally, which multiplies the n = 1 mode by −i under the SFL toroidal angle
+            # φ = −helicity·(2πζ + ν) (this fixture has helicity +1). The y tilt of
+            # `apply_transforms` rotates x toward z, the left-handed sense about +y, so the tilt
+            # pair carries the opposite sign.
+            Sx, Sy, Sz = (sens.shift_sensitivity[:, a, 2] for a in 1:3)
+            Tx, Ty, Tz = (sens.tilt_sensitivity[:, a, 2] for a in 1:3)
+            @test norm(sens.nominal_field[:, 2]) < 1e-10 * norm(Sx)
+            @test norm(Sz) < 1e-8 * norm(Sx)
+            @test norm(Tz) < 1e-8 * norm(Tx)
+            @test Sy ≈ -im .* Sx rtol = 1e-8
+            @test Ty ≈ im .* Tx rtol = 1e-8
+
+            # Projection onto the full-window dominant mode: the sets' overlaps sum to the run's.
+            rc = PE.ResonantCoupling(pe, ffs)
+            dom = PE.dominant_coupling(rc)
+            table = EF.sensitivity_table(sens, dom)
+            @test table.mode == 1
+            @test sum(table.delta_nominal) ≈ pe.dominant_forcing_overlap[1] / sens.b_t0 rtol = 1e-10
+            @test table.shift_rms[2] ≈ abs(table.shift[1, 2])  # axisymmetric: |S_y| = |S_x|
+            for j in 1:2
+                @test abs(table.delta_nominal[j] + table.shift[1, j] * table.cancelling_shift[1, j] + table.shift[2, j] * table.cancelling_shift[2, j]) < 1e-12
+            end
+            @test_throws ArgumentError EF.sensitivity_table(sens, dom; mode=length(dom.singular_values) + 1)
+            windowed = EF.sensitivity_table(sens, PE.dominant_coupling(rc; psi_low=rc.rational_psi[end]))
+            @test length(windowed.delta_nominal) == 2
+
+            # HDF5: self-describing, and the reader and file-based table reproduce memory exactly.
+            h5open(h5path, "r") do f
+                @test haskey(f, "ErrorFields/CoilSensitivities/DominantMode/delta_nominal")
+                @test isempty(_collect_metadata_violations(f))
+            end
+            from_file = EF.CoilSensitivities(h5path)
+            @test from_file.coil_names == sens.coil_names
+            @test from_file.m_modes == sens.m_modes && from_file.n_modes == sens.n_modes
+            @test from_file.nominal_field == sens.nominal_field
+            @test from_file.shift_sensitivity == sens.shift_sensitivity
+            @test from_file.tilt_sensitivity == sens.tilt_sensitivity
+            @test from_file.b_t0 == sens.b_t0
+            table_file = EF.sensitivity_table(h5path)
+            @test table_file.delta_nominal == table.delta_nominal
+            @test table_file.shift == table.shift && table_file.tilt == table.tilt
+
+            # Post-hoc entry point: equilibrium and coupling rebuilt from the file, same coils.
+            cfg = FT.CoilConfig(GPEC.forcing_terms_control(inputs))
+            sets = FT.load_coil_sets(cfg, 1; equil=ffs.equil)
+            rebuilt = GPEC.equilibrium_from_h5(h5path)
+            @test rebuilt.psilim == ffs.psilim
+            @test rebuilt.equil.params.bt0 ≈ ffs.equil.params.bt0
+            post_hoc = EF.compute_coil_sensitivities(h5path, sets)
+            @test post_hoc.nominal_field ≈ sens.nominal_field rtol = 1e-10
+            @test post_hoc.shift_sensitivity ≈ sens.shift_sensitivity rtol = 1e-10
+            @test post_hoc.tilt_sensitivity ≈ sens.tilt_sensitivity rtol = 1e-10
+
+            # Central differences: doubling the step moves the derivatives at O(h²).
+            coarse = EF.compute_coil_sensitivities(sets, rc, ffs.equil, cfg,
+                EF.ErrorFieldsControl(; fd_step_shift_m=2e-3, fd_step_tilt_deg=0.2); psi=ffs.psilim, b_t0=sens.b_t0)
+            @test coarse.shift_sensitivity ≈ sens.shift_sensitivity rtol = 1e-4
+            @test coarse.tilt_sensitivity ≈ sens.tilt_sensitivity rtol = 1e-3
+
+            # Single-conductor sets: the set pivot is the conductor pivot.
+            set_pivot = EF.compute_coil_sensitivities(sets, rc, ffs.equil, cfg,
+                EF.ErrorFieldsControl(; rotation_center="set"); psi=ffs.psilim, b_t0=sens.b_t0)
+            @test set_pivot.tilt_sensitivity ≈ sens.tilt_sensitivity rtol = 1e-10
+
+            # Guards: a current-free set, a bad pivot name, a non-positive step.
+            dead = FT.CoilSet(sets[1].name, sets[1].ncoil, sets[1].s, sets[1].nw, sets[1].nsec, sets[1].x, sets[1].y, sets[1].z, zeros(sets[1].ncoil))
+            @test_throws ArgumentError EF.compute_coil_sensitivities([dead], rc, ffs.equil, cfg; psi=ffs.psilim, b_t0=sens.b_t0)
+            @test_throws ArgumentError EF.compute_coil_sensitivities(sets, rc, ffs.equil, cfg,
+                EF.ErrorFieldsControl(; rotation_center="pack"); psi=ffs.psilim, b_t0=sens.b_t0)
+            @test_throws ArgumentError EF.compute_coil_sensitivities(sets, rc, ffs.equil, cfg,
+                EF.ErrorFieldsControl(; fd_step_shift_m=0.0); psi=ffs.psilim, b_t0=sens.b_t0)
+        end
+    end
+end


### PR DESCRIPTION
Third PR of the OMFIT → Julia error-field tolerance migration (after #446 and #447, whose APIs it consumes). It adds the `src/ErrorFields` module and its first deliverable: the linearization of every coil set's resonant drive with respect to its six rigid-body degrees of freedom, computed once per plasma solve, so every downstream tolerance question (Monte Carlo, locking risk, allowable tolerance) becomes linear algebra on a small cached table. No device-specific data enters the repo.

**What it does**

- `[ErrorFields]` TOML section → `run_error_fields` stage after PerturbedEquilibrium (PE). For each `[[ForcingTerms.coil_set]]` it takes central differences of the root-area-weighted control-surface spectrum b̃ under rigid shifts (Δx, Δy, Δz) and tilts (θx, θy, θz), on one shared boundary grid per toroidal mode, and conforms them with R⁻¹ through PR1's `ResonantCoupling`. Errors, rather than skipping, when the deck lacks coil forcing or the singular-coupling step.
- Stored primitive is the **spectrum** linearization (`CoilSensitivities`), not a scalar: the overlap δ = Vᴴb̃ / B_T0 with any dominant mode is linear in b̃, so the ψ_N window, the singular mode, and the normalization stay post-hoc analysis choices. `sensitivity_table(sens, dom; mode)` / `sensitivity_table("gpec.h5"; psi_low, psi_high, mode)` project to δ, ∂δ/∂Δ, ∂δ/∂θ per coil set, with the direction-averaged in-plane RMS (the single number the OMFIT tool used) and the closed-form shift/tilt that cancels δ_nominal.
- HDF5: `ErrorFields/CoilSensitivities/` (spectra, derivatives, per-tap linearity residual, current pattern) plus a `DominantMode/` full-window summary, all annotated.
- Post-hoc entry point `ErrorFields.compute_coil_sensitivities("gpec.h5", coil_sets; …)` sweeps *any* coil geometry against a stored solve via a new side-effect-free `equilibrium_from_h5` (Rerun; the shared equilibrium rebuild is factored out of `build_inputs_from_h5` as `rebuild_equilibrium_inputs`).
- `rotation_center = "conductor" | "set"`: the tilt pivot. `"conductor"` (default) is the Fortran `coil_read`/OMFIT convention needed for the validation gate; `"set"` rotates a multi-filament winding pack rigidly, which is what an engineering axis-line tolerance constrains.

**Verification** (a self-contained HTML review package with figures was delivered to the author alongside this PR)

- Axisymmetric PF hoop at n=1: nominal drive, vertical-shift and axial-tilt responses vanish; S_y = −i·S_x and T_y = +i·T_x (the tilt sign follows `apply_transforms`' y-tilt sense) — all to 1e-13–1e-16.
- Per-set nominal spectra sum to the run's `forcing_b_rootarea` (1e-14); per-set overlaps sum to the run's `dominant_forcing_overlap`.
- Step doubling moves derivatives at O(h²); HDF5 round trip and metadata contract; file-based table equals in-memory; post-hoc entry point reproduces the in-run sweep to round-off, on the single-pass Solovev fixture and on the two-pass DIII-D run alike (the equilibrium is rebuilt on the run's stored ψ grid).
- DIII-D C-coil, six conductors swept post hoc one at a time: their overlaps sum to the whole set's.
- **Example:** `examples/DIIID-like_error_field_example/` adds the eighteen DIII-D F coils as single-filament hoops at their winding-pack centroids (OpenFUSIONToolkit TokaMaker `DIIID_geom.json`) to the DIII-D-like solve; `analyze_example.jl` ranks them by error field per mm of shift and per 0.1° of tilt. Not a harness case (it would double the harness runtime); `diiid_n1` already tracks the stage.

**Not in this PR:** the cross-check against the original OMFIT tool needs the target device's coils and equilibrium, which stay outside the repo; it runs from a parallel user directory. Tolerance input, sampling, the Monte Carlo kernel, and risk follow in PR4–PR7.

cc @matt-pharr — you may want to follow this series.

## Release note

- **Audience:** users
- **Numerical impact:** none _(harness @ bd02569d)_
- **Migration:** none

A coil-forced run can now add an `[ErrorFields]` section to get, per coil set, the resonant-field sensitivity to rigid shifts and tilts (`ErrorFields/CoilSensitivities/`), and `sensitivity_table` projects it onto any dominant mode after the fact; `compute_coil_sensitivities("gpec.h5", coil_sets)` sweeps a new coil design against an existing solve without re-running the plasma.

## Regression report

```
Regression Report: diiid_n1
=================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
Ref 2: local  @ local (2026-09-11)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
-------------------------------------------------------------------------------------------------
Quantity                                      develop          local            Diff       Status
-------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01     0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05     0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00    0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00     0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01     0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]        0.0e+00    OK    
ODE steps (saved)                             2576             2576             0.0e+00    OK    
ODE steps (total)                             4572             4572             0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00     0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00     0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02     0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00     0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01     0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01     0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01     0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01     0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01     0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01     0.0e+00    OK    
# singular surfaces                           5                5                0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]         0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]         0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01     0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01     0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00     0.0e+00    OK    
mpert                                         35               35               0.0e+00    OK    
npert                                         1                1                0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00     0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01     0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00     0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00     0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...  identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...  identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...  identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...  identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...  identical  OK    
island half-widths                            [5 elem]         [5 elem]         0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]         0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04     0.0e+00    OK    
dominant-coupling singular values             N/A              [5 elem]         N/A        N/A   
|forcing overlap with dominant mode|          N/A              3.284975e-02     N/A        N/A   
|delta_nominal| of coil set 1                 N/A              1.637107e-02                N/A   
||ddelta/d(shift)|| over coil sets            N/A              2.998822e-02                N/A   
||ddelta/d(tilt)|| over coil sets             N/A              1.012616e-04                N/A   
PE plasma energy                              3.422677e+00     3.422677e+00     0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00     0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00     0.0e+00    OK    
PE toroidal torque                            5.087465e-02     5.087465e-02     0.0e+00    OK    
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01     0.0e+00    OK    
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02     0.0e+00    OK    
Runtime (s)                                   295.4s           302.6s                      --    
resonant area-weighted field b^r              [5 elem]         [5 elem]         0.0e+00    OK    
=================================================================================================
Summary: 47 unchanged, 5 missing/N/A
```

## Notes for reviewers

- The whole DIII-D C-coil array's in-plane sensitivities vanish by symmetry (an n=1-phased array shifted rigidly in x produces only n=0 and n=2), so the harness tracks the norms of the sensitivity vectors (vertical shift and axial tilt survive) rather than the in-plane RMS, which is 1e-14 noise there. Per-conductor sensitivities are the physically meaningful ones and are what the device workflow uses.
- `src/Rerun.jl` and `src/GeneralizedPerturbedEquilibrium.jl` picked up a little JuliaFormatter normalization on first touch (expected churn per CLAUDE.md).
- Branch is stacked on #446 and #447; the PR3 commits are the ones after the two merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu

