### PR TITLE
ErrorFields - FEATURE - Add the locking-risk model and tolerance scan

### DIFF
--- a/docs/development/hdf5-conventions.md
+++ b/docs/development/hdf5-conventions.md
@@ -45,7 +45,7 @@ Top level (11 groups):
 | `SingularSurfaces/` | Per-rational-surface data: `rational_psi`/`rational_q`/`rational_m`/`rational_n`, GGJ coefficients, `Delta_prime_matrix`/`Delta_prime_raw`/`Delta_coil`/`pest3_A`/`pest3_B`/`pest3_Gamma` (Riccati or Galerkin alike), `Kinetic/` |
 | `PerturbedEquilibrium/` | `ForcingModes/`, `Response/`, `ResponseMatrices/`, `SingularCoupling/`, `Energies/`, control-surface spectra |
 | `KineticForces/` | `<method>/` (torque/energy profiles, `EnergyIntegrals/`, `KineticMatrices/`); multi-ion runs add `PerSpecies/<species>/<method>/` with the same per-method layout, summing to the top-level total |
-| `ErrorFields/` | `CoilSensitivities/` (per-coil-set control-surface spectra and their rigid shift/tilt derivatives, `DominantMode/` full-window projection); `MonteCarlo/` (intrinsic and corrected `\|δ\|` histograms over the sampled tolerances, per batch and averaged) |
+| `ErrorFields/` | `CoilSensitivities/` (per-coil-set control-surface spectra and their rigid shift/tilt derivatives, `DominantMode/` full-window projection); `MonteCarlo/` (intrinsic and corrected `\|δ\|` histograms over the sampled tolerances, per batch and averaged); `Risk/` (threshold density, `P(lock\|δ)`, locking probabilities, `ToleranceScan/`) |
 | `Tearing/` | `PerSurface/` (+ `DpMatrix/`), `Roots/`, `LayerWidths/`, `Diagnostics/{ValidRoots,Poles,FilteredRoots}`, `Scan/Surface_<k>/` |
 | `SurfaceGeometries/` | `{Plasma,Wall}/{x,y,z}` point clouds |
 

--- a/docs/src/error_fields.md
+++ b/docs/src/error_fields.md
@@ -189,6 +189,45 @@ mc.pdf_efc                     # corrected
 mc.mean_abs_delta, mc.delta_nominal
 ```
 
+## Locking risk and allowable tolerance
+
+An overlap distribution becomes a locking risk through the empirical ITPA penetration-threshold
+scalings (n = 1: Logan et al., *Plasma Phys. Control. Fusion* **62**, 084001 (2020); n = 2:
+Logan et al., *Nucl. Fusion* **60**, 086010 (2020)):
+`δ_thresh = 10^α_c · n_e^α_n · B_T^α_B · R_0^α_R · (β_N/l_i)^α_β`. Sampling the fitted exponents
+within their standard errors turns the threshold into a distribution; its cumulative
+distribution is the probability that an overlap `δ` locks, and the locking probability of the
+assembled machine is `100 ∫ pdf(δ) P(lock|δ) dδ` over the Monte Carlo bins, per batch. The
+operating point is an `[ErrorFields.scenario]` table: density must be given (it is not an
+equilibrium output); field, major radius, β_N and l_i default from the equilibrium.
+
+```toml
+[ErrorFields.scenario]
+n_e = 5.0                       # Electron density for the threshold scaling [1e19 m^-3]
+
+[ErrorFields.Risk]
+dataset = "O,L"                 # ITPA dataset of the threshold fit: "O,L" or "O,L,H" (n = 1); "O,L", "O,L,-C", "O,L,N" (n = 2)
+fit = "WLS"                     # Fitting method: "OLS", "DSOLS", or "WLS"
+distribution = "normal"         # How the fit exponents are sampled: "normal", "flat", or "normal_truncated"
+nsample_threshold = 1000000     # Threshold samples
+seed = 1                        # Seed of the threshold sampling
+scan_scales = [0.25, 0.5, 1.0, 2.0, 4.0]   # Tolerance multipliers of the allowable-tolerance scan (empty: no scan)
+```
+
+`ErrorFields/Risk/` holds the threshold density and `P(lock|δ)` on the Monte Carlo grid, the
+locking probability of the intrinsic and corrected distributions (with per-batch values), the
+as-designed risk, and the sharp-threshold risk; `ErrorFields/Risk/ToleranceScan/` the risk
+against tolerance scale. The scan is the stored quantity; the allowable tolerance for a target
+risk is a post-hoc inversion, and every window or fit choice is re-evaluated from the file:
+
+```julia
+scan = EF.ToleranceScan("gpec.h5")
+EF.allowable_tolerance(scan, 1.0)                  # tolerance multiplier at 1 % locking risk
+EF.allowable_tolerance(scan, 1.0; corrected=true)  # with error-field correction
+risk = EF.locking_risk("gpec.h5"; n_e=5.0, psi_low=0.7, risk_ctrl=EF.RiskControl(; dataset="O,L,H"))
+scan2 = EF.tolerance_scan("gpec.h5"; n_e=5.0, scales=[0.5, 1, 2, 4], coil_subset=["F6A", "F7A"])
+```
+
 ## Analysis after the run
 
 Window the coupling to any range of rational surfaces and project onto any singular mode

--- a/examples/DIIID-like_error_field_example/analyze_example.jl
+++ b/examples/DIIID-like_error_field_example/analyze_example.jl
@@ -1,6 +1,6 @@
 using Pkg;
 Pkg.activate(joinpath(@__DIR__, "../.."))
-using GeneralizedPerturbedEquilibrium, Plots, Printf
+using GeneralizedPerturbedEquilibrium, Plots, Printf, HDF5
 using GeneralizedPerturbedEquilibrium: PerturbedEquilibrium, ErrorFields
 isinteractive() ? plotlyjs() : gr()
 
@@ -50,7 +50,7 @@ p_spec = plot(; xlabel="poloidal mode m", ylabel="|b̃| [T]", yscale=:log10, leg
     left_margin=12Plots.mm, bottom_margin=6Plots.mm, size=(900, 420))
 c = findfirst(==("d3d_c"), names)   # file-based sets are named machine_name
 me, ae = step_series(m, max.(abs.(sens.nominal_field[:, c]), 1e-30))
-plot!(p_spec, me, ae; seriestype=:steppre, lw=2, label="C-coil nominal (1 kA)")
+plot!(p_spec, me, ae; seriestype=:steppre, lw=2, label="C-coil nominal (20 A)")
 for j in picks
     me, ae = step_series(m, max.(1e-3 .* abs.(sens.shift_sensitivity[:, 1, j]), 1e-30))
     plot!(p_spec, me, ae; seriestype=:steppre, lw=2, label="$(names[j]) ∂b̃/∂Δx · 1 mm")
@@ -78,3 +78,31 @@ println("Saved: ", abspath(pdf_path))
 @printf("⟨|δ|⟩ = %.3e intrinsic, %.3e corrected; as designed %.3e; batch spread of ⟨|δ|⟩ ≈ %.1e\n",
     mc.mean_abs_delta, mc.mean_abs_delta_efc, mc.delta_nominal,
     maximum(abs.(vec(sum(mc.pdf_batches .* centers(mc) .* diff(mc.bin_edges); dims=1)) .- mc.mean_abs_delta)))
+
+# Locking risk: the threshold distribution against the overlap distribution, and the risk against
+# tolerance scale with the allowable tolerance for a 1 % target read off the scan.
+scan = ErrorFields.ToleranceScan(h5path)
+risk_nominal = h5open(f -> (read(f["ErrorFields/Risk/plock_percent"]), read(f["ErrorFields/Risk/plock_efc_percent"]),
+        read(f["ErrorFields/Risk/threshold_nominal"]), read(f["ErrorFields/Risk/threshold_pdf"]), read(f["ErrorFields/Risk/p_lock_given_delta"])), h5path, "r")
+plock, plock_efc, thr_nom, thr_pdf, p_given = risk_nominal
+p_thr = plot(; xlabel="dominant-mode overlap |δ|", ylabel="probability density", legend=:topright, xscale=:log10,
+    title="Overlap distribution vs ITPA penetration threshold", left_margin=12Plots.mm, bottom_margin=6Plots.mm, size=(900, 420))
+c = centers(mc)
+keep = c .> 0
+plot!(p_thr, c[keep], mc.pdf[keep] ./ maximum(mc.pdf); lw=2, label="intrinsic |δ| (normalized)")
+plot!(p_thr, c[keep], mc.pdf_efc[keep] ./ maximum(mc.pdf_efc); lw=2, label="corrected |δ| (normalized)")
+plot!(p_thr, c[keep], thr_pdf[keep] ./ maximum(thr_pdf); lw=2, c=:black, label="threshold density (normalized)")
+plot!(p_thr, mc.bin_edges[2:end], p_given[2:end]; lw=1.5, ls=:dash, c=:red, label="P(lock | δ)")
+vline!(p_thr, [thr_nom]; ls=:dot, c=:black, label="nominal threshold")
+p_scan = plot(; xlabel="tolerance scale (× tolerances.toml)", ylabel="locking probability [%]", xscale=:log10, yscale=:log10,
+    legend=:topleft, title="Risk vs tolerance scale", left_margin=12Plots.mm, bottom_margin=6Plots.mm)
+plot!(p_scan, scan.scale, max.(scan.plock, 1e-4); marker=:circle, lw=2, label="intrinsic")
+plot!(p_scan, scan.scale, max.(scan.plock_efc, 1e-4); marker=:square, lw=2, label="corrected")
+hline!(p_scan, [1.0]; ls=:dash, c=:gray, label="1 % target")
+p_risk = plot(p_thr, p_scan; layout=(2, 1), size=(900, 760))
+display(p_risk)
+risk_path = joinpath(@__DIR__, "locking_risk.png")
+Plots.savefig(p_risk, risk_path)
+println("Saved: ", abspath(risk_path))
+@printf("P_lock = %.2f %% intrinsic, %.2f %% corrected at the design tolerances; allowable scale for 1 %%: %.2f (intrinsic), %.2f (corrected)\n",
+    plock, plock_efc, ErrorFields.allowable_tolerance(scan, 1.0), ErrorFields.allowable_tolerance(scan, 1.0; corrected=true))

--- a/examples/DIIID-like_error_field_example/gpec.toml
+++ b/examples/DIIID-like_error_field_example/gpec.toml
@@ -1,6 +1,6 @@
 # DIII-D-like H-mode equilibrium — n=1 error-field sensitivity of the poloidal-field coils.
 # Same free-boundary ideal solve as DIIID-like_ideal_example, with the DIII-D C-coil supplying
-# the nominal n=1 forcing and every F coil (F1A–F9B) added as a single-filament hoop at the
+# a small intrinsic n=1 error field and every F coil (F1A–F9B) added as a single-filament hoop at the
 # centroid of its winding pack, from OpenFUSIONToolkit's TokaMaker DIIID_geom.json. An
 # axisymmetric hoop drives no n=1 field as built, so each F coil's error-field content is
 # entirely its sensitivity to misalignment: the [ErrorFields] stage linearizes every coil set's
@@ -67,7 +67,7 @@ nzeta_coil = 32                         # Toroidal grid (0 = auto = 32·n)
 
 [[ForcingTerms.coil_set]]
 name = "c"                              # Coil set; resolves to coil_geometries/d3d_c.dat (DIII-D C-coil, 6 coils): the nominal n=1 source
-currents = [1000.0, 500.0, -500.0, -1000.0, -500.0, 500.0]  # n=1 cosine phasing, 1 kA peak [A]
+currents = [20.0, 10.0, -10.0, -20.0, -10.0, 10.0]  # n=1 cosine phasing, 20 A peak: an intrinsic error field just below the penetration threshold [A]
 
 [[ForcingTerms.coil_set]]
 name = "F1A"                            # DIII-D F coil F1A: 58-turn winding pack, TokaMaker DIIID_geom.json cross-section centroid
@@ -213,7 +213,16 @@ verbose = true                          # Log per-coil-set progress and linearit
 tolerance_file = "tolerances.toml"      # Manufacturing-tolerance TOML, relative to the run directory
 
 [ErrorFields.MonteCarlo]
-nsample = 1000000                       # Samples per batch
+nsample = 200000                        # Samples per batch
 nbatch = 10                             # Independent batches; their spread is the statistical error bar
 seed = 1                                # Base seed; batch b uses Xoshiro(hash((seed, b)))
 nbins = 300                             # Histogram bins, linear on [0, delta_max]
+
+[ErrorFields.scenario]
+n_e = 5.0                               # Electron density for the threshold scaling [1e19 m^-3]
+
+[ErrorFields.Risk]
+dataset = "O,L"                         # ITPA dataset of the threshold fit: "O,L" or "O,L,H" (n = 1)
+fit = "WLS"                             # Fitting method: "OLS", "DSOLS", or "WLS"
+nsample_threshold = 1000000             # Threshold samples
+scan_scales = [0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0]   # Tolerance multipliers of the allowable-tolerance scan

--- a/examples/DIIID-like_error_field_example/tolerances.toml
+++ b/examples/DIIID-like_error_field_example/tolerances.toml
@@ -1,5 +1,5 @@
 # Illustrative manufacturing tolerances for the DIII-D F coils of DIIID-like_error_field_example:
-# every coil may sit anywhere within 1 mm of its nominal centre and tilt up to 0.05°, sampled
+# every coil may sit anywhere within 0.1 mm of its nominal centre and tilt up to 0.005°, sampled
 # with the hollow radial shape; the upper and lower outboard pairs are also bound into coherent
 # groups standing in for a common support, and an unattributed 1 G budget is carried. These are
 # round numbers for the example, not DIII-D engineering data.
@@ -11,107 +11,107 @@ tolerance_model = "additive"      # "additive" (independent shift and tilt) or "
 
 [[ErrorFields.coil]]
 name = "F1A"                      # DIII-D F coil F1A; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F2A"                      # DIII-D F coil F2A; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F3A"                      # DIII-D F coil F3A; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F4A"                      # DIII-D F coil F4A; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F5A"                      # DIII-D F coil F5A; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F6A"                      # DIII-D F coil F6A; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F7A"                      # DIII-D F coil F7A; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F8A"                      # DIII-D F coil F8A; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F9A"                      # DIII-D F coil F9A; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F1B"                      # DIII-D F coil F1B; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F2B"                      # DIII-D F coil F2B; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F3B"                      # DIII-D F coil F3B; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F4B"                      # DIII-D F coil F4B; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F5B"                      # DIII-D F coil F5B; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F6B"                      # DIII-D F coil F6B; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F7B"                      # DIII-D F coil F7B; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F8B"                      # DIII-D F coil F8B; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coil]]
 name = "F9B"                      # DIII-D F coil F9B; must match the [[ForcingTerms.coil_set]] name
-shift_tol_mm = 1.0                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
-tilt_tol = 0.05                   # Tilt tolerance, in tilt_units
+shift_tol_mm = 0.1                # Radius of the in-plane displacement disk the coil centre may lie in [mm]
+tilt_tol = 0.005                  # Tilt tolerance, in tilt_units
 
 [[ErrorFields.coherent_group]]
 name = "outboard_upper"           # Label of the coherently moving group
 members = ["F6A", "F7A"]          # Coil sets sharing one random draw per sample
-shift_tol_mm = 0.5                # Coherent shift amplitude shared by the group [mm]
-tilt_tol = 0.02                   # Coherent tilt amplitude shared by the group, in tilt_units
+shift_tol_mm = 0.05               # Coherent shift amplitude shared by the group [mm]
+tilt_tol = 0.002                  # Coherent tilt amplitude shared by the group, in tilt_units
 phase_group = "outboard"          # Groups naming the same phase_group share the random direction
 rotation_center_z_m = 0.0         # Height of the pivot of the group's rigid rotation on the machine axis [m]
 
 [[ErrorFields.coherent_group]]
 name = "outboard_lower"           # Label of the coherently moving group
 members = ["F6B", "F7B"]          # Coil sets sharing one random draw per sample
-shift_tol_mm = 0.5                # Coherent shift amplitude shared by the group [mm]
-tilt_tol = 0.02                   # Coherent tilt amplitude shared by the group, in tilt_units
+shift_tol_mm = 0.05               # Coherent shift amplitude shared by the group [mm]
+tilt_tol = 0.002                  # Coherent tilt amplitude shared by the group, in tilt_units
 phase_group = "outboard"          # Groups naming the same phase_group share the random direction
 rotation_center_z_m = 0.0         # Height of the pivot of the group's rigid rotation on the machine axis [m]
 

--- a/src/ErrorFields/ErrorFields.jl
+++ b/src/ErrorFields/ErrorFields.jl
@@ -23,6 +23,8 @@ plasma solve or a new Biot-Savart integration.
   shapes, `sample_disk`, `sample_uncertainty`, and the additive and cylinder tolerance models
 - `MonteCarlo.jl`: `run_monte_carlo`, the batched, seeded recombination of a `SensitivityTable`
   with a `ToleranceSet` into intrinsic and corrected `|δ|` histograms
+- `Risk.jl`: the ITPA penetration-threshold scalings, `locking_risk` (the overlap distribution
+  convolved with the threshold distribution), `tolerance_scan` and `allowable_tolerance`
 
 The stored primitive is the derivative of each coil set's root-area-weighted control-surface
 spectrum b̃, not a scalar: the overlap with any dominant mode is linear in b̃, so the ψ_N window,
@@ -48,6 +50,7 @@ include("Sensitivity.jl")
 include("ToleranceTOML.jl")
 include("Sampling.jl")
 include("MonteCarlo.jl")
+include("Risk.jl")
 include("Output.jl")
 
 export ErrorFieldsControl, CoilSensitivities, SensitivityTable
@@ -57,5 +60,7 @@ export read_tolerance_toml, parse_tolerance_toml, validate_tolerances, tilt_tole
 export RadialDistribution, Flat, UniformArea, Hollow, Ring, PowerLaw, randpow, radial_distribution
 export disk_radius, sample_disk, sample_uncertainty, sample_additive, sample_cylinder
 export MonteCarloControl, MonteCarloResult, run_monte_carlo
+export ThresholdScaling, ITPA_THRESHOLD_SCALINGS, threshold_scaling, ScenarioParameters, nominal_threshold, threshold_samples
+export RiskControl, RiskResult, locking_risk, ToleranceScan, tolerance_scan, allowable_tolerance
 
 end # module ErrorFields

--- a/src/ErrorFields/Output.jl
+++ b/src/ErrorFields/Output.jl
@@ -173,3 +173,72 @@ function MonteCarloResult(h5path::AbstractString)
             read(g["clamped_fraction"]), ctrl.nsample, size(pdf_batches, 2), ctrl.seed)
     end
 end
+
+const _RISK_GROUP = "ErrorFields/Risk"
+
+# Metadata table for ErrorFields/Risk/ (paths relative to the group). Percentages are stored as
+# such; the threshold density and P(lock|δ) share the Monte Carlo's |δ| grid.
+const RISK_H5_ANNOTATIONS = [
+    "threshold_pdf" => (; long_name="probability density of the sampled ITPA penetration threshold on the Monte Carlo |δ| bins", dims=("delta_bin",)),
+    "p_lock_given_delta" => (; long_name="probability that an overlap equal to each Monte Carlo bin edge locks (threshold cumulative distribution)", dims=("delta_edge",)),
+    "threshold_nominal" => (; long_name="ITPA penetration threshold at the fitted exponents"),
+    "plock_percent" => (; long_name="locking probability of the intrinsic overlap distribution, 100 ∫ pdf(δ) P(lock|δ) dδ, batch average", units="%"),
+    "plock_efc_percent" => (; long_name="locking probability of the corrected overlap distribution, batch average", units="%"),
+    "plock_batches_percent" => (; long_name="locking probability of the intrinsic distribution per Monte Carlo batch", units="%"),
+    "plock_efc_batches_percent" => (; long_name="locking probability of the corrected distribution per Monte Carlo batch", units="%"),
+    "plock_nominal_percent" => (; long_name="locking probability of the as-designed machine, 100 P(lock|δ_nominal)", units="%"),
+    "plock_sharp_percent" => (; long_name="locking probability if the threshold were exactly its nominal value, 100 P(|δ| > threshold_nominal)", units="%"),
+    "ToleranceScan/scale" => (; long_name="multiplier applied to every shift and tilt tolerance"),
+    "ToleranceScan/plock_percent" => (; long_name="locking probability of the intrinsic distribution at each tolerance scale", units="%", dims=("scale",)),
+    "ToleranceScan/plock_efc_percent" => (; long_name="locking probability of the corrected distribution at each tolerance scale", units="%", dims=("scale",)),
+    "ToleranceScan/plock_spread_percent" => (; long_name="range of the intrinsic locking probability over the Monte Carlo batches at each scale", units="%", dims=("scale",)),
+    "ToleranceScan/plock_efc_spread_percent" =>
+        (; long_name="range of the corrected locking probability over the Monte Carlo batches at each scale", units="%", dims=("scale",))
+]
+
+"""
+    write_to_hdf5!(h5file::HDF5.File, risk::RiskResult; scan=nothing)
+
+Write the locking risk to `ErrorFields/Risk/`, with the tolerance scan under
+`ErrorFields/Risk/ToleranceScan/` when given. The threshold fit, scenario and sampling settings
+live in the run's `[ErrorFields.Risk]` and `[ErrorFields.scenario]` tables under
+`Input/gpec_toml_raw`. An existing group is replaced.
+"""
+function write_to_hdf5!(h5file::HDF5.File, risk::RiskResult; scan::Union{Nothing,ToleranceScan}=nothing)
+    haskey(h5file, _RISK_GROUP) && delete_object(h5file, _RISK_GROUP)
+    g = create_group(h5file, _RISK_GROUP)
+    g["threshold_pdf"] = risk.threshold_pdf
+    g["p_lock_given_delta"] = risk.p_lock_given_delta
+    g["threshold_nominal"] = risk.threshold_nominal
+    g["plock_percent"] = risk.plock
+    g["plock_efc_percent"] = risk.plock_efc
+    g["plock_batches_percent"] = risk.plock_batches
+    g["plock_efc_batches_percent"] = risk.plock_efc_batches
+    g["plock_nominal_percent"] = risk.plock_nominal
+    g["plock_sharp_percent"] = risk.plock_sharp
+    if scan !== nothing
+        sg = create_group(g, "ToleranceScan")
+        sg["scale"] = scan.scale
+        sg["plock_percent"] = scan.plock
+        sg["plock_efc_percent"] = scan.plock_efc
+        sg["plock_spread_percent"] = scan.plock_spread
+        sg["plock_efc_spread_percent"] = scan.plock_efc_spread
+    end
+    Utilities.HDF5Annotations.annotate!(g, RISK_H5_ANNOTATIONS)
+    return g
+end
+
+"""
+    ToleranceScan(h5path::AbstractString)
+
+Read a run's tolerance scan back from `ErrorFields/Risk/ToleranceScan/`.
+"""
+function ToleranceScan(h5path::AbstractString)
+    h5open(h5path, "r") do f
+        path = _RISK_GROUP * "/ToleranceScan"
+        haskey(f, path) || throw(ArgumentError("$h5path has no $path group (set scan_scales in [ErrorFields.Risk])"))
+        g = f[path]
+        return ToleranceScan(read(g["scale"]), read(g["plock_percent"]), read(g["plock_efc_percent"]), read(g["plock_spread_percent"]),
+            read(g["plock_efc_spread_percent"]), read(f[_RISK_GROUP*"/plock_nominal_percent"]))
+    end
+end

--- a/src/ErrorFields/Risk.jl
+++ b/src/ErrorFields/Risk.jl
@@ -1,0 +1,357 @@
+"""
+    Risk
+
+From an overlap distribution to a locking risk. The empirical ITPA penetration-threshold
+scalings give the overlap δ at which an error field locks as a power law in density, field,
+major radius and β_N/l_i, with fitted exponents and their uncertainties; sampling the
+exponents turns the threshold into a distribution and its cumulative distribution into the
+probability that an overlap δ locks. Convolving that with the Monte Carlo distribution of
+`|δ|` gives the locking probability of the assembled machine, and repeating the Monte Carlo
+over a range of tolerance scales gives the allowable tolerance for a target risk.
+
+n = 1 fits: Logan et al., "Robustness of the tokamak error field correction tolerance scaling",
+Plasma Phys. Control. Fusion 62 (2020) 084001; n = 2 fits: Logan et al., "Empirical scaling of
+the n = 2 error field penetration threshold in tokamaks", Nucl. Fusion 60 (2020) 086010.
+"""
+
+"""
+    ThresholdScaling
+
+One fit of the ITPA error-field penetration threshold,
+`δ_thresh = 10^α_c · n_e^α_n · B_T^α_B · R_0^α_R · (β_N/l_i)^α_β`, with `n_e` in 10¹⁹ m⁻³,
+`B_T` in tesla and `R_0` in metres. Each exponent carries the fit's standard error.
+
+## Fields
+
+  - `n`: toroidal mode number of the scaling
+  - `dataset`: plasma dataset the fit was made on (`"O,L"` ohmic and L-mode, `"O,L,H"` with H-modes, ...)
+  - `fit`: fitting method (`"OLS"`, `"DSOLS"` downsampled, `"WLS"` weighted)
+  - `alpha_c`, `alpha_n`, `alpha_b`, `alpha_r`, `alpha_beta`: `(value, standard error)` of each exponent
+"""
+struct ThresholdScaling
+    n::Int
+    dataset::String
+    fit::String
+    alpha_c::Tuple{Float64,Float64}
+    alpha_n::Tuple{Float64,Float64}
+    alpha_b::Tuple{Float64,Float64}
+    alpha_r::Tuple{Float64,Float64}
+    alpha_beta::Tuple{Float64,Float64}
+end
+
+# The published ITPA fits, keyed "n=<n> <dataset> <fit>".
+const ITPA_THRESHOLD_SCALINGS = Dict{String,ThresholdScaling}(
+    "n=1 O,L OLS" => ThresholdScaling(1, "O,L", "OLS", (-3.75, 0.05), (0.63, 0.09), (-0.98, 0.12), (0.15, 0.08), (-0.13, 0.10)),
+    "n=1 O,L DSOLS" => ThresholdScaling(1, "O,L", "DSOLS", (-3.39, 0.06), (0.58, 0.08), (-1.08, 0.10), (0.19, 0.07), (0.26, 0.10)),
+    "n=1 O,L WLS" => ThresholdScaling(1, "O,L", "WLS", (-3.46, 0.05), (0.64, 0.06), (-1.14, 0.08), (0.20, 0.07), (0.15, 0.07)),
+    "n=1 O,L,H OLS" => ThresholdScaling(1, "O,L,H", "OLS", (-3.64, 0.04), (0.60, 0.08), (-0.95, 0.08), (0.12, 0.08), (-0.30, 0.05)),
+    "n=1 O,L,H DSOLS" => ThresholdScaling(1, "O,L,H", "DSOLS", (-3.58, 0.04), (0.45, 0.06), (-0.94, 0.08), (0.09, 0.07), (-0.15, 0.05)),
+    "n=1 O,L,H WLS" => ThresholdScaling(1, "O,L,H", "WLS", (-3.62, 0.04), (0.53, 0.06), (-0.95, 0.07), (0.14, 0.08), (-0.19, 0.05)),
+    "n=2 O,L WLS" => ThresholdScaling(2, "O,L", "WLS", (-3.36, 0.06), (1.07, 0.09), (-1.52, 0.2), (1.46, 0.09), (0.36, 0.11)),
+    "n=2 O,L,-C WLS" => ThresholdScaling(2, "O,L,-C", "WLS", (-2.98, 0.05), (0.93, 0.08), (-1.28, 0.15), (0.0, 0.0), (0.41, 0.08)),
+    "n=2 O,L,N WLS" => ThresholdScaling(2, "O,L,N", "WLS", (-3.16, 0.05), (0.64, 0.06), (-1.14, 0.08), (0.20, 0.07), (0.15, 0.07))
+)
+
+"""
+    threshold_scaling(; n=1, dataset="O,L", fit="WLS") -> ThresholdScaling
+
+Look up a published ITPA fit; the available keys are those of `ITPA_THRESHOLD_SCALINGS`.
+"""
+function threshold_scaling(; n::Int=1, dataset::AbstractString="O,L", fit::AbstractString="WLS")
+    key = "n=$n $dataset $fit"
+    haskey(ITPA_THRESHOLD_SCALINGS, key) ||
+        throw(ArgumentError("no ITPA threshold scaling \"$key\"; available: $(join(sort(collect(keys(ITPA_THRESHOLD_SCALINGS))), ", "))"))
+    return ITPA_THRESHOLD_SCALINGS[key]
+end
+
+"""
+    ScenarioParameters
+
+Operating point the threshold scaling is evaluated at. Density is not an ideal-MHD equilibrium
+output and must be given; the other four default from the equilibrium when built with
+`ScenarioParameters(equil; n_e)`.
+
+## Fields
+
+  - `n_e`: electron density, 10¹⁹ m⁻³
+  - `b_t0`: toroidal field magnitude on axis, tesla
+  - `r_0`: major radius of the magnetic axis, metres
+  - `beta_n`: normalized beta
+  - `l_i`: normalized internal inductance (`l_i(1)`)
+"""
+struct ScenarioParameters
+    n_e::Float64
+    b_t0::Float64
+    r_0::Float64
+    beta_n::Float64
+    l_i::Float64
+    function ScenarioParameters(n_e, b_t0, r_0, beta_n, l_i)
+        all(>(0), (n_e, b_t0, r_0, beta_n, l_i)) || throw(ArgumentError("scenario parameters must be positive (got n_e=$n_e, B_T0=$b_t0, R_0=$r_0, β_N=$beta_n, l_i=$l_i)"))
+        return new(n_e, b_t0, r_0, beta_n, l_i)
+    end
+end
+
+"""
+    ScenarioParameters(equil::PlasmaEquilibrium; n_e, b_t0=equil.params.bt0, r_0=equil.ro, beta_n=equil.params.betan, l_i=equil.params.li1)
+    ScenarioParameters(h5path; n_e, kwargs...)
+
+Build the operating point from an equilibrium (or a run's `Equilibrium/` scalars), with the
+density supplied and any other parameter overridable.
+"""
+function ScenarioParameters(equil::Equilibrium.PlasmaEquilibrium; n_e::Real, b_t0::Real=equil.params.bt0, r_0::Real=equil.ro,
+    beta_n::Real=equil.params.betan, l_i::Real=equil.params.li1)
+    return ScenarioParameters(n_e, b_t0, r_0, beta_n, l_i)
+end
+
+function ScenarioParameters(h5path::AbstractString; n_e::Real, kwargs...)
+    vals = h5open(h5path, "r") do f
+        (b_t0=read(f["Equilibrium/B_T_axis"]), r_0=read(f["Equilibrium/R_axis"]), beta_n=read(f["Equilibrium/beta_N"]), l_i=read(f["Equilibrium/l_i_1"]))
+    end
+    merged = merge(vals, values(kwargs))
+    return ScenarioParameters(n_e, merged.b_t0, merged.r_0, merged.beta_n, merged.l_i)
+end
+
+_threshold(sc::ThresholdScaling, scen::ScenarioParameters, αc, αn, αb, αr, αβ) =
+    10.0^αc * scen.n_e^αn * scen.b_t0^αb * scen.r_0^αr * (scen.beta_n / scen.l_i)^αβ
+
+"""
+    nominal_threshold(sc::ThresholdScaling, scen::ScenarioParameters) -> Float64
+
+The penetration threshold at the fitted exponents.
+"""
+nominal_threshold(sc::ThresholdScaling, scen::ScenarioParameters) = _threshold(sc, scen, sc.alpha_c[1], sc.alpha_n[1], sc.alpha_b[1], sc.alpha_r[1], sc.alpha_beta[1])
+
+"""
+    threshold_samples(rng, sc, scen; nsample=1_000_000, dist="normal") -> Vector{Float64}
+
+Thresholds with the five exponents drawn around their fitted values: `"normal"` (Gaussian with
+the standard error), `"flat"` (uniform within one standard error), or `"normal_truncated"`
+(Gaussian, redrawn beyond 1.5 standard errors). The exponents' uncertainties are far from small
+relative to the sensitivity of a power law, so the distribution is sampled rather than
+propagated to first order.
+"""
+function threshold_samples(rng::AbstractRNG, sc::ThresholdScaling, scen::ScenarioParameters; nsample::Int=1_000_000, dist::AbstractString="normal")
+    draw = if dist == "normal"
+        () -> randn(rng)
+    elseif dist == "flat"
+        () -> 2 * rand(rng) - 1
+    elseif dist == "normal_truncated"
+        () -> begin
+            x = randn(rng)
+            while abs(x) > 1.5
+                x = randn(rng)
+            end
+            x
+        end
+    else
+        throw(ArgumentError("dist must be \"normal\", \"flat\", or \"normal_truncated\" (got \"$dist\")"))
+    end
+    out = Vector{Float64}(undef, nsample)
+    for i in 1:nsample
+        out[i] = _threshold(sc, scen,
+            sc.alpha_c[1] + sc.alpha_c[2] * draw(), sc.alpha_n[1] + sc.alpha_n[2] * draw(), sc.alpha_b[1] + sc.alpha_b[2] * draw(),
+            sc.alpha_r[1] + sc.alpha_r[2] * draw(), sc.alpha_beta[1] + sc.alpha_beta[2] * draw())
+    end
+    return out
+end
+
+"""
+    RiskControl
+
+Settings of the locking-risk evaluation, the `[ErrorFields.Risk]` TOML table.
+
+## Fields
+
+  - `dataset`, `fit`: which ITPA threshold fit to use (the toroidal mode number is the run's)
+  - `distribution`: how the fit exponents are sampled — `"normal"`, `"flat"`, or `"normal_truncated"`
+  - `nsample_threshold`: threshold samples
+  - `seed`: seed of the threshold sampling
+  - `scan_scales`: tolerance multipliers of the allowable-tolerance scan (empty: no scan); each
+    is a fresh Monte Carlo with every shift and tilt tolerance multiplied by the scale
+"""
+Base.@kwdef struct RiskControl
+    dataset::String = "O,L"
+    fit::String = "WLS"
+    distribution::String = "normal"
+    nsample_threshold::Int = 1_000_000
+    seed::Int = 1
+    scan_scales::Vector{Float64} = Float64[]
+end
+
+"""
+    RiskResult
+
+The locking risk of a Monte Carlo overlap distribution under one threshold scaling. All
+probabilities are percentages.
+
+## Fields
+
+  - `bin_edges`: the Monte Carlo's `|δ|` grid `[nbins + 1]`
+  - `threshold_pdf`: probability density of the sampled penetration threshold on that grid `[nbins]`
+  - `p_lock_given_delta`: probability that an overlap equal to each bin edge locks, the
+    threshold's cumulative distribution `[nbins + 1]`
+  - `threshold_nominal`: the threshold at the fitted exponents
+  - `plock`, `plock_efc`: locking probability of the intrinsic and of the corrected distribution,
+    `100 ∫ pdf(δ) P(lock|δ) dδ`, batch averages
+  - `plock_batches`, `plock_efc_batches`: the same per Monte Carlo batch `[nbatch]`; their ranges
+    are the statistical error bars
+  - `plock_nominal`: risk of the as-designed machine, `100 P(lock|δ_nominal)`
+  - `plock_sharp`: risk if the threshold were exactly its nominal value, `100 P(|δ| > threshold_nominal)`
+  - `scaling`: the threshold fit used
+"""
+struct RiskResult
+    bin_edges::Vector{Float64}
+    threshold_pdf::Vector{Float64}
+    p_lock_given_delta::Vector{Float64}
+    threshold_nominal::Float64
+    plock::Float64
+    plock_efc::Float64
+    plock_batches::Vector{Float64}
+    plock_efc_batches::Vector{Float64}
+    plock_nominal::Float64
+    plock_sharp::Float64
+    scaling::ThresholdScaling
+end
+
+"""
+    locking_risk(mc::MonteCarloResult, sc::ThresholdScaling, scen::ScenarioParameters; ctrl=RiskControl()) -> RiskResult
+    locking_risk(mc, thresholds::AbstractVector, sc, scen) -> RiskResult
+
+Convolve an overlap distribution with the threshold distribution: `P(lock|δ)` is the fraction of
+sampled thresholds below `δ`, and the locking probability is `100 ∫ pdf(δ) P(lock|δ) dδ` over
+the Monte Carlo's bins, evaluated per batch. Thresholds are sampled with `ctrl` or passed in.
+"""
+function locking_risk(mc::MonteCarloResult, sc::ThresholdScaling, scen::ScenarioParameters; ctrl::RiskControl=RiskControl())
+    thresholds = threshold_samples(Xoshiro(ctrl.seed), sc, scen; nsample=ctrl.nsample_threshold, dist=ctrl.distribution)
+    return locking_risk(mc, thresholds, sc, scen)
+end
+
+function locking_risk(mc::MonteCarloResult, thresholds::AbstractVector{<:Real}, sc::ThresholdScaling, scen::ScenarioParameters)
+    edges = mc.bin_edges
+    sorted = sort(Float64.(thresholds))
+    n = length(sorted)
+    cdf_at(x) = searchsortedlast(sorted, x) / n
+    p_given = [e == 0 ? 0.0 : cdf_at(e) for e in edges]
+    threshold_pdf = diff(p_given) ./ diff(edges)
+    # Bin-average of P(lock|δ) times the bin's probability mass; the last bin also holds the
+    # clamped tail, whose overlaps are at least the last edge.
+    weights = (p_given[1:end-1] .+ p_given[2:end]) ./ 2
+    widths = diff(edges)
+    # Densities integrate to one only to round-off, so the percentage is clamped to [0, 100].
+    plock_of(pdf) = clamp(100 * sum(pdf .* widths .* weights), 0.0, 100.0)
+    plock_b = [plock_of(view(mc.pdf_batches, :, b)) for b in 1:size(mc.pdf_batches, 2)]
+    plock_efc_b = [plock_of(view(mc.pdf_efc_batches, :, b)) for b in 1:size(mc.pdf_efc_batches, 2)]
+    nominal = nominal_threshold(sc, scen)
+    plock_sharp = clamp(100 * (1 - sum(mc.pdf[edges[2:end].<=nominal] .* widths[edges[2:end].<=nominal])), 0.0, 100.0)
+    return RiskResult(copy(edges), threshold_pdf, p_given, nominal, sum(plock_b) / length(plock_b), sum(plock_efc_b) / length(plock_efc_b),
+        plock_b, plock_efc_b, 100 * cdf_at(mc.delta_nominal), plock_sharp, sc)
+end
+
+"""
+    locking_risk(h5path; n_e, psi_low=0.0, psi_high=1.0, mode=1, risk_ctrl=RiskControl(), kwargs...) -> RiskResult
+
+Post-hoc locking risk from a run: the Monte Carlo is re-run from the file for the given window
+and mode with [`MonteCarloControl`](@ref) `kwargs`, the threshold fit is chosen by `risk_ctrl`
+for the run's toroidal mode number, and the scenario is the run's equilibrium at density `n_e`.
+"""
+function locking_risk(h5path::AbstractString; n_e::Real, psi_low::Real=0.0, psi_high::Real=1.0, mode::Int=1, risk_ctrl::RiskControl=RiskControl(), kwargs...)
+    mc = run_monte_carlo(h5path; psi_low, psi_high, mode, kwargs...)
+    n = h5open(f -> Int(read(f["Info/nlow"])), h5path, "r")
+    sc = threshold_scaling(; n, dataset=risk_ctrl.dataset, fit=risk_ctrl.fit)
+    return locking_risk(mc, sc, ScenarioParameters(h5path; n_e); ctrl=risk_ctrl)
+end
+
+"""
+    ToleranceScan
+
+Locking risk against a multiplier of every shift and tilt tolerance, from repeated Monte
+Carlos on the same sensitivities. Percentages throughout.
+
+## Fields
+
+  - `scale`: tolerance multipliers `[nscale]`
+  - `plock`, `plock_efc`: locking probability at each scale, batch averages
+  - `plock_spread`, `plock_efc_spread`: range of the batch values at each scale
+  - `plock_nominal`: risk of the as-designed machine (independent of the scale)
+"""
+struct ToleranceScan
+    scale::Vector{Float64}
+    plock::Vector{Float64}
+    plock_efc::Vector{Float64}
+    plock_spread::Vector{Float64}
+    plock_efc_spread::Vector{Float64}
+    plock_nominal::Float64
+end
+
+"""
+    tolerance_scan(table, ts, coil_sets, mc_ctrl, sc, scen; scales, risk_ctrl=RiskControl()) -> ToleranceScan
+    tolerance_scan(h5path; scales, psi_low=0.0, psi_high=1.0, mode=1, n_e, kwargs...) -> ToleranceScan
+
+Run the Monte Carlo once per tolerance multiplier in `scales` and evaluate the locking risk of
+each with one threshold sampling. The file form takes the run's tolerances, coil geometry and
+equilibrium scalars from `gpec.h5`; `kwargs` are [`MonteCarloControl`](@ref) fields, and the
+threshold fit is chosen with `risk_ctrl`.
+"""
+function tolerance_scan(table::SensitivityTable, ts::ToleranceSet, coil_sets::Vector{CoilSet}, mc_ctrl::MonteCarloControl,
+    sc::ThresholdScaling, scen::ScenarioParameters; scales::AbstractVector{<:Real}, risk_ctrl::RiskControl=RiskControl())
+    isempty(scales) && throw(ArgumentError("tolerance_scan needs at least one scale"))
+    all(>=(0), scales) || throw(ArgumentError("tolerance scales must be ≥ 0"))
+    thresholds = threshold_samples(Xoshiro(risk_ctrl.seed), sc, scen; nsample=risk_ctrl.nsample_threshold, dist=risk_ctrl.distribution)
+    fields = (f => getfield(mc_ctrl, f) for f in fieldnames(MonteCarloControl) if f != :tolerance_scale)
+    plock = Float64[]
+    plock_efc = Float64[]
+    spread = Float64[]
+    spread_efc = Float64[]
+    nominal = 0.0
+    for s in scales
+        mc = run_monte_carlo(table, ts, coil_sets, MonteCarloControl(; fields..., tolerance_scale=Float64(s)))
+        risk = locking_risk(mc, thresholds, sc, scen)
+        push!(plock, risk.plock)
+        push!(plock_efc, risk.plock_efc)
+        push!(spread, maximum(risk.plock_batches) - minimum(risk.plock_batches))
+        push!(spread_efc, maximum(risk.plock_efc_batches) - minimum(risk.plock_efc_batches))
+        nominal = risk.plock_nominal
+    end
+    return ToleranceScan(Float64.(collect(scales)), plock, plock_efc, spread, spread_efc, nominal)
+end
+
+function tolerance_scan(h5path::AbstractString; scales::AbstractVector{<:Real}, psi_low::Real=0.0, psi_high::Real=1.0, mode::Int=1,
+    n_e::Real, risk_ctrl::RiskControl=RiskControl(), kwargs...)
+    ts = read_tolerance_snapshot(h5path)
+    ts === nothing && throw(ArgumentError("$h5path carries no tolerance snapshot (the run named no tolerance_file)"))
+    table = sensitivity_table(h5path; psi_low, psi_high, mode)
+    coil_sets, n = h5open(h5path, "r") do f
+        haskey(f, "Input/RawInputs/Coils") || throw(ArgumentError("$h5path has no Input/RawInputs/Coils snapshot"))
+        sets = CoilSet[]
+        ForcingTerms.load_coils_from_h5_group!(sets, f["Input/RawInputs/Coils"])
+        sets, Int(read(f["Info/nlow"]))
+    end
+    sc = threshold_scaling(; n, dataset=risk_ctrl.dataset, fit=risk_ctrl.fit)
+    scen = ScenarioParameters(h5path; n_e)
+    return tolerance_scan(table, ts, coil_sets, MonteCarloControl(; kwargs...), sc, scen; scales, risk_ctrl)
+end
+
+"""
+    allowable_tolerance(scan::ToleranceScan, target_percent; corrected=false) -> Float64
+
+The tolerance multiplier at which the locking risk reaches `target_percent`, by linear
+interpolation in the logarithms of both the scale and the risk between the two scan points
+that bracket the target (the scan need not be monotonic; the first bracketing pair from the
+smallest scale is used). Returns `NaN` when no pair brackets the target. `corrected` reads the
+error-field-corrected curve.
+"""
+function allowable_tolerance(scan::ToleranceScan, target_percent::Real; corrected::Bool=false)
+    target_percent > 0 || throw(ArgumentError("target_percent must be positive"))
+    p = corrected ? scan.plock_efc : scan.plock
+    lt = log10(target_percent)
+    for i in 1:length(scan.scale)-1
+        p1, p2 = p[i], p[i+1]
+        (p1 > 0 && p2 > 0) || continue
+        l1, l2 = log10(p1), log10(p2)
+        (min(l1, l2) <= lt <= max(l1, l2)) || continue
+        l1 == l2 && return scan.scale[i]
+        f = (lt - l1) / (l2 - l1)
+        return 10^(log10(scan.scale[i]) + f * (log10(scan.scale[i+1]) - log10(scan.scale[i])))
+    end
+    return NaN
+end

--- a/src/GeneralizedPerturbedEquilibrium.jl
+++ b/src/GeneralizedPerturbedEquilibrium.jl
@@ -266,7 +266,7 @@ function main_from_inputs(
     if ctrl.force_termination
         slayer_result = run_slayer_stage(ffs_result, inputs, nothing)
         @info "\n$_BANNER\n  GPEC completed successfully in $(@sprintf("%.3f", time() - total_start)) s\n$_BANNER"
-        return (; ffs=ffs_result, pe=nothing, slayer=slayer_result, coil_sensitivities=nothing, monte_carlo=nothing)
+        return (; ffs=ffs_result, pe=nothing, slayer=slayer_result, coil_sensitivities=nothing, monte_carlo=nothing, locking_risk=nothing)
     end
 
     pe_state = run_perturbed_equilibrium(ffs_result, inputs, forcing_modes_snapshot, preloaded_coil_sets)
@@ -274,7 +274,7 @@ function main_from_inputs(
     run_kinetic_forces(inputs, ffs_result, pe_state, kf_ctrl, kinetic_profiles, kf_species)
 
     error_fields = run_error_fields(inputs, ffs_result, pe_state, preloaded_coil_sets)
-    coil_sensitivities, monte_carlo = error_fields === nothing ? (nothing, nothing) : error_fields
+    coil_sensitivities, monte_carlo, locking_risk = error_fields === nothing ? (nothing, nothing, nothing) : error_fields
 
     # SLAYER runs after PE so it appends to the PE output file; it falls back to the
     # ForceFreeStates file when PE did not run.
@@ -293,7 +293,7 @@ function main_from_inputs(
 
     # TODO: Do not allow perturbed equilibrium calculations if zero crossings are found
 
-    return (; ffs=ffs_result, pe=pe_state, slayer=slayer_result, coil_sensitivities, monte_carlo)
+    return (; ffs=ffs_result, pe=pe_state, slayer=slayer_result, coil_sensitivities, monte_carlo, locking_risk)
 
 end
 
@@ -994,13 +994,15 @@ function forcing_terms_control(inputs::Dict{String,Any})
 end
 
 """
-    run_error_fields(inputs, result, pe_state, preloaded_coil_sets) -> (sensitivities, monte_carlo) or nothing
+    run_error_fields(inputs, result, pe_state, preloaded_coil_sets) -> (sensitivities, monte_carlo, risk) or nothing
 
 Linearize every coil set's resonant drive with respect to its rigid shifts and tilts and write
 `ErrorFields/CoilSensitivities/` when the deck carries an `[ErrorFields]` section. When the
 section names a `tolerance_file`, read, validate and echo it, then run the tolerance Monte
 Carlo on the full-window dominant mode with the `[ErrorFields.MonteCarlo]` settings and write
-`ErrorFields/MonteCarlo/`; `monte_carlo` is `nothing` otherwise. Needs the
+`ErrorFields/MonteCarlo/`; with an `[ErrorFields.scenario]` table as well, evaluate the locking
+risk (and the tolerance scan when `[ErrorFields.Risk]` names `scan_scales`) and write
+`ErrorFields/Risk/`. Stages not requested return `nothing`. Needs the
 perturbed-equilibrium state's singular-coupling matrix and coil-format forcing, and errors
 otherwise: a deck asking for error-field sensitivities without them is a misconfiguration, not a
 case to skip silently. Coil geometry is rebuilt from the deck unless a replay injected it.
@@ -1016,10 +1018,14 @@ function run_error_fields(
     @info "\n  ErrorFields\n$_SECTION"
     ef_start = time()
 
-    # [ErrorFields.MonteCarlo] is a nested table, excluded from the control-struct splat.
+    # [ErrorFields.MonteCarlo], [ErrorFields.Risk] and [ErrorFields.scenario] are nested tables,
+    # excluded from the control-struct splat.
     ef_raw = inputs["ErrorFields"]
-    ef_ctrl = ErrorFields.ErrorFieldsControl(; (Symbol(k) => v for (k, v) in ef_raw if k != "MonteCarlo")...)
+    nested = ("MonteCarlo", "Risk", "scenario")
+    ef_ctrl = ErrorFields.ErrorFieldsControl(; (Symbol(k) => v for (k, v) in ef_raw if !(k in nested))...)
     mc_ctrl = ErrorFields.MonteCarloControl(; (Symbol(k) => v for (k, v) in get(ef_raw, "MonteCarlo", Dict{String,Any}()))...)
+    risk_ctrl = ErrorFields.RiskControl(; (Symbol(k) => v for (k, v) in get(ef_raw, "Risk", Dict{String,Any}()))...)
+    scenario_raw = get(ef_raw, "scenario", nothing)
     pe_state === nothing && error("[ErrorFields] needs a [PerturbedEquilibrium] section with compute_singular_coupling = true")
     ft_ctrl = forcing_terms_control(inputs)
     ft_ctrl.forcing_data_format == "coil" ||
@@ -1051,6 +1057,26 @@ function run_error_fields(
               "(nominal $(@sprintf("%.3e", monte_carlo.delta_nominal)))"
     end
 
+    # Locking risk needs the operating point: [ErrorFields.scenario] with at least n_e.
+    risk = nothing
+    scan = nothing
+    if monte_carlo !== nothing && scenario_raw !== nothing
+        haskey(scenario_raw, "n_e") || error("[ErrorFields.scenario] must give n_e (electron density, 1e19 m^-3)")
+        scen = ErrorFields.ScenarioParameters(result.equil; (Symbol(k) => v for (k, v) in scenario_raw)...)
+        sc = ErrorFields.threshold_scaling(; n=result.nlow, dataset=risk_ctrl.dataset, fit=risk_ctrl.fit)
+        risk_start = time()
+        risk = ErrorFields.locking_risk(monte_carlo, sc, scen; ctrl=risk_ctrl)
+        @info "Locking risk ($(sc.dataset) $(sc.fit), n=$(sc.n)): threshold $(@sprintf("%.3e", risk.threshold_nominal)); " *
+              "P_lock = $(@sprintf("%.2f", risk.plock)) % intrinsic, $(@sprintf("%.2f", risk.plock_efc)) % corrected, " *
+              "$(@sprintf("%.2f", risk.plock_nominal)) % as designed ($(@sprintf("%.2f", time() - risk_start)) s)"
+        if !isempty(risk_ctrl.scan_scales)
+            scan_start = time()
+            scan = ErrorFields.tolerance_scan(ErrorFields.sensitivity_table(sens, dom), tolerances, coil_sets, mc_ctrl, sc, scen;
+                scales=risk_ctrl.scan_scales, risk_ctrl)
+            @info "Tolerance scan over $(length(scan.scale)) scales in $(@sprintf("%.2f", time() - scan_start)) s"
+        end
+    end
+
     if ef_ctrl.write_outputs_to_HDF5
         output_file = isempty(ef_ctrl.output_filename) ? result.control.HDF5_filename : ef_ctrl.output_filename
         h5open(joinpath(result.dir_path, output_file), "cw") do h5file
@@ -1058,13 +1084,14 @@ function run_error_fields(
             # Raw echo of the tolerance input for replay (read back by ErrorFields.read_tolerance_snapshot).
             tolerances === nothing || ErrorFields.write_tolerance_snapshot!(h5file, tolerances)
             monte_carlo === nothing || ErrorFields.write_to_hdf5!(h5file, monte_carlo)
+            risk === nothing || ErrorFields.write_to_hdf5!(h5file, risk; scan)
         end
         @info "Results written to $output_file"
     end
 
     @info "ErrorFields completed in $(@sprintf("%.3f", time() - ef_start)) s"
 
-    return sens, monte_carlo
+    return sens, monte_carlo, risk
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ else
     include("./runtests_tolerance_toml.jl")
     include("./runtests_sampling.jl")
     include("./runtests_monte_carlo.jl")
+    include("./runtests_risk.jl")
     include("./runtests_sing.jl")
     include("./runtests_innerlayer.jl")
     include("./runtests_tj_analytic.jl")

--- a/test/runtests_error_fields.jl
+++ b/test/runtests_error_fields.jl
@@ -51,7 +51,10 @@ include("h5_metadata_check.jl")
                 "verbose" => false, "write_outputs_to_HDF5" => true)
             cp(joinpath(@__DIR__, "test_data", "ErrorFields", "tolerances_two_hoops.toml"), joinpath(dir, "tolerances.toml"))
             inputs["ErrorFields"] = Dict{String,Any}("verbose" => false, "tolerance_file" => "tolerances.toml",
-                "MonteCarlo" => Dict{String,Any}("nsample" => 20_000, "nbatch" => 2, "seed" => 5, "nbins" => 100))
+                "MonteCarlo" => Dict{String,Any}("nsample" => 20_000, "nbatch" => 2, "seed" => 5, "nbins" => 100),
+                # Density chosen so the ITPA threshold sits near the fixture's nominal overlap: risk neither 0 nor saturated.
+                "scenario" => Dict{String,Any}("n_e" => 12.0),
+                "Risk" => Dict{String,Any}("nsample_threshold" => 20_000, "seed" => 3, "scan_scales" => [0.5, 1.0, 2.0]))
             open(io -> TOML.print(io, inputs), toml_path, "w")
 
             res = GPEC.main([dir])
@@ -125,6 +128,27 @@ include("h5_metadata_check.jl")
             @test rerun.pdf == mc.pdf
             windowed_mc = EF.run_monte_carlo(h5path; psi_low=rc.rational_psi[end], nsample=5_000, nbatch=1, seed=5, nbins=50)
             @test windowed_mc.delta_nominal ≈ abs(sum(windowed.delta_nominal))
+
+            # Locking risk and tolerance scan: written, bounded, and reproducible from the file.
+            risk = res.locking_risk
+            @test risk isa EF.RiskResult
+            @test risk.scaling.n == 1 && risk.scaling.dataset == "O,L" && risk.scaling.fit == "WLS"
+            @test risk.threshold_nominal == EF.nominal_threshold(risk.scaling, EF.ScenarioParameters(ffs.equil; n_e=12.0))
+            @test 0 <= risk.plock_efc <= risk.plock <= 100
+            @test length(risk.plock_batches) == 2
+            h5open(h5path, "r") do f
+                @test haskey(f, "ErrorFields/Risk/plock_percent") && haskey(f, "ErrorFields/Risk/ToleranceScan/scale")
+                @test read(f["ErrorFields/Risk/plock_percent"]) == risk.plock
+                @test isempty(_collect_metadata_violations(f))
+            end
+            scan = EF.ToleranceScan(h5path)
+            @test scan.scale == [0.5, 1.0, 2.0]
+            @test all(diff(scan.plock) .>= -0.5)                          # risk grows with tolerance (to Monte Carlo noise)
+            @test 0 < risk.plock < 100                                     # neither empty nor saturated at this density
+            @test scan.plock[2] ≈ risk.plock rtol = 1e-12                # the scale-1 point is the run's own Monte Carlo
+            again = EF.locking_risk(h5path; n_e=12.0, nsample=20_000, nbatch=2, seed=5, nbins=100,
+                risk_ctrl=EF.RiskControl(; nsample_threshold=20_000, seed=3))
+            @test again.plock == risk.plock
             from_file = EF.CoilSensitivities(h5path)
             @test from_file.coil_names == sens.coil_names
             @test from_file.m_modes == sens.m_modes && from_file.n_modes == sens.n_modes

--- a/test/runtests_risk.jl
+++ b/test/runtests_risk.jl
@@ -1,0 +1,99 @@
+using Random
+using Statistics
+
+# The locking-risk model: the ITPA threshold table and its nominal value, the sampled threshold
+# distribution, the convolution with a Monte Carlo overlap distribution in closed-form limits
+# (a sharp threshold, a distribution entirely below or above it), the tolerance scan, and the
+# log-space inversion for an allowable tolerance.
+@testset "locking risk" begin
+    GPEC = GeneralizedPerturbedEquilibrium
+    EF = GPEC.ErrorFields
+    FT = GPEC.ForcingTerms
+
+    scen = EF.ScenarioParameters(2.0, 2.0, 1.7, 1.8, 1.0)   # n_e [1e19], B_T [T], R_0 [m], β_N, l_i
+
+    @testset "scaling table and nominal threshold" begin
+        sc = EF.threshold_scaling(; n=1, dataset="O,L", fit="WLS")
+        @test sc.alpha_c == (-3.46, 0.05) && sc.alpha_beta == (0.15, 0.07)
+        @test EF.nominal_threshold(sc, scen) ≈ 10.0^-3.46 * 2.0^0.64 * 2.0^-1.14 * 1.7^0.20 * 1.8^0.15
+        @test_throws ArgumentError EF.threshold_scaling(; n=3)
+        @test_throws ArgumentError EF.threshold_scaling(; n=1, fit="XYZ")
+        @test length(EF.ITPA_THRESHOLD_SCALINGS) == 9
+        # n=2 "O,L,N" is the n=1 O,L WLS fit doubled: 10^(-3.16) ≈ 2·10^(-3.46).
+        @test 10^EF.threshold_scaling(; n=2, dataset="O,L,N").alpha_c[1] ≈ 2 * 10^EF.threshold_scaling(; n=1, dataset="O,L").alpha_c[1] rtol = 5e-3
+        @test_throws ArgumentError EF.ScenarioParameters(0.0, 2.0, 1.7, 1.8, 1.0)
+        # Sampled thresholds: median near the nominal, log-normal-ish spread from the exponent errors.
+        t = EF.threshold_samples(Xoshiro(1), sc, scen; nsample=100_000)
+        @test abs(log10(median(t)) - log10(EF.nominal_threshold(sc, scen))) < 0.01
+        @test all(>(0), t)
+        flat = EF.threshold_samples(Xoshiro(1), sc, scen; nsample=50_000, dist="flat")
+        @test maximum(abs.(log10.(flat) .- log10(EF.nominal_threshold(sc, scen)))) < 0.05 + 0.09 * log10(2) + 0.12 * log10(2) + 0.08 * log10(1.7) + 0.07 * log10(1.8) + 1e-9
+        trunc = EF.threshold_samples(Xoshiro(1), sc, scen; nsample=50_000, dist="normal_truncated")
+        @test std(log10.(trunc)) < std(log10.(t))
+        @test_throws ArgumentError EF.threshold_samples(Xoshiro(1), sc, scen; nsample=10, dist="cauchy")
+    end
+
+    # A Monte Carlo result with a known |δ| density: uniform on [a, b].
+    function uniform_mc(a, b; nbins=200, nbatch=2, edge_max=2b)
+        edges = collect(range(0.0, edge_max; length=nbins + 1))
+        centers = (edges[1:end-1] .+ edges[2:end]) ./ 2
+        pdf = [a <= c <= b ? 1 / (b - a) : 0.0 for c in centers]
+        pdf ./= sum(pdf .* diff(edges))
+        batches = repeat(pdf, 1, nbatch)
+        EF.MonteCarloResult(edges, pdf, pdf ./ 2, batches, batches ./ 2, (a + b) / 2, b, (a + b) / 2, (a + b) / 4, 0.0, 1000, nbatch, 1)
+    end
+    sc = EF.threshold_scaling(; n=1)
+
+    @testset "risk in closed-form limits" begin
+        mc = uniform_mc(1e-4, 3e-4)
+        # A sharp threshold at δ_t: P_lock = fraction of the distribution above δ_t.
+        δt = mc.delta_nominal                                # = 2e-4, the midpoint
+        risk = EF.locking_risk(mc, fill(δt, 1000), sc, scen)
+        @test risk.plock ≈ 50.0 atol = 1.0
+        @test risk.plock_nominal == 100.0                    # δ_nominal = δ_t counts as locked
+        @test risk.plock_batches ≈ fill(risk.plock, 2)
+        @test risk.p_lock_given_delta[1] == 0.0 && risk.p_lock_given_delta[end] == 1.0
+        @test sum(risk.threshold_pdf .* diff(risk.bin_edges)) ≈ 1.0
+        # Thresholds entirely above the distribution: no risk; entirely below: certain.
+        @test EF.locking_risk(mc, fill(1e-3, 100), sc, scen).plock == 0.0
+        @test EF.locking_risk(mc, fill(1e-6, 100), sc, scen).plock ≈ 100.0 atol = 1e-9
+        # Uniform thresholds on [1e-4, 3e-4] against a uniform |δ| on the same interval: P = 1/2.
+        thr = collect(range(1e-4, 3e-4; length=20_001))
+        @test EF.locking_risk(mc, thr, sc, scen).plock ≈ 50.0 atol = 1.0
+        # Sampled ITPA thresholds through the RiskControl path are reproducible and bounded.
+        r1 = EF.locking_risk(mc, sc, scen; ctrl=EF.RiskControl(; nsample_threshold=50_000, seed=4))
+        r2 = EF.locking_risk(mc, sc, scen; ctrl=EF.RiskControl(; nsample_threshold=50_000, seed=4))
+        @test r1.plock == r2.plock && 0 <= r1.plock <= 100 && r1.plock_efc <= r1.plock
+        @test r1.threshold_nominal == EF.nominal_threshold(sc, scen)
+        @test 0 <= r1.plock_sharp <= 100
+    end
+
+    @testset "tolerance scan and allowable tolerance" begin
+        # One coil, S real, δ_nominal = 0, Flat 1 mm tolerance: |δ| uniform on [0, |S|·scale·1e-3].
+        # With a sharp threshold the risk is analytic: P = 1 − δ_t / (|S|·scale·1e-3) once the edge passes δ_t.
+        S = 0.2
+        table = EF.SensitivityTable(["a"], 1, [0.0im], ComplexF64[S; -im*S; 0.0;;], zeros(ComplexF64, 3, 1), [S], [0.0], zeros(2, 1), zeros(2, 1))
+        ts = EF.parse_tolerance_toml("[[ErrorFields.coil]]\nname = \"a\"\nshift_tol_mm = 1.0\nradial_shape = \"flat\"\n")
+        sets = [FT.make_pf_hoop(; radius=1.5, height=0.0, name="a")]
+        mc_ctrl = EF.MonteCarloControl(; nsample=100_000, nbatch=2, seed=7, nbins=200)
+        scales = [0.5, 0.6, 0.7, 0.8, 1.0, 2.0, 4.0]
+        δt = 1e-4   # = |S| · 0.5 mm: the scale-0.5 edge
+        # A degenerate scaling whose exponents have no spread gives a sharp threshold; pick one so
+        # that nominal_threshold == δt by construction.
+        sharp = EF.ThresholdScaling(1, "test", "sharp", (log10(δt), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+        scan = EF.tolerance_scan(table, ts, sets, mc_ctrl, sharp, scen; scales, risk_ctrl=EF.RiskControl(; nsample_threshold=1000))
+        expected = [max(0.0, 1 - δt / (S * s * 1e-3)) * 100 for s in scales]
+        @test scan.scale == scales
+        @test all(abs.(scan.plock .- expected) .< 1.5)
+        @test all(scan.plock_efc .<= scan.plock .+ 1e-9)
+        @test all(scan.plock_spread .>= 0)
+        @test scan.plock_nominal == 0.0
+        # Inversion: the scale at which the risk reaches 25 %, from the analytic curve, is 0.5/(1−0.25) = 2/3,
+        # bracketed by the 0.6 (16.7 %) and 0.7 (28.6 %) points.
+        s25 = EF.allowable_tolerance(scan, 25.0)
+        @test isapprox(s25, 2 / 3; rtol=0.05)
+        @test isnan(EF.allowable_tolerance(scan, 99.0))     # never reached within the scan
+        @test_throws ArgumentError EF.allowable_tolerance(scan, 0.0)
+        @test_throws ArgumentError EF.tolerance_scan(table, ts, sets, mc_ctrl, sharp, scen; scales=Float64[])
+    end
+end


### PR DESCRIPTION
Seventh PR of the OMFIT → Julia error-field tolerance migration, stacked on #451. It closes the loop from tolerances to an engineering answer: the ITPA penetration-threshold scalings turn the Monte Carlo overlap distribution (PR6) into a locking probability, a scan over tolerance scale gives the risk-versus-tolerance curve, and a log-space inversion reads off the allowable tolerance for a target risk.

**What it does** (`src/ErrorFields/Risk.jl`)

- `ITPA_THRESHOLD_SCALINGS`: the nine published fits (n = 1 O,L and O,L,H × OLS/DSOLS/WLS; n = 2 O,L, O,L,−C, O,L,N WLS) as `ThresholdScaling` with `(value, standard error)` per exponent; `threshold_scaling(; n, dataset, fit)`. Cited to Logan et al. PPCF **62** 084001 (2020) and NF **60** 086010 (2020), not to the OMFIT file.
- `ScenarioParameters(n_e, B_T0, R_0, β_N, l_i)`, built from the equilibrium with only `n_e` supplied (`[ErrorFields.scenario]`), or from a run's `Equilibrium/` scalars.
- `threshold_samples` (normal / flat / truncated-normal exponent sampling, as OMFIT), `locking_risk(mc, scaling, scenario)`: `P(lock|δ)` is the sampled threshold's cumulative distribution on the Monte Carlo's own bin edges, `P_lock = 100 ∫ pdf(δ) P(lock|δ) dδ` per batch for the intrinsic and corrected distributions, plus the as-designed risk `100 P(lock|δ_nominal)` and the sharp-threshold risk `100 P(|δ| > δ_thresh,nominal)`. Sharing the Monte Carlo grid removes OMFIT's interpolation between two independently binned histograms.
- `tolerance_scan(...; scales)`: one Monte Carlo per tolerance multiplier against one threshold sampling → `ToleranceScan` (risk and batch spread per scale); `allowable_tolerance(scan, target_percent; corrected)` inverts by linear interpolation in log(scale)–log(risk) between the first bracketing pair, `NaN` when unreached — OMFIT's scan-then-interpolate rather than root-finding on a stochastic function.
- Run wiring: with `[ErrorFields.scenario]` (and optional `[ErrorFields.Risk]`: dataset, fit, distribution, nsample_threshold, seed, scan_scales) the run writes `ErrorFields/Risk/` and `ErrorFields/Risk/ToleranceScan/`; `main` returns `locking_risk`. Post hoc: `locking_risk("gpec.h5"; n_e, psi_low, …)`, `tolerance_scan("gpec.h5"; n_e, scales, coil_subset, …)`, `ToleranceScan("gpec.h5")`. The target risk is never an input: the scan is stored and inverted afterwards.
- The example gains the scenario/risk tables and plots the threshold density against the overlap distributions and the risk-versus-tolerance curve.

**Verification** (`test/runtests_risk.jl`, 32 tests, plus the Solovev run test)

- Table entries and the nominal threshold by hand; the n = 2 O,L,N fit is the n = 1 O,L WLS fit doubled (10^−3.16 ≈ 2·10^−3.46).
- Sampled thresholds: log-median at the nominal, flat sampling bounded by the summed exponent errors, truncated narrower than normal.
- Closed-form risks against a uniform overlap distribution: a sharp threshold at the midpoint gives 50 %, thresholds entirely above/below give 0 / 100 %, uniform thresholds on the same interval give 50 %; the as-designed risk at the threshold counts as locked; per-batch values equal the average for identical batches.
- Tolerance scan on one coil with a Flat tolerance and a sharp threshold: `P = 1 − δ_t/(|S|·s·1 mm)` reproduced to 1.5 % at seven scales; the inversion for 25 % returns 2/3 to 5 %; unreached targets give `NaN`.
- Solovev run: `ErrorFields/Risk/` written with the metadata contract, the scale-1 scan point equals the run's own risk, and `locking_risk("gpec.h5"; n_e=2.0, …)` reproduces it bit for bit.

cc @matt-pharr

## Release note

- **Audience:** users
- **Numerical impact:** none _(harness @ ea68be08)_
- **Migration:** none

With an `[ErrorFields.scenario]` density, a run with tolerances now reports the locking probability of the assembled machine under the ITPA penetration-threshold scalings (intrinsic, corrected, as designed), and `scan_scales` in `[ErrorFields.Risk]` gives risk against tolerance scale; `allowable_tolerance` inverts the scan for a target risk after the fact.

## Regression report

```
Regression Report: diiid_n1
=================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
Ref 2: local  @ local (2026-09-11)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
-------------------------------------------------------------------------------------------------
Quantity                                      develop          local            Diff       Status
-------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01     0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05     0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00    0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00     0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01     0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]        0.0e+00    OK    
ODE steps (saved)                             2576             2576             0.0e+00    OK    
ODE steps (total)                             4572             4572             0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00     0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00     0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02     0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00     0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01     0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01     0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01     0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01     0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01     0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01     0.0e+00    OK    
# singular surfaces                           5                5                0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]         0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]         0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01     0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01     0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00     0.0e+00    OK    
mpert                                         35               35               0.0e+00    OK    
npert                                         1                1                0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00     0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01     0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00     0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00     0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...  identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...  identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...  identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...  identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...  identical  OK    
island half-widths                            [5 elem]         [5 elem]         0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]         0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04     0.0e+00    OK    
dominant-coupling singular values             N/A              [5 elem]         N/A        N/A   
|forcing overlap with dominant mode|          N/A              3.284975e-02     N/A        N/A   
|delta_nominal| of coil set 1                 N/A              1.637107e-02                N/A   
||ddelta/d(shift)|| over coil sets            N/A              2.998822e-02                N/A   
||ddelta/d(tilt)|| over coil sets             N/A              1.012616e-04                N/A   
PE plasma energy                              3.422677e+00     3.422677e+00     0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00     0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00     0.0e+00    OK    
PE toroidal torque                            5.087465e-02     5.087465e-02     0.0e+00    OK    
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01     0.0e+00    OK    
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02     0.0e+00    OK    
Runtime (s)                                   295.4s           295.5s                      --    
resonant area-weighted field b^r              [5 elem]         [5 elem]         0.0e+00    OK    
=================================================================================================
Summary: 47 unchanged, 5 missing/N/A
```

## Notes for reviewers

- Stacked on #451 (base branch `feature/errorfields-monte-carlo`).
- Risk integration uses bin-averaged `P(lock|δ)` times the bin mass rather than OMFIT's trapezoid over a zero-padded density; both converge with bin count, neither is bit-comparable to the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu
