### PR TITLE
ErrorFields/ForcingTerms - FEATURE - Add the tolerance TOML schema and parser

### DIFF
--- a/docs/src/error_fields.md
+++ b/docs/src/error_fields.md
@@ -71,6 +71,66 @@ tolerance tool, while `"set"` rotates the pack rigidly about its common centre, 
 an engineering axis-line tolerance constrains. Single-conductor sets give identical results
 either way.
 
+## Tolerance input
+
+Manufacturing tolerances are engineering data, reviewed and versioned independently of any
+run, so they live in their own TOML file named by `tolerance_file` in `[ErrorFields]` (a path
+relative to the run directory). The run validates the file, echoes its text into
+`Input/RawInputs/ErrorFields/tolerance_toml_raw` for replay, and leaves the device numbers
+where they belong: outside the repository. The sampling and Monte Carlo stages that consume
+these tolerances follow in later releases; this release fixes the format.
+
+```toml
+# Fallbacks for keys a coil block leaves out (every key optional)
+[ErrorFields.defaults]
+shift_sigma_mm = 0.0             # Gaussian uncertainty added to the sampled shift [mm]
+tilt_sigma = 0.0                 # Gaussian uncertainty added to the sampled tilt, in tilt_units
+tilt_units = "deg"               # "deg", or "m" for a rim displacement converted through the nominal radius
+radial_shape = "hollow"          # Radial sampling density on the disk: flat, uniform_area, hollow, or ring
+tolerance_model = "additive"     # "additive" (independent shift and tilt) or "cylinder" (correlated axis line)
+cylinder_half_height_m = 0.0     # Cylinder half-height for the cylinder model [m]
+
+# One block per coil set that moves on its own
+[[ErrorFields.coil]]
+name = "PF1U"                    # Coil set name; must match a [[ForcingTerms.coil_set]] of the run
+shift_tol_mm = 0.5               # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.019                 # Tilt tolerance, in tilt_units
+tolerance_model = "cylinder"     # Axis line confined to a cylinder; shift and tilt drawn together
+cylinder_half_height_m = 1.5     # Cylinder half-height; sets the tilt reachable at the given radius [m]
+
+# Coil sets that move together: one shared draw per sample
+[[ErrorFields.coherent_group]]
+name = "upper_pf_brace"          # Label of the coherently moving group
+members = ["PF1U", "PF2U"]       # Coil sets sharing the draw
+shift_tol_mm = 2.0               # Coherent shift amplitude shared by the group [mm]
+tilt_tol = 0.0                   # Coherent tilt amplitude shared by the group, in tilt_units
+phase_group = "braces"           # Groups naming the same phase_group share the random direction
+rotation_center_z_m = 0.0        # Height of the pivot of the group's rigid rotation on the machine axis [m]
+
+[ErrorFields.correctability]
+uncorrectable_coils = ["EFCC_U"] # Coil sets the error-field correction cannot reduce
+efc_factor = 2.0                 # Divisor applied to correctable contributions under error-field correction
+
+[ErrorFields.other_field]
+magnitude = 8.2e-6               # Overlap budget of sources not attributed to any coil
+sigma = 0.0                      # Gaussian uncertainty on that budget
+radial_shape = "ring"            # Radial sampling density of the budget magnitude
+```
+
+The shift tolerance is one number, the radius of the disk the coil centre may sit in; the
+direction is sampled. A tilt may be given in degrees or, as legacy tolerance tables do, as a
+rim displacement in metres, which `tilt_tolerance_deg` converts through the coil set's
+arc-length-weighted major radius exactly as the coil loader's `tilt_in_meters` does. A coherent
+group's tilt is a rigid rotation of all its members about a pivot on the machine axis at
+`rotation_center_z_m`, so a member at height `z` also shifts laterally by `(z − z_pivot)·θ`.
+Groups sharing a `phase_group` label draw the same random direction with independent
+amplitudes. A group is correctable only if none of its members is listed as uncorrectable.
+Coil sets of the run without a tolerance block contribute their nominal overlap only.
+
+Every key is checked against the schema, so a misspelled key is an error rather than a silent
+default. `read_tolerance_toml` parses a file into a `ToleranceSet`, and `validate_tolerances`
+checks its names against a run's coil sets.
+
 ## Analysis after the run
 
 Window the coupling to any range of rational surfaces and project onto any singular mode

--- a/src/ErrorFields/ErrorFields.jl
+++ b/src/ErrorFields/ErrorFields.jl
@@ -17,6 +17,8 @@ plasma solve or a new Biot-Savart integration.
 - `Sensitivity.jl`: `compute_coil_sensitivities` (central-difference sweep of every rigid
   shift and tilt of every coil set on one shared boundary grid), `sensitivity_table`
 - `Output.jl`: HDF5 writer under `ErrorFields/CoilSensitivities/` and the matching reader
+- `ToleranceTOML.jl`: the tolerance input file — `read_tolerance_toml`, `ToleranceSet`,
+  `validate_tolerances`, and the tilt unit conversion `tilt_tolerance_deg`
 
 The stored primitive is the derivative of each coil set's root-area-weighted control-surface
 spectrum b̃, not a scalar: the overlap with any dominant mode is linear in b̃, so the ψ_N window,
@@ -26,6 +28,7 @@ the mode index, and the field normalization stay post-hoc analysis choices.
 using LinearAlgebra
 using HDF5
 using Printf
+using TOML
 
 import ..Equilibrium
 import ..ForcingTerms
@@ -36,9 +39,12 @@ import ..Utilities
 
 include("ErrorFieldsStructs.jl")
 include("Sensitivity.jl")
+include("ToleranceTOML.jl")
 include("Output.jl")
 
 export ErrorFieldsControl, CoilSensitivities, SensitivityTable
 export compute_coil_sensitivities, sensitivity_table, cancelling_offset
+export ToleranceSet, CoilTolerance, CoherentGroupTolerance, OtherFieldBudget
+export read_tolerance_toml, parse_tolerance_toml, validate_tolerances, tilt_tolerance_deg
 
 end # module ErrorFields

--- a/src/ErrorFields/ErrorFieldsStructs.jl
+++ b/src/ErrorFields/ErrorFieldsStructs.jl
@@ -15,6 +15,9 @@ never inputs: the full spectra are stored and projected post hoc with [`sensitiv
     about its own arc-length centre (the Fortran `coil_read` convention the OMFIT tolerance tool
     inherited), `"set"` rotates the whole set rigidly about its common arc-length centre (a
     winding pack moving as one body, which is what an axis-line tolerance constrains)
+  - `tolerance_file`: manufacturing-tolerance TOML (see `ToleranceTOML`), relative to the run
+    directory; empty means none. It is validated against the run's coil sets and echoed into
+    `Input/RawInputs/ErrorFields/tolerance_toml_raw`
   - `output_filename`: HDF5 file the results are appended to; empty means the run's main output
   - `write_outputs_to_HDF5`: write `ErrorFields/CoilSensitivities/` when true
   - `verbose`: log per-coil-set progress and the linearity diagnostics
@@ -23,6 +26,7 @@ Base.@kwdef struct ErrorFieldsControl
     fd_step_shift_m::Float64 = 1e-3
     fd_step_tilt_deg::Float64 = 0.1
     rotation_center::String = "conductor"
+    tolerance_file::String = ""
     output_filename::String = ""
     write_outputs_to_HDF5::Bool = true
     verbose::Bool = false

--- a/src/ErrorFields/Output.jl
+++ b/src/ErrorFields/Output.jl
@@ -85,3 +85,30 @@ function CoilSensitivities(h5path::AbstractString)
         )
     end
 end
+
+const _TOLERANCE_SNAPSHOT = "Input/RawInputs/ErrorFields/tolerance_toml_raw"
+
+"""
+    write_tolerance_snapshot!(h5file, ts::ToleranceSet)
+
+Echo the tolerance file's text into `Input/RawInputs/ErrorFields/tolerance_toml_raw`, the raw
+input snapshot a replay reads back with [`read_tolerance_snapshot`](@ref). Replaces an existing echo.
+"""
+function write_tolerance_snapshot!(h5file::HDF5.File, ts::ToleranceSet)
+    haskey(h5file, _TOLERANCE_SNAPSHOT) && delete_object(h5file, _TOLERANCE_SNAPSHOT)
+    h5file[_TOLERANCE_SNAPSHOT] = ts.raw
+    return h5file
+end
+
+"""
+    read_tolerance_snapshot(h5path) -> ToleranceSet
+
+The tolerance set a run used, parsed from the raw echo in its `gpec.h5`; `nothing` when the run
+named no tolerance file.
+"""
+function read_tolerance_snapshot(h5path::AbstractString)
+    h5open(h5path, "r") do f
+        haskey(f, _TOLERANCE_SNAPSHOT) || return nothing
+        return parse_tolerance_toml(read(f[_TOLERANCE_SNAPSHOT]))
+    end
+end

--- a/src/ErrorFields/ToleranceTOML.jl
+++ b/src/ErrorFields/ToleranceTOML.jl
@@ -1,0 +1,299 @@
+"""
+    ToleranceTOML
+
+The manufacturing-tolerance input of an error-field assessment: a TOML file, separate from
+`gpec.toml` and named by `ErrorFieldsControl.tolerance_file`, holding one `[[ErrorFields.coil]]`
+block per coil set that may move on its own, `[[ErrorFields.coherent_group]]` blocks for coil
+sets that move together, and the `[ErrorFields.correctability]` and `[ErrorFields.other_field]`
+tables. Tolerances are human-authored engineering data, so the format is diffable, commentable
+text; the raw file is echoed into `Input/RawInputs/ErrorFields/tolerance_toml_raw` for replay.
+
+```toml
+[ErrorFields.defaults]           # fallbacks for keys a coil block leaves out (all optional)
+tilt_units = "deg"
+radial_shape = "hollow"
+
+[[ErrorFields.coil]]
+name = "PF1U"                    # a coil set name of the run
+shift_tol_mm = 0.5               # radius of the in-plane displacement disk the coil may sit in
+tilt_tol = 0.019                 # tilt tolerance, in tilt_units
+tolerance_model = "cylinder"     # axis line inside a cylinder: shift and tilt drawn together
+cylinder_half_height_m = 1.5
+
+[[ErrorFields.coherent_group]]
+name = "upper_pf_brace"
+members = ["PF1U", "PF2U"]       # move together with one shared draw per sample
+shift_tol_mm = 2.0
+tilt_tol = 0.0
+phase_group = "braces"           # groups naming the same phase_group share the random direction
+
+[ErrorFields.correctability]
+uncorrectable_coils = ["EFCC_U"] # excluded from the error-field-correction division
+efc_factor = 2.0
+
+[ErrorFields.other_field]
+magnitude = 8.2e-6               # overlap budget of sources not attributed to any coil
+```
+"""
+
+const RADIAL_SHAPES = ("flat", "uniform_area", "hollow", "ring")
+const TOLERANCE_MODELS = ("additive", "cylinder")
+const TILT_UNITS = ("deg", "m")
+
+"""
+    CoilTolerance
+
+Manufacturing tolerance of one coil set that moves independently. Lengths are in metres and
+the tilt tolerance in `tilt_units`; convert it to the degrees the sensitivities are stored in
+with [`tilt_tolerance_deg`](@ref).
+
+## Fields
+
+  - `name`: coil set name; must match a coil set of the run
+  - `shift_tol_m`: radius of the in-plane displacement disk the coil centre may lie in, metres
+  - `shift_sigma_m`: Gaussian uncertainty added to the sampled shift, metres
+  - `tilt_tol`: tilt tolerance, in `tilt_units`
+  - `tilt_sigma`: Gaussian uncertainty added to the sampled tilt, in `tilt_units`
+  - `tilt_units`: `"deg"`, or `"m"` for a rim displacement converted through the coil's
+    nominal major radius
+  - `radial_shape`: radial sampling density on the disk: `"flat"` (uniform in radius),
+    `"uniform_area"`, `"hollow"` (peaked toward the edge), or `"ring"` (always at the edge)
+  - `tolerance_model`: `"additive"` (independent shift and tilt draws) or `"cylinder"` (the
+    coil axis line confined to a cylinder of radius `shift_tol_m`, shift and tilt drawn together)
+  - `cylinder_half_height_m`: half-height of that cylinder, metres; sets the tilt reachable at
+    the given radius
+"""
+struct CoilTolerance
+    name::String
+    shift_tol_m::Float64
+    shift_sigma_m::Float64
+    tilt_tol::Float64
+    tilt_sigma::Float64
+    tilt_units::String
+    radial_shape::String
+    tolerance_model::String
+    cylinder_half_height_m::Float64
+end
+
+"""
+    CoherentGroupTolerance
+
+Tolerance of a set of coils that move together: every member receives the same displacement
+(and the same rotation about a common pivot) from one random draw per sample. Groups that name
+the same `phase_group` share the random direction of that draw while keeping independent
+amplitudes.
+
+## Fields
+
+  - `name`: label of the group
+  - `members`: coil set names moving together
+  - `shift_tol_m`, `tilt_tol`, `tilt_units`, `radial_shape`, `tolerance_model`,
+    `cylinder_half_height_m`: as in [`CoilTolerance`](@ref), applied to the shared draw
+  - `phase_group`: groups with equal labels share the random direction; defaults to `name`
+  - `rotation_center_z_m`: height of the pivot of the group's rigid rotation on the machine axis,
+    metres; a member at height `z` tilted by θ also shifts laterally by `(z − z_pivot)·θ`
+"""
+struct CoherentGroupTolerance
+    name::String
+    members::Vector{String}
+    shift_tol_m::Float64
+    tilt_tol::Float64
+    tilt_units::String
+    radial_shape::String
+    tolerance_model::String
+    cylinder_half_height_m::Float64
+    phase_group::String
+    rotation_center_z_m::Float64
+end
+
+"""
+    OtherFieldBudget
+
+Overlap budget for error-field sources not attributed to any coil, sampled once per Monte
+Carlo sample as an incoherent contribution with a random direction.
+
+## Fields
+
+  - `magnitude`: dimensionless overlap magnitude of the budget
+  - `sigma`: Gaussian uncertainty on that magnitude
+  - `radial_shape`: radial sampling density of the magnitude, as in [`CoilTolerance`](@ref)
+"""
+struct OtherFieldBudget
+    magnitude::Float64
+    sigma::Float64
+    radial_shape::String
+end
+
+"""
+    ToleranceSet
+
+Everything a tolerance TOML file specifies, parsed and validated by [`read_tolerance_toml`](@ref).
+
+## Fields
+
+  - `coils`: independently moving coil sets `[ncoil]`
+  - `groups`: coherently moving groups `[ngroup]`
+  - `uncorrectable_coils`: coil set names whose error field the correction system cannot reduce
+  - `efc_factor`: divisor applied to the correctable contributions when error-field correction is on
+  - `other_field`: the unattributed budget
+  - `raw`: the file's text, echoed into the output for replay
+"""
+struct ToleranceSet
+    coils::Vector{CoilTolerance}
+    groups::Vector{CoherentGroupTolerance}
+    uncorrectable_coils::Vector{String}
+    efc_factor::Float64
+    other_field::OtherFieldBudget
+    raw::String
+end
+
+# Built-in fallbacks for the per-coil keys, overridable by [ErrorFields.defaults]. The radial
+# shape and the other-field shape follow the OMFIT tool's defaults.
+const _COIL_KEY_DEFAULTS = Dict{String,Any}(
+    "shift_sigma_mm" => 0.0, "tilt_sigma" => 0.0, "tilt_units" => "deg", "radial_shape" => "hollow",
+    "tolerance_model" => "additive", "cylinder_half_height_m" => 0.0
+)
+const _GROUP_ONLY_KEYS = ("members", "phase_group", "rotation_center_z_m")
+
+"""
+    read_tolerance_toml(path) -> ToleranceSet
+    parse_tolerance_toml(text) -> ToleranceSet
+
+Read and validate a tolerance TOML file (see the module docstring for the schema). Every key is
+checked against the schema so a misspelled key errors instead of silently taking a default;
+tolerances must be non-negative, names unique, enumerated fields one of their allowed values,
+`efc_factor ≥ 1`, and a cylinder model needs a positive half-height. Names are checked against
+the run's coil sets separately by [`validate_tolerances`](@ref).
+"""
+read_tolerance_toml(path::AbstractString) = parse_tolerance_toml(read(path, String))
+
+function parse_tolerance_toml(text::AbstractString)
+    root = TOML.parse(String(text))
+    haskey(root, "ErrorFields") || throw(ArgumentError("tolerance TOML has no [ErrorFields] tables (blocks are [[ErrorFields.coil]], ...)"))
+    ef = root["ErrorFields"]
+    _check_keys(ef, ("defaults", "coil", "coherent_group", "correctability", "other_field"), "ErrorFields")
+
+    defaults = merge(_COIL_KEY_DEFAULTS, get(ef, "defaults", Dict{String,Any}()))
+    _check_keys(defaults, collect(keys(_COIL_KEY_DEFAULTS)), "ErrorFields.defaults")
+
+    coils = [_parse_coil(d, defaults) for d in get(ef, "coil", Dict{String,Any}[])]
+    groups = [_parse_group(d, defaults) for d in get(ef, "coherent_group", Dict{String,Any}[])]
+    _unique_names([c.name for c in coils], "[[ErrorFields.coil]]")
+    _unique_names([g.name for g in groups], "[[ErrorFields.coherent_group]]")
+
+    corr = get(ef, "correctability", Dict{String,Any}())
+    _check_keys(corr, ("uncorrectable_coils", "efc_factor"), "ErrorFields.correctability")
+    uncorrectable = String.(get(corr, "uncorrectable_coils", String[]))
+    efc_factor = Float64(get(corr, "efc_factor", 2.0))
+    efc_factor >= 1 || throw(ArgumentError("efc_factor must be ≥ 1 (got $efc_factor)"))
+
+    other = get(ef, "other_field", Dict{String,Any}())
+    _check_keys(other, ("magnitude", "sigma", "radial_shape"), "ErrorFields.other_field")
+    other_field = OtherFieldBudget(_nonneg(get(other, "magnitude", 0.0), "other_field.magnitude"),
+        _nonneg(get(other, "sigma", 0.0), "other_field.sigma"),
+        _enum(get(other, "radial_shape", "ring"), RADIAL_SHAPES, "other_field.radial_shape"))
+
+    return ToleranceSet(coils, groups, uncorrectable, efc_factor, other_field, String(text))
+end
+
+function _parse_coil(d::Dict{String,Any}, defaults::Dict{String,Any})
+    _check_keys(d, vcat("name", "shift_tol_mm", "tilt_tol", collect(keys(_COIL_KEY_DEFAULTS))), "[[ErrorFields.coil]]")
+    haskey(d, "name") || throw(ArgumentError("a [[ErrorFields.coil]] block has no name"))
+    name = String(d["name"])
+    get_key(k) = get(d, k, defaults[k])
+    model = _enum(get_key("tolerance_model"), TOLERANCE_MODELS, "$name.tolerance_model")
+    half_height = _nonneg(get_key("cylinder_half_height_m"), "$name.cylinder_half_height_m")
+    model == "cylinder" && half_height <= 0 && throw(ArgumentError("coil $name: the cylinder model needs cylinder_half_height_m > 0"))
+    return CoilTolerance(name,
+        1e-3 * _nonneg(get(d, "shift_tol_mm", 0.0), "$name.shift_tol_mm"),
+        1e-3 * _nonneg(get_key("shift_sigma_mm"), "$name.shift_sigma_mm"),
+        _nonneg(get(d, "tilt_tol", 0.0), "$name.tilt_tol"),
+        _nonneg(get_key("tilt_sigma"), "$name.tilt_sigma"),
+        _enum(get_key("tilt_units"), TILT_UNITS, "$name.tilt_units"),
+        _enum(get_key("radial_shape"), RADIAL_SHAPES, "$name.radial_shape"),
+        model, half_height)
+end
+
+function _parse_group(d::Dict{String,Any}, defaults::Dict{String,Any})
+    _check_keys(d, vcat("name", "shift_tol_mm", "tilt_tol", "tilt_units", "radial_shape", "tolerance_model",
+            "cylinder_half_height_m", collect(_GROUP_ONLY_KEYS)), "[[ErrorFields.coherent_group]]")
+    haskey(d, "name") || throw(ArgumentError("a [[ErrorFields.coherent_group]] block has no name"))
+    name = String(d["name"])
+    members = String.(get(d, "members", String[]))
+    isempty(members) && throw(ArgumentError("coherent group $name lists no members"))
+    _unique_names(members, "coherent group $name members")
+    get_key(k) = get(d, k, defaults[k])
+    model = _enum(get_key("tolerance_model"), TOLERANCE_MODELS, "$name.tolerance_model")
+    half_height = _nonneg(get_key("cylinder_half_height_m"), "$name.cylinder_half_height_m")
+    model == "cylinder" && half_height <= 0 && throw(ArgumentError("coherent group $name: the cylinder model needs cylinder_half_height_m > 0"))
+    return CoherentGroupTolerance(name, members,
+        1e-3 * _nonneg(get(d, "shift_tol_mm", 0.0), "$name.shift_tol_mm"),
+        _nonneg(get(d, "tilt_tol", 0.0), "$name.tilt_tol"),
+        _enum(get_key("tilt_units"), TILT_UNITS, "$name.tilt_units"),
+        _enum(get_key("radial_shape"), RADIAL_SHAPES, "$name.radial_shape"),
+        model, half_height,
+        String(get(d, "phase_group", name)),
+        Float64(get(d, "rotation_center_z_m", 0.0)))
+end
+
+function _check_keys(d::Dict{String,Any}, allowed, where::String)
+    for k in keys(d)
+        k in allowed || throw(ArgumentError("unknown key \"$k\" in $where (allowed: $(join(allowed, ", ")))"))
+    end
+end
+
+function _unique_names(names, where::String)
+    length(unique(names)) == length(names) || throw(ArgumentError("duplicate names in $where: $(join(unique(filter(n -> count(==(n), names) > 1, names)), ", "))"))
+end
+
+function _nonneg(v, what::String)
+    x = Float64(v)
+    x >= 0 || throw(ArgumentError("$what must be ≥ 0 (got $x)"))
+    return x
+end
+
+function _enum(v, allowed, what::String)
+    s = lowercase(String(v))
+    s in allowed || throw(ArgumentError("$what must be one of $(join(allowed, ", ")) (got \"$v\")"))
+    return s
+end
+
+"""
+    validate_tolerances(ts::ToleranceSet, coil_names) -> ts
+
+Check every coil, group member, and uncorrectable-coil name of `ts` against the coil set names
+of a run (for instance `CoilSensitivities.coil_names`), throwing an `ArgumentError` that lists
+the unknown names. Coil sets of the run that carry no tolerance are allowed: they contribute
+only their nominal overlap.
+"""
+function validate_tolerances(ts::ToleranceSet, coil_names::AbstractVector{<:AbstractString})
+    known = Set(String.(coil_names))
+    unknown = String[]
+    for c in ts.coils
+        c.name in known || push!(unknown, "coil $(c.name)")
+    end
+    for g in ts.groups, m in g.members
+        m in known || push!(unknown, "member $m of group $(g.name)")
+    end
+    for u in ts.uncorrectable_coils
+        u in known || push!(unknown, "uncorrectable coil $u")
+    end
+    isempty(unknown) || throw(ArgumentError("tolerance names not among the run's coil sets ($(join(sort(collect(known)), ", "))): $(join(unknown, "; "))"))
+    return ts
+end
+
+"""
+    tilt_tolerance_deg(tilt, tilt_units, cs::CoilSet) -> Float64
+    tilt_tolerance_deg(t::CoilTolerance, cs::CoilSet) -> Float64
+
+A tilt tolerance in the degrees the stored sensitivities use. `"deg"` passes through; `"m"` is
+a rim displacement converted through the coil set's arc-length-weighted major radius exactly as
+`apply_transforms` converts `tilt_in_meters`: `asin(t / R_nom)`.
+"""
+function tilt_tolerance_deg(tilt::Real, tilt_units::AbstractString, cs::CoilSet)
+    tilt_units == "deg" && return Float64(tilt)
+    r_nom = ForcingTerms.nominal_major_radius(cs)
+    tilt <= r_nom || throw(ArgumentError("tilt $tilt m exceeds the nominal radius $r_nom m of coil set $(cs.name)"))
+    return rad2deg(asin(tilt / r_nom))
+end
+tilt_tolerance_deg(t::CoilTolerance, cs::CoilSet) = tilt_tolerance_deg(t.tilt_tol, t.tilt_units, cs)

--- a/src/ForcingTerms/CoilGeometry.jl
+++ b/src/ForcingTerms/CoilGeometry.jl
@@ -402,10 +402,12 @@ function make_window_pane_standoff(equil; standoff::Real, poloidal_angle::Real,
     # boundary along the normal is standoff - half*|sin(tilt)| — the tilt tips the legs toward the
     # surface, while tangential displacement leaves the normal clearance unchanged.
     clearance = standoff - half * abs(sin(deg2rad(poloidal_tilt)))
-    clearance > 0 || error("make_window_pane_standoff: coil intersects the plasma boundary " *
-                           "(standoff=$standoff, poloidal_length=$poloidal_length, poloidal_tilt=$poloidal_tilt); " *
-                           "an external coil must lie outside the control surface — increase standoff or reduce " *
-                           "poloidal_length/poloidal_tilt")
+    clearance > 0 || error(
+        "make_window_pane_standoff: coil intersects the plasma boundary " *
+        "(standoff=$standoff, poloidal_length=$poloidal_length, poloidal_tilt=$poloidal_tilt); " *
+        "an external coil must lie outside the control surface — increase standoff or reduce " *
+        "poloidal_length/poloidal_tilt"
+    )
 
     c1 = [Rc - half * uR, Zc - half * uZ]
     c2 = [Rc + half * uR, Zc + half * uZ]
@@ -743,6 +745,44 @@ function convert_coil_h5_to_dat(h5_path::String, dat_path::String;
 end
 
 """
+    nominal_major_radius(x, y, z) -> Float64
+    nominal_major_radius(cs::CoilSet) -> Float64
+
+Arc-length-weighted major radius √(x²+y²) of a strand, or of every strand of a coil set: the
+radius through which a rim displacement in metres converts to a tilt angle, `asin(t / R_nom)`,
+as `apply_transforms` does for `tilt_in_meters`. A strand with no length returns 1.
+"""
+function nominal_major_radius(x::AbstractVector, y::AbstractVector, z::AbstractVector)
+    weighted_r, total_len = _weighted_major_radius(x, y, z)
+    return total_len > 0 ? weighted_r / total_len : 1.0
+end
+
+function nominal_major_radius(cs::CoilSet)
+    weighted_r = 0.0
+    total_len = 0.0
+    for j in 1:cs.ncoil, k in 1:cs.s
+        w, l = _weighted_major_radius(view(cs.x, j, k, :), view(cs.y, j, k, :), view(cs.z, j, k, :))
+        weighted_r += w
+        total_len += l
+    end
+    return total_len > 0 ? weighted_r / total_len : 1.0
+end
+
+# Arc-length-weighted major radius sum and total arc length of one strand.
+function _weighted_major_radius(x::AbstractVector, y::AbstractVector, z::AbstractVector)
+    total_len = 0.0
+    weighted_r = 0.0
+    for l in 1:(length(x)-1)
+        xm = (x[l] + x[l+1]) / 2
+        ym = (y[l] + y[l+1]) / 2
+        dl = sqrt((x[l+1] - x[l])^2 + (y[l+1] - y[l])^2 + (z[l+1] - z[l])^2)
+        weighted_r += sqrt(xm^2 + ym^2) * dl
+        total_len += dl
+    end
+    return weighted_r, total_len
+end
+
+"""
     _arc_length_center(x, y, z) -> (x0, y0, z0)
 
 Compute the arc-length-weighted centroid of a strand (1D array of points).
@@ -833,22 +873,8 @@ function apply_transforms(cs::CoilSet, cfg::CoilSetConfig; n_tilt::Int=1)
                 (x0, y0, z0)
             end
 
-            # Compute nominal radius for tilt_in_meters conversion
-            r_nom = if cfg.tilt_in_meters
-                total_len = 0.0
-                weighted_r = 0.0
-                for l in 1:(nsec-1)
-                    xm = (cs.x[j, k, l] + cs.x[j, k, l+1]) / 2
-                    ym = (cs.y[j, k, l] + cs.y[j, k, l+1]) / 2
-                    dl = sqrt((cs.x[j, k, l+1] - cs.x[j, k, l])^2 + (cs.y[j, k, l+1] - cs.y[j, k, l])^2 +
-                              (cs.z[j, k, l+1] - cs.z[j, k, l])^2)
-                    weighted_r += sqrt(xm^2 + ym^2) * dl
-                    total_len += dl
-                end
-                total_len > 0 ? weighted_r / total_len : 1.0
-            else
-                1.0  # not used
-            end
+            # Nominal radius for the tilt_in_meters conversion
+            r_nom = cfg.tilt_in_meters ? nominal_major_radius(view(cs.x, j, k, :), view(cs.y, j, k, :), view(cs.z, j, k, :)) : 1.0
 
             # Convert tilt to radians
             dtor = π / 180.0
@@ -1032,7 +1058,7 @@ function load_coil_sets(cfg::CoilConfig, n_tilt::Int; equil=nothing)
 end
 
 export CoilSet, CoilSetConfig, CoilConfig
-export read_coil_dat, apply_transforms, load_coil_sets
+export read_coil_dat, apply_transforms, load_coil_sets, nominal_major_radius
 export make_pf_hoop, make_window_pane, make_helical
 export make_window_pane_standoff, surface_point_and_normal
 export read_coil_h5, write_coil_h5, write_coil_dat, save_coils_to_h5, load_coils_from_h5_group!

--- a/src/GeneralizedPerturbedEquilibrium.jl
+++ b/src/GeneralizedPerturbedEquilibrium.jl
@@ -996,7 +996,8 @@ end
     run_error_fields(inputs, result, pe_state, preloaded_coil_sets) -> CoilSensitivities or nothing
 
 Linearize every coil set's resonant drive with respect to its rigid shifts and tilts and write
-`ErrorFields/CoilSensitivities/` when the deck carries an `[ErrorFields]` section. Needs the
+`ErrorFields/CoilSensitivities/` when the deck carries an `[ErrorFields]` section; read, validate
+and echo the tolerance file when one is named. Needs the
 perturbed-equilibrium state's singular-coupling matrix and coil-format forcing, and errors
 otherwise: a deck asking for error-field sensitivities without them is a misconfiguration, not a
 case to skip silently. Coil geometry is rebuilt from the deck unless a replay injected it.
@@ -1024,10 +1025,20 @@ function run_error_fields(
     sens = ErrorFields.compute_coil_sensitivities(coil_sets, rc, result.equil, cfg, ef_ctrl;
         psi=result.psilim, b_t0=result.equil.params.bt0)
 
+    tolerances = nothing
+    if !isempty(ef_ctrl.tolerance_file)
+        tol_path = joinpath(result.dir_path, ef_ctrl.tolerance_file)
+        isfile(tol_path) || error("[ErrorFields] tolerance_file not found: $tol_path")
+        tolerances = ErrorFields.validate_tolerances(ErrorFields.read_tolerance_toml(tol_path), sens.coil_names)
+        @info "Tolerances: $(length(tolerances.coils)) coil sets, $(length(tolerances.groups)) coherent groups from $(ef_ctrl.tolerance_file)"
+    end
+
     if ef_ctrl.write_outputs_to_HDF5
         output_file = isempty(ef_ctrl.output_filename) ? result.control.HDF5_filename : ef_ctrl.output_filename
         h5open(joinpath(result.dir_path, output_file), "cw") do h5file
             ErrorFields.write_to_hdf5!(h5file, sens, PerturbedEquilibrium.dominant_coupling(rc))
+            # Raw echo of the tolerance input for replay (read back by ErrorFields.parse_tolerance_toml).
+            tolerances === nothing || ErrorFields.write_tolerance_snapshot!(h5file, tolerances)
         end
         @info "Results written to $output_file"
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ else
     include("./runtests_solve_api.jl")
     include("./runtests_dominant_coupling.jl")
     include("./runtests_error_fields.jl")
+    include("./runtests_tolerance_toml.jl")
     include("./runtests_sing.jl")
     include("./runtests_innerlayer.jl")
     include("./runtests_tj_analytic.jl")

--- a/test/runtests_error_fields.jl
+++ b/test/runtests_error_fields.jl
@@ -49,7 +49,8 @@ include("h5_metadata_check.jl")
             inputs["PerturbedEquilibrium"] = Dict{String,Any}(
                 "compute_response" => true, "compute_singular_coupling" => true,
                 "verbose" => false, "write_outputs_to_HDF5" => true)
-            inputs["ErrorFields"] = Dict{String,Any}("verbose" => false)
+            cp(joinpath(@__DIR__, "test_data", "ErrorFields", "tolerances_two_hoops.toml"), joinpath(dir, "tolerances.toml"))
+            inputs["ErrorFields"] = Dict{String,Any}("verbose" => false, "tolerance_file" => "tolerances.toml")
             open(io -> TOML.print(io, inputs), toml_path, "w")
 
             res = GPEC.main([dir])
@@ -102,7 +103,13 @@ include("h5_metadata_check.jl")
             h5open(h5path, "r") do f
                 @test haskey(f, "ErrorFields/CoilSensitivities/DominantMode/delta_nominal")
                 @test isempty(_collect_metadata_violations(f))
+                @test haskey(f, "Input/RawInputs/ErrorFields/tolerance_toml_raw")
             end
+            # The tolerance file was validated against these coil sets and echoed verbatim.
+            snapshot = EF.read_tolerance_snapshot(h5path)
+            @test snapshot isa EF.ToleranceSet
+            @test snapshot.raw == read(joinpath(dir, "tolerances.toml"), String)
+            @test [c.name for c in snapshot.coils] == ["hoop_tilted", "hoop_axi"]
             from_file = EF.CoilSensitivities(h5path)
             @test from_file.coil_names == sens.coil_names
             @test from_file.m_modes == sens.m_modes && from_file.n_modes == sens.n_modes

--- a/test/runtests_tolerance_toml.jl
+++ b/test/runtests_tolerance_toml.jl
@@ -1,0 +1,99 @@
+using TOML
+
+# The tolerance TOML schema: the fixture parses into the expected structs with defaults and
+# unit conversions applied, every validation rule throws on a bad file, name checks against a
+# run's coil sets work, and the metres-to-degrees tilt conversion matches apply_transforms.
+@testset "tolerance TOML" begin
+    GPEC = GeneralizedPerturbedEquilibrium
+    EF = GPEC.ErrorFields
+    FT = GPEC.ForcingTerms
+    fixture = joinpath(@__DIR__, "test_data", "ErrorFields", "tolerances_two_hoops.toml")
+
+    @testset "fixture parses with defaults and units" begin
+        ts = EF.read_tolerance_toml(fixture)
+        @test ts isa EF.ToleranceSet
+        @test ts.raw == read(fixture, String)
+        @test [c.name for c in ts.coils] == ["hoop_tilted", "hoop_axi"]
+
+        c1, c2 = ts.coils
+        @test c1.shift_tol_m ≈ 0.5e-3
+        @test c1.shift_sigma_m ≈ 0.1e-3          # from [ErrorFields.defaults]
+        @test c1.tilt_tol == 0.002 && c1.tilt_units == "m" && c1.tilt_sigma == 0.0005
+        @test c1.radial_shape == "flat"          # from [ErrorFields.defaults]
+        @test c1.tolerance_model == "additive" && c1.cylinder_half_height_m == 0.0
+        @test c2.tolerance_model == "cylinder" && c2.cylinder_half_height_m == 1.5
+        @test c2.radial_shape == "hollow" && c2.tilt_units == "deg" && c2.shift_tol_m ≈ 2e-3
+
+        @test length(ts.groups) == 1
+        g = ts.groups[1]
+        @test g.name == "both_hoops" && g.members == ["hoop_tilted", "hoop_axi"]
+        @test g.shift_tol_m ≈ 1e-3 && g.tilt_tol == 0.01 && g.tilt_units == "deg"
+        @test g.phase_group == "support" && g.rotation_center_z_m == 0.2
+        @test g.radial_shape == "flat"           # defaults apply to groups too
+        @test ts.uncorrectable_coils == ["hoop_axi"] && ts.efc_factor == 2.0
+        @test ts.other_field.magnitude == 8.2e-6 && ts.other_field.sigma == 1e-6 && ts.other_field.radial_shape == "ring"
+
+        # Defaults when tables are absent, and the phase group defaulting to the group's name.
+        minimal = EF.parse_tolerance_toml("""
+            [[ErrorFields.coil]]
+            name = "a"
+            shift_tol_mm = 1.0
+            [[ErrorFields.coherent_group]]
+            name = "g"
+            members = ["a"]
+            """)
+        @test minimal.coils[1].radial_shape == "hollow" && minimal.coils[1].tilt_units == "deg"
+        @test minimal.coils[1].tilt_tol == 0.0 && minimal.coils[1].shift_sigma_m == 0.0
+        @test minimal.groups[1].phase_group == "g" && minimal.groups[1].rotation_center_z_m == 0.0
+        @test minimal.efc_factor == 2.0 && isempty(minimal.uncorrectable_coils)
+        @test minimal.other_field.magnitude == 0.0 && minimal.other_field.radial_shape == "ring"
+    end
+
+    @testset "validation errors" begin
+        bad(text) = @test_throws ArgumentError EF.parse_tolerance_toml(text)
+        bad("[[coil]]\nname = \"a\"\n")                                          # no [ErrorFields] prefix
+        bad("[[ErrorFields.coil]]\nshift_tol_mm = 1.0\n")                       # unnamed coil
+        bad("[[ErrorFields.coil]]\nname = \"a\"\nshift_tol = 1.0\n")            # misspelled key
+        bad("[[ErrorFields.coil]]\nname = \"a\"\nshift_tol_mm = -1.0\n")        # negative tolerance
+        bad("[[ErrorFields.coil]]\nname = \"a\"\nradial_shape = \"gaussian\"\n") # unknown shape
+        bad("[[ErrorFields.coil]]\nname = \"a\"\ntilt_units = \"rad\"\n")       # unknown units
+        bad("[[ErrorFields.coil]]\nname = \"a\"\ntolerance_model = \"cylinder\"\n") # cylinder without height
+        bad("[[ErrorFields.coil]]\nname = \"a\"\n[[ErrorFields.coil]]\nname = \"a\"\n") # duplicate
+        bad("[[ErrorFields.coherent_group]]\nname = \"g\"\n")                    # no members
+        bad("[[ErrorFields.coherent_group]]\nname = \"g\"\nmembers = [\"a\", \"a\"]\n") # duplicate member
+        bad("[ErrorFields.correctability]\nefc_factor = 0.5\n")                  # efc_factor < 1
+        bad("[ErrorFields.defaults]\nname = \"x\"\n")                            # name is not a default
+        bad("[ErrorFields.other_field]\nmagnitude = -1.0\n")
+        # Case-insensitive enumerations are normalized.
+        @test EF.parse_tolerance_toml("[[ErrorFields.coil]]\nname = \"a\"\nradial_shape = \"Hollow\"\n").coils[1].radial_shape == "hollow"
+    end
+
+    @testset "name validation against a run" begin
+        ts = EF.read_tolerance_toml(fixture)
+        @test EF.validate_tolerances(ts, ["hoop_tilted", "hoop_axi", "c"]) === ts
+        err = try
+            EF.validate_tolerances(ts, ["hoop_tilted"])
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("coil hoop_axi", err.msg) && occursin("member hoop_axi", err.msg) && occursin("uncorrectable coil hoop_axi", err.msg)
+    end
+
+    @testset "tilt units through the nominal radius" begin
+        hoop = FT.make_pf_hoop(; radius=1.5, height=0.4, name="hoop")
+        # A 361-point polygon sits at R·cos(π/360) on its chord midpoints, 4e-5 inside the circle.
+        @test FT.nominal_major_radius(hoop) ≈ 1.5 rtol = 1e-4
+        @test EF.tilt_tolerance_deg(0.01, "deg", hoop) == 0.01
+        @test EF.tilt_tolerance_deg(0.002, "m", hoop) ≈ rad2deg(asin(0.002 / 1.5)) rtol = 1e-4
+        @test_throws ArgumentError EF.tilt_tolerance_deg(2.0, "m", hoop)
+        ts = EF.read_tolerance_toml(fixture)
+        @test EF.tilt_tolerance_deg(ts.coils[1], hoop) ≈ rad2deg(asin(0.002 / 1.5)) rtol = 1e-4
+        # The conversion is the one apply_transforms uses for tilt_in_meters: a rim displacement
+        # of t metres tilts the hoop by the same angle either way.
+        by_meters = FT.apply_transforms(hoop, FT.CoilSetConfig(; tiltx=[0.002], tilt_in_meters=true); n_tilt=1)
+        by_degrees = FT.apply_transforms(hoop, FT.CoilSetConfig(; tiltx=[EF.tilt_tolerance_deg(0.002, "m", hoop)]); n_tilt=1)
+        @test by_meters.z ≈ by_degrees.z atol = 1e-12
+    end
+end

--- a/test/test_data/ErrorFields/tolerances_two_hoops.toml
+++ b/test/test_data/ErrorFields/tolerances_two_hoops.toml
@@ -1,0 +1,42 @@
+# Manufacturing tolerances for the two-hoop Solovev error-field test fixture: one coil with an
+# additive shift+tilt tolerance given in metres, one with the cylinder axis-line model, a
+# coherent group binding both, an uncorrectable coil, and an unattributed budget. Exercises
+# every table of the tolerance schema (see docs/src/error_fields.md).
+
+[ErrorFields.defaults]
+shift_sigma_mm = 0.1             # Gaussian uncertainty added to the sampled shift [mm]
+radial_shape = "flat"            # Radial sampling density on the disk: flat, uniform_area, hollow, or ring
+
+[[ErrorFields.coil]]
+name = "hoop_tilted"             # Coil set name; must match a [[ForcingTerms.coil_set]] of the run
+shift_tol_mm = 0.5               # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.002                 # Tilt tolerance, in tilt_units
+tilt_sigma = 0.0005              # Gaussian uncertainty added to the sampled tilt, in tilt_units
+tilt_units = "m"                 # "deg", or "m" for a rim displacement converted through the nominal radius
+tolerance_model = "additive"     # "additive" (independent shift and tilt) or "cylinder" (correlated axis line)
+
+[[ErrorFields.coil]]
+name = "hoop_axi"                # Coil set name; must match a [[ForcingTerms.coil_set]] of the run
+shift_tol_mm = 2.0               # Cylinder radius the coil axis line must stay within [mm]
+tilt_tol = 0.019                 # Tilt tolerance, in tilt_units
+radial_shape = "hollow"          # Radial sampling density for each axis endpoint
+tolerance_model = "cylinder"     # Axis line confined to a cylinder; shift and tilt drawn together
+cylinder_half_height_m = 1.5     # Cylinder half-height; sets the tilt reachable at the given radius [m]
+
+[[ErrorFields.coherent_group]]
+name = "both_hoops"              # Label of the coherently moving group
+members = ["hoop_tilted", "hoop_axi"] # Coil sets sharing one random draw per sample
+shift_tol_mm = 1.0               # Coherent shift amplitude shared by the group [mm]
+tilt_tol = 0.01                  # Coherent tilt amplitude shared by the group, in tilt_units
+tilt_units = "deg"               # "deg" or "m"
+phase_group = "support"          # Groups naming the same phase_group share the random direction
+rotation_center_z_m = 0.2        # Height of the pivot of the group's rigid rotation on the machine axis [m]
+
+[ErrorFields.correctability]
+uncorrectable_coils = ["hoop_axi"] # Coil sets the error-field correction cannot reduce
+efc_factor = 2.0                 # Divisor applied to correctable contributions under error-field correction
+
+[ErrorFields.other_field]
+magnitude = 8.2e-6               # Overlap budget of sources not attributed to any coil
+sigma = 1.0e-6                   # Gaussian uncertainty on that budget
+radial_shape = "ring"            # Radial sampling density of the budget magnitude


### PR DESCRIPTION
Fourth PR of the OMFIT → Julia error-field tolerance migration, stacked on #448. It fixes the **tolerance input format**: a TOML file, separate from `gpec.toml`, holding the manufacturing tolerances of each coil set and coherent group, the correctability split, and the unattributed error-field budget. The sampling, Monte Carlo, and risk stages that consume it follow in PR5–PR7; this PR gives them a validated, replayable input and keeps device numbers out of the repository.

**What it does**

- `src/ErrorFields/ToleranceTOML.jl`: `read_tolerance_toml` / `parse_tolerance_toml` → `ToleranceSet` (`CoilTolerance`, `CoherentGroupTolerance`, `OtherFieldBudget`), with an `[ErrorFields.defaults]` table for per-coil fallbacks. Every key is schema-checked (a misspelled key errors), tolerances non-negative, enumerations normalized, `efc_factor ≥ 1`, a cylinder model needs a positive half-height.
- `validate_tolerances(ts, coil_names)` cross-checks coil, member, and uncorrectable names against a run's coil sets; `tilt_tolerance_deg` converts a rim-displacement tilt tolerance in metres to degrees through the coil set's arc-length-weighted major radius, exactly as the coil loader's `tilt_in_meters` does — that radius is now `ForcingTerms.nominal_major_radius`, factored out of `apply_transforms`.
- `ErrorFieldsControl.tolerance_file` (relative to the run directory): the driver reads, validates against the run's coil sets, and echoes the text into `Input/RawInputs/ErrorFields/tolerance_toml_raw`; `read_tolerance_snapshot(h5path)` reads it back.
- Docs section with the annotated schema; fixture `test/test_data/ErrorFields/tolerances_two_hoops.toml`; 45 parser tests plus the echo round trip inside the existing Solovev error-fields run.

**Three schema points that differ from the plan sketch, taken from the OMFIT source rather than the plan** (worth a look, @logan-nc):

1. `phasing_index` in OMFIT is a per-row label: coherent rows sharing a label share the random *direction* while keeping independent amplitudes. The schema therefore has `phase_group = "<label>"` per group (default: the group's own name), not per-member phases in radians.
2. OMFIT's coherent tilt in degrees is a rigid rotation of the whole group about the machine centre, adding a lateral shift `(z − z_pivot)·θ` to each member, with a code note that a specifiable centre was wanted. `rotation_center_z_m` (default 0) carries that for PR6.
3. Default radial shape is `"hollow"` (OMFIT's `misalignment_pdf_types` default, used by the SPP risk scans), `other_field.radial_shape` defaults to `"ring"` (OMFIT's `other_delta_pdf_type`). `flat` keeps its OMFIT meaning (uniform in radius); `uniform_area` is the new evenly-sampled option.

One thing noticed for PR5, not encoded here: OMFIT's cylinder sampler sets `phase_bot = phase_unique_top[...]` — the bottom-disk phase it computes is never used, so both axis endpoints share a direction and the sampled axis line is always coplanar with ẑ. That looks like a typo rather than a model; PR5 will sample the endpoints independently and can carry a reproduction toggle if you want the benchmark to match it.

cc @matt-pharr

## Release note

- **Audience:** users
- **Numerical impact:** none _(harness @ d6dfc0c7)_
- **Migration:** none

Error-field tolerances can now be given in a TOML file named by `tolerance_file` in `[ErrorFields]`: per-coil shift and tilt tolerances (with sampling shape and additive or cylinder model), coherent groups, the correctable/uncorrectable split, and an unattributed budget. The file is validated against the run's coil sets and echoed into `gpec.h5` for replay.

## Regression report

```
Regression Report: diiid_n1
=================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
Ref 2: local  @ local (2026-09-11)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
-------------------------------------------------------------------------------------------------
Quantity                                      develop          local            Diff       Status
-------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01     0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05     0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00    0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00     0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01     0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]        0.0e+00    OK    
ODE steps (saved)                             2576             2576             0.0e+00    OK    
ODE steps (total)                             4572             4572             0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00     0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00     0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02     0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00     0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01     0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01     0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01     0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01     0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01     0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01     0.0e+00    OK    
# singular surfaces                           5                5                0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]         0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]         0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01     0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01     0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00     0.0e+00    OK    
mpert                                         35               35               0.0e+00    OK    
npert                                         1                1                0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00     0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01     0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00     0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00     0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...  identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...  identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...  identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...  identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...  identical  OK    
island half-widths                            [5 elem]         [5 elem]         0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]         0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04     0.0e+00    OK    
dominant-coupling singular values             N/A              [5 elem]         N/A        N/A   
|forcing overlap with dominant mode|          N/A              3.284975e-02     N/A        N/A   
|delta_nominal| of coil set 1                 N/A              1.637107e-02                N/A   
||ddelta/d(shift)|| over coil sets            N/A              2.998822e-02                N/A   
||ddelta/d(tilt)|| over coil sets             N/A              1.012616e-04                N/A   
PE plasma energy                              3.422677e+00     3.422677e+00     0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00     0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00     0.0e+00    OK    
PE toroidal torque                            5.087465e-02     5.087465e-02     0.0e+00    OK    
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01     0.0e+00    OK    
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02     0.0e+00    OK    
Runtime (s)                                   295.4s           315.1s                      --    
resonant area-weighted field b^r              [5 elem]         [5 elem]         0.0e+00    OK    
=================================================================================================
Summary: 47 unchanged, 5 missing/N/A
```

## Notes for reviewers

- Stacked on #448 (base branch `feature/errorfields-sensitivities`); GitHub retargets to `develop` when that merges.
- `ErrorFields/ForcingTerms` area: the only ForcingTerms change is factoring the nominal-radius loop out of `apply_transforms` into `nominal_major_radius` (bit-identical, `runtests_coils` re-run). `CoilGeometry.jl` picked up JuliaFormatter normalization on first touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu
