### PR TITLE
ErrorFields - FEATURE - Add the error-field Monte Carlo kernel

### DIFF
--- a/docs/development/hdf5-conventions.md
+++ b/docs/development/hdf5-conventions.md
@@ -45,7 +45,7 @@ Top level (11 groups):
 | `SingularSurfaces/` | Per-rational-surface data: `rational_psi`/`rational_q`/`rational_m`/`rational_n`, GGJ coefficients, `Delta_prime_matrix`/`Delta_prime_raw`/`Delta_coil`/`pest3_A`/`pest3_B`/`pest3_Gamma` (Riccati or Galerkin alike), `Kinetic/` |
 | `PerturbedEquilibrium/` | `ForcingModes/`, `Response/`, `ResponseMatrices/`, `SingularCoupling/`, `Energies/`, control-surface spectra |
 | `KineticForces/` | `<method>/` (torque/energy profiles, `EnergyIntegrals/`, `KineticMatrices/`); multi-ion runs add `PerSpecies/<species>/<method>/` with the same per-method layout, summing to the top-level total |
-| `ErrorFields/` | `CoilSensitivities/` (per-coil-set control-surface spectra and their rigid shift/tilt derivatives, `DominantMode/` full-window projection) |
+| `ErrorFields/` | `CoilSensitivities/` (per-coil-set control-surface spectra and their rigid shift/tilt derivatives, `DominantMode/` full-window projection); `MonteCarlo/` (intrinsic and corrected `\|δ\|` histograms over the sampled tolerances, per batch and averaged) |
 | `Tearing/` | `PerSurface/` (+ `DpMatrix/`), `Roots/`, `LayerWidths/`, `Diagnostics/{ValidRoots,Poles,FilteredRoots}`, `Scan/Surface_<k>/` |
 | `SurfaceGeometries/` | `{Plasma,Wall}/{x,y,z}` point clouds |
 

--- a/docs/src/error_fields.md
+++ b/docs/src/error_fields.md
@@ -151,6 +151,44 @@ rng = Random.Xoshiro(1)
 Δ, θ = EF.sample_cylinder(rng, 0.5e-3, 1.5, EF.randpow(EF.Flat()))   # correlated shift [m] and tilt [deg]
 ```
 
+## Tolerance Monte Carlo
+
+With a `tolerance_file` named, the run samples every coil set's misalignment within its
+tolerance and histograms the dominant-mode overlap `|δ|`: per sample and coil set the overlap
+moves by `S·(Δ + u) + T·(θ + v)` for the coil's own draw (`Δ`, `θ`) and Gaussian placement
+uncertainties (`u`, `v`); coherent groups add one shared draw per group, with the lateral shift
+a rigid rotation about the group pivot gives each member; the unattributed budget adds a random
+direction. Because the overlap is linear in the misalignments, a million samples take about a
+second and no field is recomputed. Two histograms are written to `ErrorFields/MonteCarlo/`: the
+intrinsic `|δ|` and the corrected one, in which every correctable term (coil sets and groups not
+listed as uncorrectable, and the unattributed budget) is divided by `efc_factor`. Batches are
+seeded individually, so results are bit-identical for any thread count, and their spread is the
+statistical error bar of anything derived from them.
+
+```toml
+[ErrorFields]
+tolerance_file = "tolerances.toml"      # Manufacturing-tolerance TOML, relative to the run directory
+
+[ErrorFields.MonteCarlo]
+nsample = 1000000               # Samples per batch
+nbatch = 10                     # Independent batches; their spread is the statistical error bar
+seed = 1                        # Base seed; batch b uses Xoshiro(hash((seed, b)))
+nbins = 300                     # Histogram bins, linear on [0, delta_max]
+delta_max = 0.0                 # Upper histogram edge; 0 = 1.5 × the worst-case alignment bound
+tolerance_scale = 1.0           # Multiplies every shift and tilt tolerance (for tolerance scans)
+coil_subset = []                # Coil sets whose tolerances are sampled; empty = all
+```
+
+The run's histogram is the full-window, dominant-mode summary. Any other window or mode, a
+tolerance scale, or a coil subset is a post-hoc re-run of the same kernel:
+
+```julia
+mc = EF.run_monte_carlo("gpec.h5"; psi_low=0.5, tolerance_scale=2.0, coil_subset=["PF1U", "PF2U"])
+mc.pdf, mc.bin_edges           # intrinsic |δ| density
+mc.pdf_efc                     # corrected
+mc.mean_abs_delta, mc.delta_nominal
+```
+
 ## Analysis after the run
 
 Window the coupling to any range of rational surfaces and project onto any singular mode

--- a/examples/DIIID-like_error_field_example/analyze_example.jl
+++ b/examples/DIIID-like_error_field_example/analyze_example.jl
@@ -59,3 +59,22 @@ display(p_spec)
 spec_path = joinpath(@__DIR__, "fcoil_spectra.png")
 Plots.savefig(p_spec, spec_path)
 println("Saved: ", abspath(spec_path))
+
+# The tolerance Monte Carlo: the intrinsic and corrected |δ| distributions the run wrote (full
+# window, dominant mode), and a post-hoc re-run over the edge window with the same tolerances.
+mc = ErrorFields.MonteCarloResult(h5path)
+mc_edge = ErrorFields.run_monte_carlo(h5path; psi_low=0.7, nsample=200_000, nbatch=4, seed=1)
+centers(m) = (m.bin_edges[1:end-1] .+ m.bin_edges[2:end]) ./ 2
+p_pdf = plot(; xlabel="dominant-mode overlap |δ|", ylabel="probability density", legend=:topright,
+    title="Tolerance Monte Carlo: |δ| over sampled misalignments", left_margin=12Plots.mm, bottom_margin=6Plots.mm, size=(900, 420))
+plot!(p_pdf, centers(mc), mc.pdf; lw=2, label="intrinsic, all rational surfaces")
+plot!(p_pdf, centers(mc), mc.pdf_efc; lw=2, label="corrected (efc_factor = 2)")
+plot!(p_pdf, centers(mc_edge), mc_edge.pdf; lw=2, ls=:dash, label="intrinsic, ψ_N ≥ 0.7")
+vline!(p_pdf, [mc.delta_nominal]; ls=:dot, c=:black, label="as designed")
+display(p_pdf)
+pdf_path = joinpath(@__DIR__, "tolerance_pdf.png")
+Plots.savefig(p_pdf, pdf_path)
+println("Saved: ", abspath(pdf_path))
+@printf("⟨|δ|⟩ = %.3e intrinsic, %.3e corrected; as designed %.3e; batch spread of ⟨|δ|⟩ ≈ %.1e\n",
+    mc.mean_abs_delta, mc.mean_abs_delta_efc, mc.delta_nominal,
+    maximum(abs.(vec(sum(mc.pdf_batches .* centers(mc) .* diff(mc.bin_edges); dims=1)) .- mc.mean_abs_delta)))

--- a/examples/DIIID-like_error_field_example/gpec.toml
+++ b/examples/DIIID-like_error_field_example/gpec.toml
@@ -4,7 +4,9 @@
 # centroid of its winding pack, from OpenFUSIONToolkit's TokaMaker DIIID_geom.json. An
 # axisymmetric hoop drives no n=1 field as built, so each F coil's error-field content is
 # entirely its sensitivity to misalignment: the [ErrorFields] stage linearizes every coil set's
-# resonant drive with respect to rigid shifts and tilts, and analyze_example.jl ranks them.
+# resonant drive with respect to rigid shifts and tilts, samples illustrative tolerances
+# (tolerances.toml) into an error-field distribution, and analyze_example.jl ranks the coils
+# and plots the distribution.
 
 [Equilibrium]
 eq_filename = "../DIIID-like_ideal_example/TkMkr_D3Dlike_Hmode.geqdsk" # Path to equilibrium file
@@ -208,3 +210,10 @@ fd_step_tilt_deg = 0.1                  # Central-difference step for the rigid 
 rotation_center = "conductor"           # Tilt pivot: each conductor's own centre ("conductor") or the whole set's ("set")
 write_outputs_to_HDF5 = true            # Write ErrorFields/CoilSensitivities/ to the output file
 verbose = true                          # Log per-coil-set progress and linearity diagnostics
+tolerance_file = "tolerances.toml"      # Manufacturing-tolerance TOML, relative to the run directory
+
+[ErrorFields.MonteCarlo]
+nsample = 1000000                       # Samples per batch
+nbatch = 10                             # Independent batches; their spread is the statistical error bar
+seed = 1                                # Base seed; batch b uses Xoshiro(hash((seed, b)))
+nbins = 300                             # Histogram bins, linear on [0, delta_max]

--- a/examples/DIIID-like_error_field_example/tolerances.toml
+++ b/examples/DIIID-like_error_field_example/tolerances.toml
@@ -1,0 +1,125 @@
+# Illustrative manufacturing tolerances for the DIII-D F coils of DIIID-like_error_field_example:
+# every coil may sit anywhere within 1 mm of its nominal centre and tilt up to 0.05°, sampled
+# with the hollow radial shape; the upper and lower outboard pairs are also bound into coherent
+# groups standing in for a common support, and an unattributed 1 G budget is carried. These are
+# round numbers for the example, not DIII-D engineering data.
+
+[ErrorFields.defaults]
+tilt_units = "deg"                # "deg", or "m" for a rim displacement converted through the nominal radius
+radial_shape = "hollow"           # Radial sampling density on the disk: flat, uniform_area, hollow, or ring
+tolerance_model = "additive"      # "additive" (independent shift and tilt) or "cylinder" (correlated axis line)
+
+[[ErrorFields.coil]]
+name = "F1A"                      # DIII-D F coil F1A; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F2A"                      # DIII-D F coil F2A; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F3A"                      # DIII-D F coil F3A; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F4A"                      # DIII-D F coil F4A; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F5A"                      # DIII-D F coil F5A; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F6A"                      # DIII-D F coil F6A; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F7A"                      # DIII-D F coil F7A; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F8A"                      # DIII-D F coil F8A; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F9A"                      # DIII-D F coil F9A; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F1B"                      # DIII-D F coil F1B; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F2B"                      # DIII-D F coil F2B; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F3B"                      # DIII-D F coil F3B; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F4B"                      # DIII-D F coil F4B; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F5B"                      # DIII-D F coil F5B; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F6B"                      # DIII-D F coil F6B; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F7B"                      # DIII-D F coil F7B; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F8B"                      # DIII-D F coil F8B; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coil]]
+name = "F9B"                      # DIII-D F coil F9B; must match the [[ForcingTerms.coil_set]] name
+shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+
+[[ErrorFields.coherent_group]]
+name = "outboard_upper"           # Label of the coherently moving group
+members = ["F6A", "F7A"]          # Coil sets sharing one random draw per sample
+shift_tol_mm = 0.5                # Coherent shift amplitude shared by the group [mm]
+tilt_tol = 0.02                   # Coherent tilt amplitude shared by the group, in tilt_units
+phase_group = "outboard"          # Groups naming the same phase_group share the random direction
+rotation_center_z_m = 0.0         # Height of the pivot of the group's rigid rotation on the machine axis [m]
+
+[[ErrorFields.coherent_group]]
+name = "outboard_lower"           # Label of the coherently moving group
+members = ["F6B", "F7B"]          # Coil sets sharing one random draw per sample
+shift_tol_mm = 0.5                # Coherent shift amplitude shared by the group [mm]
+tilt_tol = 0.02                   # Coherent tilt amplitude shared by the group, in tilt_units
+phase_group = "outboard"          # Groups naming the same phase_group share the random direction
+rotation_center_z_m = 0.0         # Height of the pivot of the group's rigid rotation on the machine axis [m]
+
+[ErrorFields.correctability]
+uncorrectable_coils = []          # Coil sets the error-field correction cannot reduce
+efc_factor = 2.0                  # Divisor applied to correctable contributions under error-field correction
+
+[ErrorFields.other_field]
+magnitude = 4.0e-5                # Overlap budget of sources not attributed to any coil (about 1 G at 2 T)
+sigma = 0.0                       # Gaussian uncertainty on that budget
+radial_shape = "ring"             # Radial sampling density of the budget magnitude

--- a/src/ErrorFields/ErrorFields.jl
+++ b/src/ErrorFields/ErrorFields.jl
@@ -21,6 +21,8 @@ plasma solve or a new Biot-Savart integration.
   `validate_tolerances`, and the tilt unit conversion `tilt_tolerance_deg`
 - `Sampling.jl`: random misalignment draws within a tolerance — the `RadialDistribution`
   shapes, `sample_disk`, `sample_uncertainty`, and the additive and cylinder tolerance models
+- `MonteCarlo.jl`: `run_monte_carlo`, the batched, seeded recombination of a `SensitivityTable`
+  with a `ToleranceSet` into intrinsic and corrected `|δ|` histograms
 
 The stored primitive is the derivative of each coil set's root-area-weighted control-surface
 spectrum b̃, not a scalar: the overlap with any dominant mode is linear in b̃, so the ψ_N window,
@@ -45,6 +47,7 @@ include("ErrorFieldsStructs.jl")
 include("Sensitivity.jl")
 include("ToleranceTOML.jl")
 include("Sampling.jl")
+include("MonteCarlo.jl")
 include("Output.jl")
 
 export ErrorFieldsControl, CoilSensitivities, SensitivityTable
@@ -53,5 +56,6 @@ export ToleranceSet, CoilTolerance, CoherentGroupTolerance, OtherFieldBudget
 export read_tolerance_toml, parse_tolerance_toml, validate_tolerances, tilt_tolerance_deg
 export RadialDistribution, Flat, UniformArea, Hollow, Ring, PowerLaw, randpow, radial_distribution
 export disk_radius, sample_disk, sample_uncertainty, sample_additive, sample_cylinder
+export MonteCarloControl, MonteCarloResult, run_monte_carlo
 
 end # module ErrorFields

--- a/src/ErrorFields/MonteCarlo.jl
+++ b/src/ErrorFields/MonteCarlo.jl
@@ -1,0 +1,352 @@
+"""
+    MonteCarlo
+
+The tolerance Monte Carlo: recombine a [`SensitivityTable`](@ref) with a [`ToleranceSet`](@ref)
+by drawing every coil set's misalignment within its tolerance many times and histogramming the
+resulting dominant-mode overlap `|δ|`. Because the overlap is linear in the misalignments, one
+sample is a handful of complex multiply-adds per coil set; no field is recomputed. Two
+histograms are accumulated per run, the intrinsic `|δ|` and the corrected one in which every
+correctable contribution is divided by the error-field-correction factor.
+
+The projection the table was built with (ψ_N window, singular mode) is an analysis choice, so
+the run writes the full-window summary and [`run_monte_carlo`](@ref) re-evaluates any other
+choice in memory or from `gpec.h5` in about a second.
+"""
+
+"""
+    MonteCarloControl
+
+Settings of the tolerance Monte Carlo, the `[ErrorFields.MonteCarlo]` TOML table.
+
+## Fields
+
+  - `nsample`: samples per batch
+  - `nbatch`: independent batches; their spread is the statistical error bar of every derived quantity
+  - `seed`: base seed; batch `b` uses `Xoshiro(hash((seed, b)))`, so results are bit-identical for
+    any thread count
+  - `nbins`: histogram bins, linear on `[0, delta_max]`
+  - `delta_max`: upper edge of the histogram; `0` means `1.5 ×` the worst-case alignment
+    `Σ(|δ_nominal| + tolerance × |sensitivity|)`, which the tolerance draws cannot exceed (only
+    the Gaussian uncertainties and the unattributed budget can, and those land in the last bin)
+  - `tolerance_scale`: multiplies every shift and tilt tolerance, for allowable-tolerance scans;
+    uncertainties and the unattributed budget are not scaled
+  - `coil_subset`: coil set names whose tolerances are sampled; every other coil set contributes
+    only its nominal overlap, and a coherent group is sampled only if all its members are listed.
+    Empty means all
+"""
+Base.@kwdef struct MonteCarloControl
+    nsample::Int = 1_000_000
+    nbatch::Int = 10
+    seed::Int = 1
+    nbins::Int = 300
+    delta_max::Float64 = 0.0
+    tolerance_scale::Float64 = 1.0
+    coil_subset::Vector{String} = String[]
+end
+
+"""
+    MonteCarloResult
+
+Histograms of the dominant-mode overlap magnitude over the sampled misalignments.
+
+## Fields
+
+  - `bin_edges`: `|δ|` bin edges `[nbins + 1]`; samples above the last edge are counted in the last bin
+  - `pdf`, `pdf_efc`: probability density of the intrinsic and of the corrected `|δ|`, averaged
+    over batches `[nbins]`
+  - `pdf_batches`, `pdf_efc_batches`: the same per batch `[nbins × nbatch]`
+  - `delta_nominal`: `|Σ δ_nominal|`, the as-designed overlap with every coil at its nominal position
+  - `delta_worst`: the worst-case alignment bound used to size the histogram
+  - `mean_abs_delta`, `mean_abs_delta_efc`: sample means of the two magnitudes
+  - `clamped_fraction`: fraction of samples whose intrinsic `|δ|` landed beyond `bin_edges[end]`
+    (the corrected histogram clamps too but is not separately tallied)
+  - `nsample`, `nbatch`, `seed`: as run
+"""
+struct MonteCarloResult
+    bin_edges::Vector{Float64}
+    pdf::Vector{Float64}
+    pdf_efc::Vector{Float64}
+    pdf_batches::Matrix{Float64}
+    pdf_efc_batches::Matrix{Float64}
+    delta_nominal::Float64
+    delta_worst::Float64
+    mean_abs_delta::Float64
+    mean_abs_delta_efc::Float64
+    clamped_fraction::Float64
+    nsample::Int
+    nbatch::Int
+    seed::Int
+end
+
+const _ADDITIVE = 1
+const _CYLINDER = 2
+
+const _HISTOGRAM_MARGIN = 1.5   # default delta_max = _HISTOGRAM_MARGIN × the worst-case alignment
+const _WORST_CASE_SIGMA = 3     # standard deviations at which Gaussian uncertainties enter the worst-case bound
+
+_model_code(tolerance_model::AbstractString) = tolerance_model == "cylinder" ? _CYLINDER : _ADDITIVE
+_radial_p(radial_shape::AbstractString) = randpow(radial_distribution(radial_shape))
+
+# Everything the sample loop needs, resolved to plain arrays once per run: no names, no
+# dictionaries, no dispatch inside the loop.
+struct _CoilTerms
+    delta0::Vector{ComplexF64}
+    Sx::Vector{ComplexF64}
+    Sy::Vector{ComplexF64}
+    Tx::Vector{ComplexF64}
+    Ty::Vector{ComplexF64}
+    shift_tol::Vector{Float64}      # m, scaled
+    tilt_tol::Vector{Float64}       # deg, scaled
+    shift_sigma::Vector{Float64}    # m
+    tilt_sigma::Vector{Float64}     # deg
+    p_radial::Vector{Float64}
+    model::Vector{Int}
+    z_top::Vector{Float64}
+    correctable::Vector{Bool}
+end
+
+struct _GroupTerms
+    Sx::Vector{ComplexF64}          # Σ_members S_x
+    Sy::Vector{ComplexF64}
+    Tx::Vector{ComplexF64}
+    Ty::Vector{ComplexF64}
+    Rx::Vector{ComplexF64}          # Σ_members (z_m − z_pivot)·S_x, the lateral shift of a rigid rotation
+    Ry::Vector{ComplexF64}
+    shift_tol::Vector{Float64}
+    tilt_tol::Vector{Float64}
+    p_radial::Vector{Float64}
+    model::Vector{Int}
+    z_top::Vector{Float64}
+    phase_index::Vector{Int}
+    nphase::Int
+    correctable::Vector{Bool}
+end
+
+"""
+    run_monte_carlo(table, tolerances, coil_sets, ctrl=MonteCarloControl()) -> MonteCarloResult
+    run_monte_carlo(h5path; psi_low=0.0, psi_high=1.0, mode=1, kwargs...) -> MonteCarloResult
+
+Sample every coil set's misalignment within its tolerance and histogram the dominant-mode
+overlap. Per sample and coil set `c` with sensitivities `S = (S_x, S_y)` per metre and
+`T = (T_x, T_y)` per degree,
+
+```
+δ = Σ_c [δ_nominal,c + S_c·(Δ_c + u_c) + T_c·(θ_c + v_c)] + Σ_g [S_g·(Δ_g + Δ_rot) + T_g·θ_g] + δ_other
+```
+
+where `(Δ_c, θ_c)` is the coil's own draw (additive: independent shift and tilt disks; cylinder:
+[`sample_cylinder`](@ref)), `u_c`, `v_c` its Gaussian placement uncertainties, `(Δ_g, θ_g)` one
+draw shared by every member of coherent group `g` (groups with equal `phase_group` share the
+direction), `Δ_rot = −(z_m − z_pivot)·(θy_g + iθx_g)` the lateral shift a rigid rotation of the
+group about its pivot (in the sense `apply_transforms` uses) gives a member at height `z_m`, and
+`δ_other` the unattributed budget with a random direction. `S·Δ` means `S_x·real(Δ) + S_y·imag(Δ)`.
+The corrected histogram divides every correctable term (coils and groups not listed as
+uncorrectable, and the unattributed budget) by `efc_factor`.
+
+`coil_sets` supply the nominal radii for tilt tolerances given in metres and the heights of
+group members; coil sets of the run without a tolerance block contribute their nominal overlap
+only. The file form rebuilds the coupling from `gpec.h5`, windows it, projects the stored
+linearization, and reads the tolerance snapshot the run echoed; `kwargs` are
+[`MonteCarloControl`](@ref) fields.
+"""
+function run_monte_carlo(table::SensitivityTable, ts::ToleranceSet, coil_sets::Vector{CoilSet}, ctrl::MonteCarloControl=MonteCarloControl())
+    ctrl.nsample > 0 && ctrl.nbatch > 0 && ctrl.nbins > 0 || throw(ArgumentError("nsample, nbatch and nbins must be positive"))
+    ctrl.tolerance_scale >= 0 || throw(ArgumentError("tolerance_scale must be ≥ 0"))
+    validate_tolerances(ts, table.coil_names)
+    coils, groups = _resolve_terms(table, ts, coil_sets, ctrl)
+    other = ts.other_field
+    p_other = _radial_p(other.radial_shape)
+    efc = ts.efc_factor
+
+    delta_nominal = abs(sum(table.delta_nominal))
+    delta_worst = _worst_case(table, coils, groups, other)
+    delta_max = ctrl.delta_max > 0 ? ctrl.delta_max : _HISTOGRAM_MARGIN * delta_worst
+    delta_max > 0 || throw(ArgumentError("the histogram range is zero: no nominal overlap, tolerance, or budget to sample"))
+    edges = collect(range(0.0, delta_max; length=ctrl.nbins + 1))
+    width = edges[2] - edges[1]
+
+    counts = zeros(Int, ctrl.nbins, ctrl.nbatch)
+    counts_efc = zeros(Int, ctrl.nbins, ctrl.nbatch)
+    sums = zeros(ctrl.nbatch)
+    sums_efc = zeros(ctrl.nbatch)
+    clamped = zeros(Int, ctrl.nbatch)
+
+    Threads.@threads for b in 1:ctrl.nbatch
+        rng = Xoshiro(hash((ctrl.seed, b)))
+        cnt = view(counts, :, b)
+        cnt_efc = view(counts_efc, :, b)
+        s = 0.0
+        s_efc = 0.0
+        nclamp = 0
+        phases = zeros(4, groups.nphase)
+        for _ in 1:ctrl.nsample
+            δ_corr, δ_uncorr = _sample_delta!(rng, phases, coils, groups, other, p_other)
+            a = abs(δ_corr + δ_uncorr)
+            a_efc = abs(δ_corr / efc + δ_uncorr)
+            s += a
+            s_efc += a_efc
+            i = min(floor(Int, a / width) + 1, ctrl.nbins)
+            a >= delta_max && (nclamp += 1)
+            cnt[i] += 1
+            cnt_efc[min(floor(Int, a_efc / width) + 1, ctrl.nbins)] += 1
+        end
+        sums[b] = s
+        sums_efc[b] = s_efc
+        clamped[b] = nclamp
+    end
+
+    norm = ctrl.nsample * width
+    pdf_batches = counts ./ norm
+    pdf_efc_batches = counts_efc ./ norm
+    total = ctrl.nsample * ctrl.nbatch
+    return MonteCarloResult(edges, vec(sum(pdf_batches; dims=2)) ./ ctrl.nbatch, vec(sum(pdf_efc_batches; dims=2)) ./ ctrl.nbatch,
+        pdf_batches, pdf_efc_batches, delta_nominal, delta_worst, sum(sums) / total, sum(sums_efc) / total,
+        sum(clamped) / total, ctrl.nsample, ctrl.nbatch, ctrl.seed)
+end
+
+function run_monte_carlo(h5path::AbstractString; psi_low::Real=0.0, psi_high::Real=1.0, mode::Int=1, kwargs...)
+    ts = read_tolerance_snapshot(h5path)
+    ts === nothing && throw(ArgumentError("$h5path carries no tolerance snapshot (the run named no tolerance_file)"))
+    table = sensitivity_table(h5path; psi_low, psi_high, mode)
+    coil_sets = h5open(h5path, "r") do f
+        haskey(f, "Input/RawInputs/Coils") || throw(ArgumentError("$h5path has no Input/RawInputs/Coils snapshot"))
+        sets = CoilSet[]
+        ForcingTerms.load_coils_from_h5_group!(sets, f["Input/RawInputs/Coils"])
+        sets
+    end
+    return run_monte_carlo(table, ts, coil_sets, MonteCarloControl(; kwargs...))
+end
+
+# One sample: returns (correctable, uncorrectable) complex overlaps. `phases` is scratch for
+# the per-phase-group directions (shift, tilt, cylinder top, cylinder bottom).
+@inline function _sample_delta!(rng::AbstractRNG, phases::Matrix{Float64}, coils::_CoilTerms, groups::_GroupTerms, other::OtherFieldBudget, p_other::Float64)
+    δc = zero(ComplexF64)
+    δu = zero(ComplexF64)
+    @inbounds for c in eachindex(coils.delta0)
+        if coils.model[c] == _CYLINDER
+            shift, tilt = sample_cylinder(rng, coils.shift_tol[c], coils.z_top[c], coils.p_radial[c])
+        else
+            shift, tilt = sample_additive(rng, coils.shift_tol[c], coils.p_radial[c], coils.tilt_tol[c], coils.p_radial[c])
+        end
+        shift += sample_uncertainty(rng, coils.shift_sigma[c])
+        tilt += sample_uncertainty(rng, coils.tilt_sigma[c])
+        d = coils.delta0[c] + coils.Sx[c] * real(shift) + coils.Sy[c] * imag(shift) + coils.Tx[c] * real(tilt) + coils.Ty[c] * imag(tilt)
+        coils.correctable[c] ? (δc += d) : (δu += d)
+    end
+    @inbounds for k in 1:groups.nphase, q in 1:4
+        phases[q, k] = 2π * rand(rng)
+    end
+    @inbounds for g in eachindex(groups.Sx)
+        k = groups.phase_index[g]
+        if groups.model[g] == _CYLINDER
+            shift, tilt = sample_cylinder(rng, groups.shift_tol[g], groups.z_top[g], groups.p_radial[g]; phase_top=phases[3, k], phase_bot=phases[4, k])
+        else
+            shift, tilt = sample_additive(rng, groups.shift_tol[g], groups.p_radial[g], groups.tilt_tol[g], groups.p_radial[g];
+                phase_shift=phases[1, k], phase_tilt=phases[2, k])
+        end
+        # A rigid rotation by (θx, θy) about the pivot moves a member at height h by −h·(θy + iθx).
+        θ = deg2rad(tilt)
+        d = groups.Sx[g] * real(shift) + groups.Sy[g] * imag(shift) + groups.Tx[g] * real(tilt) + groups.Ty[g] * imag(tilt) -
+            groups.Rx[g] * imag(θ) - groups.Ry[g] * real(θ)
+        groups.correctable[g] ? (δc += d) : (δu += d)
+    end
+    if other.magnitude > 0 || other.sigma > 0
+        amp = other.magnitude * rand(rng)^p_other + other.sigma * randn(rng)
+        δc += amp * cis(2π * rand(rng))
+    end
+    return δc, δu
+end
+
+function _resolve_terms(table::SensitivityTable, ts::ToleranceSet, coil_sets::Vector{CoilSet}, ctrl::MonteCarloControl)
+    names = table.coil_names
+    index = Dict(n => i for (i, n) in enumerate(names))
+    set_of = Dict(cs.name => cs for cs in coil_sets)
+    for n in names
+        haskey(set_of, n) || throw(ArgumentError("no coil set geometry named \"$n\" among the given coil sets"))
+    end
+    active(n) = isempty(ctrl.coil_subset) || n in ctrl.coil_subset
+    uncorrectable = Set(ts.uncorrectable_coils)
+    scale = ctrl.tolerance_scale
+
+    n = length(names)
+    shift_tol = zeros(n)
+    tilt_tol = zeros(n)
+    shift_sigma = zeros(n)
+    tilt_sigma = zeros(n)
+    p_radial = ones(n)
+    model = fill(_ADDITIVE, n)
+    z_top = zeros(n)
+    for t in ts.coils
+        i = index[t.name]
+        active(t.name) || continue
+        cs = set_of[t.name]
+        shift_tol[i] = scale * t.shift_tol_m
+        tilt_tol[i] = scale * tilt_tolerance_deg(t, cs)
+        shift_sigma[i] = t.shift_sigma_m
+        tilt_sigma[i] = tilt_tolerance_deg(t.tilt_sigma, t.tilt_units, cs)
+        p_radial[i] = _radial_p(t.radial_shape)
+        model[i] = _model_code(t.tolerance_model)
+        z_top[i] = t.cylinder_half_height_m
+    end
+    coils = _CoilTerms(collect(table.delta_nominal), table.shift[1, :], table.shift[2, :], table.tilt[1, :], table.tilt[2, :],
+        shift_tol, tilt_tol, shift_sigma, tilt_sigma, p_radial, model, z_top, [!(nm in uncorrectable) for nm in names])
+
+    kept = [g for g in ts.groups if all(active, g.members)]
+    ng = length(kept)
+    gSx = zeros(ComplexF64, ng)
+    gSy = zeros(ComplexF64, ng)
+    gTx = zeros(ComplexF64, ng)
+    gTy = zeros(ComplexF64, ng)
+    gRx = zeros(ComplexF64, ng)
+    gRy = zeros(ComplexF64, ng)
+    g_shift = zeros(ng)
+    g_tilt = zeros(ng)
+    g_p = ones(ng)
+    g_model = fill(_ADDITIVE, ng)
+    g_ztop = zeros(ng)
+    g_corr = trues(ng)
+    labels = unique(g.phase_group for g in kept)
+    phase_index = [findfirst(==(g.phase_group), labels) for g in kept]
+    for (gi, g) in enumerate(kept)
+        for m in g.members
+            i = index[m]
+            h = _set_center(set_of[m])[3] - g.rotation_center_z_m
+            gSx[gi] += table.shift[1, i]
+            gSy[gi] += table.shift[2, i]
+            gTx[gi] += table.tilt[1, i]
+            gTy[gi] += table.tilt[2, i]
+            gRx[gi] += h * table.shift[1, i]
+            gRy[gi] += h * table.shift[2, i]
+            m in uncorrectable && (g_corr[gi] = false)
+        end
+        g_shift[gi] = scale * g.shift_tol_m
+        # A group tilt in metres is converted through the first member's radius, as the OMFIT
+        # tables did; give group tilts in degrees when members differ in size.
+        g_tilt[gi] = scale * tilt_tolerance_deg(g.tilt_tol, g.tilt_units, set_of[g.members[1]])
+        g_p[gi] = _radial_p(g.radial_shape)
+        g_model[gi] = _model_code(g.tolerance_model)
+        g_ztop[gi] = g.cylinder_half_height_m
+    end
+    groups = _GroupTerms(gSx, gSy, gTx, gTy, gRx, gRy, g_shift, g_tilt, g_p, g_model, g_ztop, phase_index, length(labels), g_corr)
+    return coils, groups
+end
+
+# Worst-case alignment bound used to size the histogram: every term at its tolerance edge and in
+# phase. Gaussian uncertainties enter at _WORST_CASE_SIGMA standard deviations, not a hard limit.
+function _worst_case(table::SensitivityTable, coils::_CoilTerms, groups::_GroupTerms, other::OtherFieldBudget)
+    w = sum(abs, table.delta_nominal)
+    for c in eachindex(coils.delta0)
+        s_in = max(abs(coils.Sx[c]), abs(coils.Sy[c]))
+        t_in = max(abs(coils.Tx[c]), abs(coils.Ty[c]))
+        tilt_reach = coils.model[c] == _CYLINDER ? rad2deg(atan(coils.shift_tol[c] / coils.z_top[c])) : coils.tilt_tol[c]
+        w += s_in * (coils.shift_tol[c] + _WORST_CASE_SIGMA * coils.shift_sigma[c]) + t_in * (tilt_reach + _WORST_CASE_SIGMA * coils.tilt_sigma[c])
+    end
+    for g in eachindex(groups.Sx)
+        s_in = max(abs(groups.Sx[g]), abs(groups.Sy[g]))
+        # Rx, Ry carry the rotation term's per-radian sensitivity; deg2rad(1) folds it into T's per-degree units.
+        t_in = max(abs(groups.Tx[g]), abs(groups.Ty[g])) + deg2rad(1) * max(abs(groups.Rx[g]), abs(groups.Ry[g]))
+        tilt_reach = groups.model[g] == _CYLINDER ? rad2deg(atan(groups.shift_tol[g] / groups.z_top[g])) : groups.tilt_tol[g]
+        w += s_in * groups.shift_tol[g] + t_in * tilt_reach
+    end
+    return w + other.magnitude + _WORST_CASE_SIGMA * other.sigma
+end

--- a/src/ErrorFields/Output.jl
+++ b/src/ErrorFields/Output.jl
@@ -112,3 +112,64 @@ function read_tolerance_snapshot(h5path::AbstractString)
         return parse_tolerance_toml(read(f[_TOLERANCE_SNAPSHOT]))
     end
 end
+
+const _MC_GROUP = "ErrorFields/MonteCarlo"
+
+# Metadata table for ErrorFields/MonteCarlo/ (paths relative to the group). bin_edges has one
+# more entry than the densities, so it is documented rather than attached as a dimension scale.
+const MC_H5_ANNOTATIONS = [
+    "bin_edges" => (; long_name="|δ| bin edges of the overlap histograms (nbins + 1); samples beyond the last edge are counted in the last bin"),
+    "pdf" => (; long_name="probability density of the intrinsic dominant-mode overlap |δ| over the sampled misalignments, batch average", dims=("delta_bin",)),
+    "pdf_efc" => (; long_name="probability density of the corrected overlap |δ| (correctable terms divided by efc_factor), batch average", dims=("delta_bin",)),
+    "pdf_batches" => (; long_name="probability density of the intrinsic overlap |δ| per batch", dims=("delta_bin", "batch")),
+    "pdf_efc_batches" => (; long_name="probability density of the corrected overlap |δ| per batch", dims=("delta_bin", "batch")),
+    "delta_nominal" => (; long_name="|Σ δ_nominal|, the as-designed overlap with every coil set at its nominal position"),
+    "delta_worst" => (; long_name="worst-case alignment bound Σ(|δ_nominal| + tolerance × |sensitivity|) used to size the histogram"),
+    "mean_abs_delta" => (; long_name="sample mean of the intrinsic overlap |δ|"),
+    "mean_abs_delta_efc" => (; long_name="sample mean of the corrected overlap |δ|"),
+    "clamped_fraction" => (; long_name="fraction of samples beyond the last bin edge")
+]
+
+"""
+    write_to_hdf5!(h5file::HDF5.File, mc::MonteCarloResult)
+
+Write the tolerance Monte Carlo histograms to `ErrorFields/MonteCarlo/`. The sampling settings
+(`nsample`, `nbatch`, `seed`) live in the run's `[ErrorFields.MonteCarlo]` table under
+`Input/gpec_toml_raw`; the tolerances in `Input/RawInputs/ErrorFields/tolerance_toml_raw`.
+An existing group is replaced.
+"""
+function write_to_hdf5!(h5file::HDF5.File, mc::MonteCarloResult)
+    haskey(h5file, _MC_GROUP) && delete_object(h5file, _MC_GROUP)
+    g = create_group(h5file, _MC_GROUP)
+    g["bin_edges"] = mc.bin_edges
+    g["pdf"] = mc.pdf
+    g["pdf_efc"] = mc.pdf_efc
+    g["pdf_batches"] = mc.pdf_batches
+    g["pdf_efc_batches"] = mc.pdf_efc_batches
+    g["delta_nominal"] = mc.delta_nominal
+    g["delta_worst"] = mc.delta_worst
+    g["mean_abs_delta"] = mc.mean_abs_delta
+    g["mean_abs_delta_efc"] = mc.mean_abs_delta_efc
+    g["clamped_fraction"] = mc.clamped_fraction
+    Utilities.HDF5Annotations.annotate!(g, MC_H5_ANNOTATIONS)
+    return g
+end
+
+"""
+    MonteCarloResult(h5path::AbstractString)
+
+Read the tolerance Monte Carlo of a run back from its `gpec.h5`, with the sampling settings
+from the `[ErrorFields.MonteCarlo]` table of the stored deck.
+"""
+function MonteCarloResult(h5path::AbstractString)
+    h5open(h5path, "r") do f
+        haskey(f, _MC_GROUP) || throw(ArgumentError("$h5path has no $_MC_GROUP group (run with a tolerance_file)"))
+        g = f[_MC_GROUP]
+        inputs = TOML.parse(read(f["Input/gpec_toml_raw"]))
+        ctrl = MonteCarloControl(; (Symbol(k) => v for (k, v) in get(get(inputs, "ErrorFields", Dict{String,Any}()), "MonteCarlo", Dict{String,Any}()))...)
+        pdf_batches = read(g["pdf_batches"])
+        return MonteCarloResult(read(g["bin_edges"]), read(g["pdf"]), read(g["pdf_efc"]), pdf_batches, read(g["pdf_efc_batches"]),
+            read(g["delta_nominal"]), read(g["delta_worst"]), read(g["mean_abs_delta"]), read(g["mean_abs_delta_efc"]),
+            read(g["clamped_fraction"]), ctrl.nsample, size(pdf_batches, 2), ctrl.seed)
+    end
+end

--- a/src/ErrorFields/Sampling.jl
+++ b/src/ErrorFields/Sampling.jl
@@ -99,9 +99,16 @@ end
     disk_radius(rng, R, p) -> Float64
 
 A radius drawn in `[0, R]` with density exponent `p` (see [`RadialDistribution`](@ref)):
-`R·rand()^p`.
+`R·rand()^p`. The common exponents (`0`, `1/3`, `1/2`, `1`, from [`Ring`](@ref), [`Hollow`](@ref),
+[`UniformArea`](@ref), [`Flat`](@ref)) take a `sqrt`/`cbrt`/identity fast path instead of the
+general `^`, which is the hot loop's dominant cost otherwise.
 """
-disk_radius(rng::AbstractRNG, R::Real, p::Real) = Float64(R) * rand(rng)^Float64(p)
+@inline function disk_radius(rng::AbstractRNG, R::Real, p::Real)
+    u = rand(rng)
+    pf = Float64(p)
+    r = pf == 1.0 ? u : pf == 0.5 ? sqrt(u) : pf == (1 / 3) ? cbrt(u) : pf == 0.0 ? 1.0 : u^pf
+    return Float64(R) * r
+end
 
 """
     sample_disk(rng, R, p; phase=2π·rand(rng)) -> ComplexF64

--- a/src/GeneralizedPerturbedEquilibrium.jl
+++ b/src/GeneralizedPerturbedEquilibrium.jl
@@ -266,14 +266,15 @@ function main_from_inputs(
     if ctrl.force_termination
         slayer_result = run_slayer_stage(ffs_result, inputs, nothing)
         @info "\n$_BANNER\n  GPEC completed successfully in $(@sprintf("%.3f", time() - total_start)) s\n$_BANNER"
-        return (; ffs=ffs_result, pe=nothing, slayer=slayer_result, coil_sensitivities=nothing)
+        return (; ffs=ffs_result, pe=nothing, slayer=slayer_result, coil_sensitivities=nothing, monte_carlo=nothing)
     end
 
     pe_state = run_perturbed_equilibrium(ffs_result, inputs, forcing_modes_snapshot, preloaded_coil_sets)
 
     run_kinetic_forces(inputs, ffs_result, pe_state, kf_ctrl, kinetic_profiles, kf_species)
 
-    coil_sensitivities = run_error_fields(inputs, ffs_result, pe_state, preloaded_coil_sets)
+    error_fields = run_error_fields(inputs, ffs_result, pe_state, preloaded_coil_sets)
+    coil_sensitivities, monte_carlo = error_fields === nothing ? (nothing, nothing) : error_fields
 
     # SLAYER runs after PE so it appends to the PE output file; it falls back to the
     # ForceFreeStates file when PE did not run.
@@ -292,7 +293,7 @@ function main_from_inputs(
 
     # TODO: Do not allow perturbed equilibrium calculations if zero crossings are found
 
-    return (; ffs=ffs_result, pe=pe_state, slayer=slayer_result, coil_sensitivities)
+    return (; ffs=ffs_result, pe=pe_state, slayer=slayer_result, coil_sensitivities, monte_carlo)
 
 end
 
@@ -993,11 +994,13 @@ function forcing_terms_control(inputs::Dict{String,Any})
 end
 
 """
-    run_error_fields(inputs, result, pe_state, preloaded_coil_sets) -> CoilSensitivities or nothing
+    run_error_fields(inputs, result, pe_state, preloaded_coil_sets) -> (sensitivities, monte_carlo) or nothing
 
 Linearize every coil set's resonant drive with respect to its rigid shifts and tilts and write
-`ErrorFields/CoilSensitivities/` when the deck carries an `[ErrorFields]` section; read, validate
-and echo the tolerance file when one is named. Needs the
+`ErrorFields/CoilSensitivities/` when the deck carries an `[ErrorFields]` section. When the
+section names a `tolerance_file`, read, validate and echo it, then run the tolerance Monte
+Carlo on the full-window dominant mode with the `[ErrorFields.MonteCarlo]` settings and write
+`ErrorFields/MonteCarlo/`; `monte_carlo` is `nothing` otherwise. Needs the
 perturbed-equilibrium state's singular-coupling matrix and coil-format forcing, and errors
 otherwise: a deck asking for error-field sensitivities without them is a misconfiguration, not a
 case to skip silently. Coil geometry is rebuilt from the deck unless a replay injected it.
@@ -1013,7 +1016,10 @@ function run_error_fields(
     @info "\n  ErrorFields\n$_SECTION"
     ef_start = time()
 
-    ef_ctrl = ErrorFields.ErrorFieldsControl(; (Symbol(k) => v for (k, v) in inputs["ErrorFields"])...)
+    # [ErrorFields.MonteCarlo] is a nested table, excluded from the control-struct splat.
+    ef_raw = inputs["ErrorFields"]
+    ef_ctrl = ErrorFields.ErrorFieldsControl(; (Symbol(k) => v for (k, v) in ef_raw if k != "MonteCarlo")...)
+    mc_ctrl = ErrorFields.MonteCarloControl(; (Symbol(k) => v for (k, v) in get(ef_raw, "MonteCarlo", Dict{String,Any}()))...)
     pe_state === nothing && error("[ErrorFields] needs a [PerturbedEquilibrium] section with compute_singular_coupling = true")
     ft_ctrl = forcing_terms_control(inputs)
     ft_ctrl.forcing_data_format == "coil" ||
@@ -1033,19 +1039,32 @@ function run_error_fields(
         @info "Tolerances: $(length(tolerances.coils)) coil sets, $(length(tolerances.groups)) coherent groups from $(ef_ctrl.tolerance_file)"
     end
 
+    # The run's Monte Carlo is the full-window, dominant-mode summary; other windows are re-run
+    # post hoc with ErrorFields.run_monte_carlo.
+    dom = PerturbedEquilibrium.dominant_coupling(rc)
+    monte_carlo = nothing
+    if tolerances !== nothing
+        mc_start = time()
+        monte_carlo = ErrorFields.run_monte_carlo(ErrorFields.sensitivity_table(sens, dom), tolerances, coil_sets, mc_ctrl)
+        @info "Monte Carlo: $(mc_ctrl.nbatch) × $(mc_ctrl.nsample) samples in $(@sprintf("%.2f", time() - mc_start)) s; " *
+              "⟨|δ|⟩ = $(@sprintf("%.3e", monte_carlo.mean_abs_delta)) intrinsic, $(@sprintf("%.3e", monte_carlo.mean_abs_delta_efc)) corrected " *
+              "(nominal $(@sprintf("%.3e", monte_carlo.delta_nominal)))"
+    end
+
     if ef_ctrl.write_outputs_to_HDF5
         output_file = isempty(ef_ctrl.output_filename) ? result.control.HDF5_filename : ef_ctrl.output_filename
         h5open(joinpath(result.dir_path, output_file), "cw") do h5file
-            ErrorFields.write_to_hdf5!(h5file, sens, PerturbedEquilibrium.dominant_coupling(rc))
-            # Raw echo of the tolerance input for replay (read back by ErrorFields.parse_tolerance_toml).
+            ErrorFields.write_to_hdf5!(h5file, sens, dom)
+            # Raw echo of the tolerance input for replay (read back by ErrorFields.read_tolerance_snapshot).
             tolerances === nothing || ErrorFields.write_tolerance_snapshot!(h5file, tolerances)
+            monte_carlo === nothing || ErrorFields.write_to_hdf5!(h5file, monte_carlo)
         end
         @info "Results written to $output_file"
     end
 
     @info "ErrorFields completed in $(@sprintf("%.3f", time() - ef_start)) s"
 
-    return sens
+    return sens, monte_carlo
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ else
     include("./runtests_error_fields.jl")
     include("./runtests_tolerance_toml.jl")
     include("./runtests_sampling.jl")
+    include("./runtests_monte_carlo.jl")
     include("./runtests_sing.jl")
     include("./runtests_innerlayer.jl")
     include("./runtests_tj_analytic.jl")

--- a/test/runtests_error_fields.jl
+++ b/test/runtests_error_fields.jl
@@ -50,7 +50,8 @@ include("h5_metadata_check.jl")
                 "compute_response" => true, "compute_singular_coupling" => true,
                 "verbose" => false, "write_outputs_to_HDF5" => true)
             cp(joinpath(@__DIR__, "test_data", "ErrorFields", "tolerances_two_hoops.toml"), joinpath(dir, "tolerances.toml"))
-            inputs["ErrorFields"] = Dict{String,Any}("verbose" => false, "tolerance_file" => "tolerances.toml")
+            inputs["ErrorFields"] = Dict{String,Any}("verbose" => false, "tolerance_file" => "tolerances.toml",
+                "MonteCarlo" => Dict{String,Any}("nsample" => 20_000, "nbatch" => 2, "seed" => 5, "nbins" => 100))
             open(io -> TOML.print(io, inputs), toml_path, "w")
 
             res = GPEC.main([dir])
@@ -110,6 +111,20 @@ include("h5_metadata_check.jl")
             @test snapshot isa EF.ToleranceSet
             @test snapshot.raw == read(joinpath(dir, "tolerances.toml"), String)
             @test [c.name for c in snapshot.coils] == ["hoop_tilted", "hoop_axi"]
+
+            # The run's Monte Carlo (full window, dominant mode) is written and re-runnable from the file.
+            mc = res.monte_carlo
+            @test mc isa EF.MonteCarloResult
+            @test mc.nsample == 20_000 && mc.nbatch == 2 && mc.seed == 5
+            @test mc.delta_nominal ≈ abs(sum(table.delta_nominal))
+            @test sum(mc.pdf .* diff(mc.bin_edges)) ≈ 1 atol = 1e-6
+            @test mc.mean_abs_delta_efc < mc.mean_abs_delta
+            mc_file = EF.MonteCarloResult(h5path)
+            @test mc_file.pdf == mc.pdf && mc_file.bin_edges == mc.bin_edges && mc_file.nsample == 20_000
+            rerun = EF.run_monte_carlo(h5path; nsample=20_000, nbatch=2, seed=5, nbins=100)
+            @test rerun.pdf == mc.pdf
+            windowed_mc = EF.run_monte_carlo(h5path; psi_low=rc.rational_psi[end], nsample=5_000, nbatch=1, seed=5, nbins=50)
+            @test windowed_mc.delta_nominal ≈ abs(sum(windowed.delta_nominal))
             from_file = EF.CoilSensitivities(h5path)
             @test from_file.coil_names == sens.coil_names
             @test from_file.m_modes == sens.m_modes && from_file.n_modes == sens.n_modes

--- a/test/runtests_monte_carlo.jl
+++ b/test/runtests_monte_carlo.jl
@@ -1,0 +1,221 @@
+using Random
+using Statistics
+using LinearAlgebra
+
+# The tolerance Monte Carlo kernel on synthetic sensitivity tables: the closed-form |δ| density
+# of one axisymmetric coil under a Flat shift tolerance, agreement with a literal transcription
+# of the OMFIT tool's model in the limit where the two coincide (S_y = ±i·S_x), the corrected
+# histogram, coherent groups, the coil subset, and bit-for-bit reproducibility under a seed.
+@testset "tolerance Monte Carlo" begin
+    GPEC = GeneralizedPerturbedEquilibrium
+    EF = GPEC.ErrorFields
+    FT = GPEC.ForcingTerms
+
+    # A synthetic table: names, nominal overlaps, S = (Sx, Sy, Sz) per m, T per deg.
+    function synthetic_table(names, δ0, S, T)
+        n = length(names)
+        rms(M) = [sqrt((abs2(M[1, j]) + abs2(M[2, j])) / 2) for j in 1:n]
+        canc(M) = [EF.cancelling_offset(δ0[j], M[1, j], M[2, j])[i] for i in 1:2, j in 1:n]
+        return EF.SensitivityTable(names, 1, ComplexF64.(δ0), ComplexF64.(S), ComplexF64.(T), rms(S), rms(T), canc(S), canc(T))
+    end
+    hoops(names; heights=zeros(length(names))) = [FT.make_pf_hoop(; radius=1.5, height=heights[i], name=nm) for (i, nm) in enumerate(names)]
+    pdf_moments(res) = begin
+        centers = (res.bin_edges[1:end-1] .+ res.bin_edges[2:end]) ./ 2
+        w = diff(res.bin_edges)
+        (sum(res.pdf .* w), sum(centers .* res.pdf .* w))
+    end
+
+    @testset "one axisymmetric coil, Flat shift tolerance: box density" begin
+        # δ = S·conj(Δ) with |Δ| = R·u uniform in radius → |δ| uniform on [0, |S|R].
+        Sx = 4.0 + 3.0im
+        table = synthetic_table(["a"], [0.0], [Sx -im*Sx; 0.0 0.0]', zeros(3, 1))
+        ts = EF.parse_tolerance_toml("""
+            [[ErrorFields.coil]]
+            name = "a"
+            shift_tol_mm = 2.0
+            radial_shape = "flat"
+            """)
+        ctrl = EF.MonteCarloControl(; nsample=200_000, nbatch=2, seed=3, nbins=100, delta_max=abs(Sx) * 2e-3)
+        res = EF.run_monte_carlo(table, ts, hoops(["a"]), ctrl)
+        total, mean_δ = pdf_moments(res)
+        @test total ≈ 1 atol = 1e-2
+        @test isapprox(mean_δ, abs(Sx) * 1e-3; rtol=2e-2)
+        @test res.mean_abs_delta ≈ abs(Sx) * 1e-3 rtol = 2e-2
+        @test all(abs.(res.pdf .- 1 / (abs(Sx) * 2e-3)) .< 0.15 / (abs(Sx) * 2e-3))
+        @test res.clamped_fraction == 0
+        @test res.delta_nominal == 0
+        # Everything is correctable: the corrected |δ| is the intrinsic one halved, a box on [0, |S|R/2].
+        half = ctrl.nbins ÷ 2
+        @test all(abs.(res.pdf_efc[1:half] .- 2 / (abs(Sx) * 2e-3)) .< 0.3 / (abs(Sx) * 2e-3))
+        @test all(res.pdf_efc[half+1:end] .== 0)
+        @test res.mean_abs_delta_efc ≈ res.mean_abs_delta / 2 rtol = 2e-2
+        @test size(res.pdf_batches) == (100, 2)
+    end
+
+    @testset "reduction to the OMFIT model and seed reproducibility" begin
+        # Three coils with S_y = −i·S_x and T_y = +i·T_x (the axisymmetric identities) so the
+        # complex model equals OMFIT's |S|·r·e^{iφ} with a free phase; compare |δ| histograms of
+        # the kernel and of a literal transcription of the OMFIT sampling on the same tolerances.
+        names = ["c1", "c2", "c3"]
+        δ0 = [1e-4 + 2e-4im, -3e-4 + 0.5e-4im, 2e-4 - 1e-4im]
+        Sx = [0.3 + 0.1im, -0.2 + 0.25im, 0.15 - 0.3im]
+        Tx = [0.01 + 0.02im, 0.03 - 0.01im, -0.02 + 0.015im]
+        S = hcat([[Sx[j], -im * Sx[j], 0.0] for j in 1:3]...)
+        T = hcat([[Tx[j], im * Tx[j], 0.0] for j in 1:3]...)
+        table = synthetic_table(names, δ0, S, T)
+        tol = """
+            [ErrorFields.defaults]
+            radial_shape = "flat"
+            [[ErrorFields.coil]]
+            name = "c1"
+            shift_tol_mm = 1.0
+            tilt_tol = 0.02
+            shift_sigma_mm = 0.2
+            [[ErrorFields.coil]]
+            name = "c2"
+            shift_tol_mm = 0.5
+            tilt_tol = 0.01
+            radial_shape = "hollow"
+            [[ErrorFields.coil]]
+            name = "c3"
+            shift_tol_mm = 2.0
+            tilt_tol = 0.0
+            [ErrorFields.correctability]
+            uncorrectable_coils = ["c3"]
+            efc_factor = 2.0
+            [ErrorFields.other_field]
+            magnitude = 5e-5
+            radial_shape = "ring"
+            """
+        ts = EF.parse_tolerance_toml(tol)
+        ctrl = EF.MonteCarloControl(; nsample=300_000, nbatch=2, seed=11, nbins=200)
+        res = EF.run_monte_carlo(table, ts, hoops(names), ctrl)
+
+        # Literal OMFIT transcription: dfac = tol·rand^p·e^{iφ}, dunc = σ·randn·e^{iφ}, deltas =
+        # dc_nerr + dc_disp·(dfac + dunc) + dc_tilt·(tfac + tunc), other = mag·rand^0·e^{iφ},
+        # EFC divides correctable rows and the other budget.
+        rng = Xoshiro(99)
+        N = 600_000
+        dc_disp = abs.(Sx)
+        dc_tilt = abs.(Tx)
+        disp_tol = [1e-3, 0.5e-3, 2e-3]
+        tilt_tol = [0.02, 0.01, 0.0]
+        disp_unc = [0.2e-3, 0.0, 0.0]
+        pw = [1.0, 1 / 3, 1.0]
+        correct = [true, true, false]
+        δ_all = zeros(N)
+        δ_efc = zeros(N)
+        for s in 1:N
+            tot = 0.0im
+            corr = 0.0im
+            unc = 0.0im
+            for c in 1:3
+                dfac = disp_tol[c] * rand(rng)^pw[c] * cis(2π * rand(rng))
+                tfac = tilt_tol[c] * rand(rng)^pw[c] * cis(2π * rand(rng))
+                dunc = disp_unc[c] * randn(rng) * cis(2π * rand(rng))
+                d = δ0[c] + dc_disp[c] * (dfac + dunc) + dc_tilt[c] * tfac
+                correct[c] ? (corr += d) : (unc += d)
+            end
+            other = 5e-5 * cis(2π * rand(rng))
+            δ_all[s] = abs(corr + unc + other)
+            δ_efc[s] = abs((corr + other) / 2 + unc)
+        end
+        edges = res.bin_edges
+        hist(x) = [count(v -> edges[i] <= v < edges[i+1], x) for i in 1:length(edges)-1] ./ (length(x) * (edges[2] - edges[1]))
+        h_all = hist(δ_all)
+        h_efc = hist(δ_efc)
+        # Histograms agree to Monte Carlo noise: compare CDFs (max deviation) and means.
+        cdf(p) = cumsum(p .* (edges[2] - edges[1]))
+        @test maximum(abs.(cdf(res.pdf) .- cdf(h_all))) < 0.01
+        @test maximum(abs.(cdf(res.pdf_efc) .- cdf(h_efc))) < 0.01
+        @test isapprox(res.mean_abs_delta, mean(δ_all); rtol=1e-2)
+        @test isapprox(res.mean_abs_delta_efc, mean(δ_efc); rtol=1e-2)
+        @test res.delta_nominal ≈ abs(sum(δ0))
+
+        # Same seed, any thread count or batch order: bit-identical.
+        again = EF.run_monte_carlo(table, ts, hoops(names), ctrl)
+        @test again.pdf == res.pdf && again.pdf_efc == res.pdf_efc
+        @test again.pdf_batches == res.pdf_batches
+        # A different seed differs; the tolerance scale widens the distribution.
+        other_seed = EF.run_monte_carlo(table, ts, hoops(names), EF.MonteCarloControl(; nsample=300_000, nbatch=2, seed=12, nbins=200))
+        @test other_seed.pdf != res.pdf
+        wide = EF.run_monte_carlo(table, ts, hoops(names), EF.MonteCarloControl(; nsample=100_000, nbatch=1, seed=11, nbins=200, tolerance_scale=3.0))
+        @test wide.mean_abs_delta > res.mean_abs_delta
+        # Coil subset: only c1 sampled; c2 and c3 contribute their nominal overlap.
+        sub = EF.run_monte_carlo(table, ts, hoops(names), EF.MonteCarloControl(; nsample=100_000, nbatch=1, seed=11, nbins=200, coil_subset=["c1"]))
+        @test sub.delta_worst < res.delta_worst
+        none = EF.run_monte_carlo(table, ts, hoops(names), EF.MonteCarloControl(; nsample=20_000, nbatch=1, seed=11, nbins=200, coil_subset=["zzz"]))
+        # With nothing sampled but the ring budget, |δ| = |Σδ0 + 5e-5·e^{iφ}| lies within 5e-5 of the nominal.
+        @test none.mean_abs_delta ≈ res.delta_nominal rtol = 0.5
+        @test all(abs.(none.bin_edges[findall(>(0), none.pdf)] .- res.delta_nominal) .< 5e-5 + 2 * (none.bin_edges[2] - none.bin_edges[1]))
+    end
+
+    @testset "coherent group: shared draw and rigid rotation" begin
+        # Two identical coils at heights ±h in one group: a pure group tilt about z = 0 shifts
+        # them oppositely, so with equal S the rotation-induced shifts cancel and only 2·T·θ
+        # remains; with the pivot at the lower coil they do not cancel.
+        names = ["u", "l"]
+        Sx = 1.0 + 0.0im
+        Tx = 0.0 + 0.0im
+        S = [Sx -im*Sx 0.0; Sx -im*Sx 0.0]'
+        T = zeros(3, 2)
+        table = synthetic_table(names, [0.0, 0.0], S, T)
+        sets = hoops(names; heights=[0.5, -0.5])
+        centered = EF.parse_tolerance_toml("""
+            [[ErrorFields.coherent_group]]
+            name = "pair"
+            members = ["u", "l"]
+            shift_tol_mm = 0.0
+            tilt_tol = 1.0
+            radial_shape = "ring"
+            rotation_center_z_m = 0.0
+            """)
+        res0 = EF.run_monte_carlo(table, centered, sets, EF.MonteCarloControl(; nsample=20_000, nbatch=1, seed=2, nbins=50, delta_max=1e-2))
+        @test res0.mean_abs_delta < 1e-12
+        offset = EF.parse_tolerance_toml("""
+            [[ErrorFields.coherent_group]]
+            name = "pair"
+            members = ["u", "l"]
+            shift_tol_mm = 0.0
+            tilt_tol = 1.0
+            radial_shape = "ring"
+            rotation_center_z_m = -0.5
+            """)
+        # Rotation about the lower coil by 1° moves the upper coil by 1.0 m·deg2rad(1): |δ| = |S|·1.0·deg2rad(1).
+        res1 = EF.run_monte_carlo(table, offset, sets, EF.MonteCarloControl(; nsample=20_000, nbatch=1, seed=2, nbins=50, delta_max=0.05))
+        @test res1.mean_abs_delta ≈ deg2rad(1.0) rtol = 1e-2
+        # Two groups sharing a phase_group move in the same direction: their shifts add coherently.
+        shared = EF.parse_tolerance_toml("""
+            [[ErrorFields.coherent_group]]
+            name = "gu"
+            members = ["u"]
+            shift_tol_mm = 1.0
+            radial_shape = "ring"
+            phase_group = "same"
+            [[ErrorFields.coherent_group]]
+            name = "gl"
+            members = ["l"]
+            shift_tol_mm = 1.0
+            radial_shape = "ring"
+            phase_group = "same"
+            """)
+        res_s = EF.run_monte_carlo(table, shared, sets, EF.MonteCarloControl(; nsample=20_000, nbatch=1, seed=2, nbins=50, delta_max=5e-3))
+        @test res_s.mean_abs_delta ≈ 2e-3 rtol = 1e-2
+        independent = EF.parse_tolerance_toml(replace(shared.raw, "phase_group = \"same\"" => ""))
+        res_i = EF.run_monte_carlo(table, independent, sets, EF.MonteCarloControl(; nsample=50_000, nbatch=1, seed=2, nbins=50, delta_max=5e-3))
+        # |e^{iφ1} + e^{iφ2}| averages 4/π for independent phases.
+        @test res_i.mean_abs_delta ≈ 1e-3 * 4 / π rtol = 2e-2
+    end
+
+    @testset "guards" begin
+        table = synthetic_table(["a"], [1e-4], reshape([1.0, -1.0im, 0.0], 3, 1), zeros(3, 1))
+        ts = EF.parse_tolerance_toml("[[ErrorFields.coil]]\nname = \"b\"\nshift_tol_mm = 1.0\n")
+        @test_throws ArgumentError EF.run_monte_carlo(table, ts, hoops(["a"]))   # unknown coil name
+        ok = EF.parse_tolerance_toml("[[ErrorFields.coil]]\nname = \"a\"\nshift_tol_mm = 1.0\n")
+        @test_throws ArgumentError EF.run_monte_carlo(table, ok, hoops(["zzz"]))  # no geometry for the coil
+        @test_throws ArgumentError EF.run_monte_carlo(table, ok, hoops(["a"]), EF.MonteCarloControl(; nsample=0))
+        empty = EF.parse_tolerance_toml("[[ErrorFields.coil]]\nname = \"a\"\nshift_tol_mm = 0.0\n")
+        zero_table = synthetic_table(["a"], [0.0], reshape([1.0, -1.0im, 0.0], 3, 1), zeros(3, 1))
+        @test_throws ArgumentError EF.run_monte_carlo(zero_table, empty, hoops(["a"]))  # nothing to sample
+    end
+end


### PR DESCRIPTION
Sixth PR of the OMFIT → Julia error-field tolerance migration, stacked on #450. It adds the tolerance Monte Carlo: the batched, seeded recombination of a `SensitivityTable` (PR3) with a `ToleranceSet` (PR4) through the samplers (PR5) into intrinsic and corrected `|δ|` histograms, wired into the run and re-runnable post hoc for any window, mode, tolerance scale, or coil subset.

**What it does** (`src/ErrorFields/MonteCarlo.jl`)

- Per sample: `δ = Σ_c [δ_nom,c + S_c·(Δ_c + u_c) + T_c·(θ_c + v_c)] + Σ_g [S_g·(Δ_g + Δ_rot) + T_g·θ_g] + δ_other`, with each coil's own draw (additive or cylinder model), its Gaussian placement uncertainties, one shared draw per coherent group (groups with equal `phase_group` share the direction), the lateral shift `(z_m − z_pivot)·θ_g` a rigid group rotation gives each member, and the unattributed budget. `S·Δ` is the exact complex form `S_x·real(Δ) + S_y·imag(Δ)`.
- Two accumulators per run: intrinsic `|δ|` and corrected `|δ|` (correctable coils, groups, and the budget divided by `efc_factor`), histogrammed on a fixed linear grid sized by the worst-case alignment bound (nothing but the Gaussian tails and the budget can exceed it; those land in the last bin, and `clamped_fraction` reports how many).
- Every name resolved to plain arrays before the loop; group sensitivities pre-summed so a group costs one draw and a few multiply-adds per sample; per-batch `Xoshiro(hash((seed, b)))` so results are bit-identical for any thread count; `pdf_batches` kept so PR7 gets error bars for free.
- `MonteCarloControl` (`[ErrorFields.MonteCarlo]`: `nsample`, `nbatch`, `seed`, `nbins`, `delta_max`, `tolerance_scale`, `coil_subset`). The run writes the full-window dominant-mode summary to `ErrorFields/MonteCarlo/`; `run_monte_carlo("gpec.h5"; psi_low, psi_high, mode, kwargs...)` re-runs any other analysis choice from the file in about a second, using the tolerance snapshot the run echoed and the coil geometry snapshot. `MonteCarloResult(h5path)` reads a run's histograms back.
- The example gains `tolerances.toml` (illustrative 1 mm / 0.05° F-coil tolerances, two coherent outboard groups sharing a direction, a 1 G budget) and a Monte Carlo section; `analyze_example.jl` plots the intrinsic, corrected, and edge-window distributions.

**Verification** (`test/runtests_monte_carlo.jl`, 30 tests; a review package with figures accompanies this PR)

- One axisymmetric coil, Flat 2 mm shift tolerance: `|δ|` is the box `1/(|S|R)` on `[0, |S|R]` (not the linear ramp a uniform-area draw would give), the corrected one the half-box; means to 2 %.
- Three coils with `S_y = −i·S_x`, `T_y = +i·T_x` (the identities PR3 established), mixed shapes, a placement uncertainty, an uncorrectable coil and a ring budget: the kernel's intrinsic and corrected CDFs match a literal Julia transcription of OMFIT's `dfac/dunc/tfac` construction to < 0.01 (Monte Carlo noise), means to 1 %. This is the S_y = i·S_x reduction the plan called the load-bearing check: the generalized kernel subsumes the OMFIT model rather than resembling it.
- Same seed → bit-identical histograms and batches; different seed differs; `tolerance_scale` widens; `coil_subset` narrows the worst-case bound and leaves un-listed coils at their nominal overlap.
- Coherent groups: two identical coils at ±0.5 m rotated rigidly about z = 0 cancel exactly; about the lower coil the upper one's rotation shift gives `|δ| = |S|·1 m·deg2rad(1°)`; two groups sharing a `phase_group` add coherently (`2R`), independent ones average `4R/π`.
- The Solovev run test now covers the in-run Monte Carlo, its HDF5 group (metadata contract), the file reader, the file re-run reproducing the run bit for bit, and a windowed post-hoc re-run.

**Not ported:** OMFIT's `manufacturing_factor` / `manufacturing_tolerance` (a global multiplier and random perturbation of the nominal overlaps) — both at their neutral defaults in the paper scripts. Say the word if you want them as `nominal_scale` / `nominal_uncertainty`.

cc @matt-pharr

## Release note

- **Audience:** users
- **Numerical impact:** none _(harness @ 9ea94d94)_
- **Migration:** none

A run with a `tolerance_file` now samples every coil set's misalignment within its tolerance and writes the intrinsic and corrected dominant-mode overlap distributions to `ErrorFields/MonteCarlo/`; `run_monte_carlo("gpec.h5"; ...)` re-evaluates them for any ψ window, mode, tolerance scale, or coil subset without re-running the plasma.

## Regression report

```
Regression Report: diiid_n1
=================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
Ref 2: local  @ local (2026-09-11)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
-------------------------------------------------------------------------------------------------
Quantity                                      develop          local            Diff       Status
-------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01     0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05     0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00    0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00     0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01     0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]        0.0e+00    OK    
ODE steps (saved)                             2576             2576             0.0e+00    OK    
ODE steps (total)                             4572             4572             0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00     0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00     0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02     0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00     0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01     0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01     0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01     0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01     0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01     0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01     0.0e+00    OK    
# singular surfaces                           5                5                0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]         0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]         0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01     0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01     0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00     0.0e+00    OK    
mpert                                         35               35               0.0e+00    OK    
npert                                         1                1                0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00     0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01     0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00     0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00     0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...  identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...  identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...  identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...  identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...  identical  OK    
island half-widths                            [5 elem]         [5 elem]         0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]         0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04     0.0e+00    OK    
dominant-coupling singular values             N/A              [5 elem]         N/A        N/A   
|forcing overlap with dominant mode|          N/A              3.284975e-02     N/A        N/A   
|delta_nominal| of coil set 1                 N/A              1.637107e-02                N/A   
||ddelta/d(shift)|| over coil sets            N/A              2.998822e-02                N/A   
||ddelta/d(tilt)|| over coil sets             N/A              1.012616e-04                N/A   
PE plasma energy                              3.422677e+00     3.422677e+00     0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00     0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00     0.0e+00    OK    
PE toroidal torque                            5.087465e-02     5.087465e-02     0.0e+00    OK    
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01     0.0e+00    OK    
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02     0.0e+00    OK    
Runtime (s)                                   295.4s           297.8s                      --    
resonant area-weighted field b^r              [5 elem]         [5 elem]         0.0e+00    OK    
=================================================================================================
Summary: 47 unchanged, 5 missing/N/A
```

## Notes for reviewers

- Stacked on #450 (base branch `feature/errorfields-sampling`).
- The kernel had a budgeted `julia-performance-optimizer` pass and a `clean-code-reviewer` pass; their outcomes are in the review package.
- The regression harness does not track the Monte Carlo (the DIII-D ideal example names no tolerance file); the example deck exercises it. A seeded harness quantity can be added if you want it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu
