### PR TITLE
Analysis/ErrorFields - FEATURE - Add error-field assessment plots and coil-array phasing maps

### DIFF
--- a/docs/src/analysis.md
+++ b/docs/src/analysis.md
@@ -43,3 +43,9 @@ Modules = [GeneralizedPerturbedEquilibrium.Analysis.PerturbedEquilibrium]
 ```@autodocs
 Modules = [GeneralizedPerturbedEquilibrium.Analysis.PerturbedEquilibriumModes]
 ```
+
+## ErrorFields
+
+```@autodocs
+Modules = [GeneralizedPerturbedEquilibrium.Analysis.ErrorFields]
+```

--- a/docs/src/error_fields.md
+++ b/docs/src/error_fields.md
@@ -228,6 +228,34 @@ risk = EF.locking_risk("gpec.h5"; n_e=5.0, psi_low=0.7, risk_ctrl=EF.RiskControl
 scan2 = EF.tolerance_scan("gpec.h5"; n_e=5.0, scales=[0.5, 1, 2, 4], coil_subset=["F6A", "F7A"])
 ```
 
+## Plots and coil-array phasing
+
+`Analysis.ErrorFields` plots everything above from `gpec.h5`, and every function takes a list
+of `label => path` pairs so coil-design revisions overplot on one axis:
+
+```julia
+AEF = GeneralizedPerturbedEquilibrium.Analysis.ErrorFields
+AEF.plot_coil_sensitivities(["rev A" => "revA/gpec.h5", "rev B" => "revB/gpec.h5"]; quantity=:shift)
+AEF.plot_tolerance_pdf("gpec.h5"; corrected=true)
+AEF.plot_locking_risk("gpec.h5"; target_percent=1.0)     # marks the allowable scale
+AEF.plot_threshold_scaling("gpec.h5")
+AEF.plot_dominant_mode_spectrum("gpec.h5")
+AEF.plot_error_field_summary("gpec.h5"; save_path="error_field_summary.png")
+```
+
+When several independently powered coil arrays share the job of correcting the error field,
+the relative phases of their current patterns decide how much dominant-mode field they can
+drive per ampere-turn. `phasing_map` evaluates `|Σ_k δ_k e^{iφ_k}|` per kilo-ampere-turn and
+the resonant fraction of the applied field on a grid of the `N − 1` relative phases from the
+stored nominal spectra, a closed form with no optimizer, and `plot_phasing_map` draws it (a
+line for two arrays, a contour for three):
+
+```julia
+pmap = EF.phasing_map("gpec.h5", ["EFCC_L", "EFCC_M", "EFCC_U"]; psi_low=0.5)
+EF.extreme_phasing(pmap)                        # best |δ| per kAt and the phases giving it
+AEF.plot_phasing_map(pmap; quantity=:overlap_percent)
+```
+
 ## Analysis after the run
 
 Window the coupling to any range of rational surfaces and project onto any singular mode

--- a/examples/DIIID-like_error_field_example/analyze_example.jl
+++ b/examples/DIIID-like_error_field_example/analyze_example.jl
@@ -82,7 +82,8 @@ println("Saved: ", abspath(pdf_path))
 # Locking risk: the threshold distribution against the overlap distribution, and the risk against
 # tolerance scale with the allowable tolerance for a 1 % target read off the scan.
 scan = ErrorFields.ToleranceScan(h5path)
-risk_nominal = h5open(f -> (read(f["ErrorFields/Risk/plock_percent"]), read(f["ErrorFields/Risk/plock_efc_percent"]),
+risk_nominal = h5open(
+    f -> (read(f["ErrorFields/Risk/plock_percent"]), read(f["ErrorFields/Risk/plock_efc_percent"]),
         read(f["ErrorFields/Risk/threshold_nominal"]), read(f["ErrorFields/Risk/threshold_pdf"]), read(f["ErrorFields/Risk/p_lock_given_delta"])), h5path, "r")
 plock, plock_efc, thr_nom, thr_pdf, p_given = risk_nominal
 p_thr = plot(; xlabel="dominant-mode overlap |δ|", ylabel="probability density", legend=:topright, xscale=:log10,
@@ -106,3 +107,8 @@ Plots.savefig(p_risk, risk_path)
 println("Saved: ", abspath(risk_path))
 @printf("P_lock = %.2f %% intrinsic, %.2f %% corrected at the design tolerances; allowable scale for 1 %%: %.2f (intrinsic), %.2f (corrected)\n",
     plock, plock_efc, ErrorFields.allowable_tolerance(scan, 1.0), ErrorFields.allowable_tolerance(scan, 1.0; corrected=true))
+
+# The same figures through the Analysis module, which overplots design revisions when given
+# several `label => gpec.h5` pairs.
+p_summary = GeneralizedPerturbedEquilibrium.Analysis.ErrorFields.plot_error_field_summary(h5path; save_path=joinpath(@__DIR__, "error_field_summary.png"))
+display(p_summary)

--- a/src/Analysis/Analysis.jl
+++ b/src/Analysis/Analysis.jl
@@ -10,6 +10,7 @@ Post-processing and visualization utilities for GPEC simulation outputs.
   - `CoilForcing`: Plotting functions for coil forcing spectra
   - `PerturbedEquilibrium`: Plotting functions for perturbed equilibrium and singular coupling results
   - `PerturbedEquilibriumModes`: Data helpers to convert modal GPEC output to (ψ, θ) and (ψ, θ, φ) grids
+  - `ErrorFields`: Plotting functions for the error-field assessment (coil sensitivities, tolerance Monte Carlo, locking risk, phasing maps)
 """
 module Analysis
 
@@ -18,5 +19,6 @@ include("Equilibrium.jl")
 include("CoilForcing.jl")
 include("PerturbedEquilibrium.jl")
 include("PerturbedEquilibriumModes.jl")
+include("ErrorFields.jl")
 
 end # module Analysis

--- a/src/Analysis/ErrorFields.jl
+++ b/src/Analysis/ErrorFields.jl
@@ -1,0 +1,272 @@
+"""
+    ErrorFields
+
+Plots for the error-field assessment stored under `ErrorFields/` of a GPEC HDF5 output:
+per-coil sensitivities, the tolerance Monte Carlo distributions, the locking risk and its
+dependence on tolerance, the threshold scaling, the dominant coupling mode, and coil-array
+phasing maps. Every plot takes a list of `label => h5path` pairs so design revisions can be
+overplotted, with a single-path convenience method for the common case.
+"""
+module ErrorFields
+
+using HDF5
+using Plots
+using LinearAlgebra
+
+import ...ErrorFields as EF
+import ...PerturbedEquilibrium as PE
+
+const Sources = Vector{Pair{String,String}}
+
+_sources(h5path::AbstractString) = [basename(dirname(abspath(h5path))) => String(h5path)]
+
+# Everything the plots read, `nothing` where the run did not produce it.
+function _load(h5path::AbstractString)
+    h5open(h5path, "r") do f
+        has(k) = haskey(f, k)
+        cs = "ErrorFields/CoilSensitivities"
+        mc = "ErrorFields/MonteCarlo"
+        rk = "ErrorFields/Risk"
+        (
+            coil_names=has(cs) ? read(f["$cs/coil_name"]) : nothing,
+            delta_nominal=has(cs) ? read(f["$cs/DominantMode/delta_nominal"]) : nothing,
+            shift_rms=has(cs) ? read(f["$cs/DominantMode/shift_rms"]) : nothing,
+            tilt_rms=has(cs) ? read(f["$cs/DominantMode/tilt_rms"]) : nothing,
+            shift_sensitivity=has(cs) ? read(f["$cs/DominantMode/shift_sensitivity"]) : nothing,
+            tilt_sensitivity=has(cs) ? read(f["$cs/DominantMode/tilt_sensitivity"]) : nothing,
+            bin_edges=has(mc) ? read(f["$mc/bin_edges"]) : nothing,
+            pdf=has(mc) ? read(f["$mc/pdf"]) : nothing,
+            pdf_efc=has(mc) ? read(f["$mc/pdf_efc"]) : nothing,
+            mc_delta_nominal=has(mc) ? read(f["$mc/delta_nominal"]) : nothing,
+            threshold_pdf=has(rk) ? read(f["$rk/threshold_pdf"]) : nothing,
+            p_lock_given_delta=has(rk) ? read(f["$rk/p_lock_given_delta"]) : nothing,
+            threshold_nominal=has(rk) ? read(f["$rk/threshold_nominal"]) : nothing,
+            plock=has(rk) ? read(f["$rk/plock_percent"]) : nothing,
+            plock_efc=has(rk) ? read(f["$rk/plock_efc_percent"]) : nothing,
+            scan_scale=has("$rk/ToleranceScan") ? read(f["$rk/ToleranceScan/scale"]) : nothing,
+            scan_plock=has("$rk/ToleranceScan") ? read(f["$rk/ToleranceScan/plock_percent"]) : nothing,
+            scan_plock_efc=has("$rk/ToleranceScan") ? read(f["$rk/ToleranceScan/plock_efc_percent"]) : nothing,
+            scan_spread=has("$rk/ToleranceScan") ? read(f["$rk/ToleranceScan/plock_spread_percent"]) : nothing,
+            scan_spread_efc=has("$rk/ToleranceScan") ? read(f["$rk/ToleranceScan/plock_efc_spread_percent"]) : nothing,
+            dominant_v=has("PerturbedEquilibrium/SingularCoupling/DominantMode") ? read(f["PerturbedEquilibrium/SingularCoupling/DominantMode/right_singular_vectors"]) : nothing,
+            singular_values=has("PerturbedEquilibrium/SingularCoupling/DominantMode") ? read(f["PerturbedEquilibrium/SingularCoupling/DominantMode/singular_values"]) : nothing,
+            mn_index=has("Info/mn_index") ? read(f["Info/mn_index"]) : nothing
+        )
+    end
+end
+
+_centers(edges) = (edges[1:end-1] .+ edges[2:end]) ./ 2
+_step_series(m, a) = (vcat(m[1] - 1, m, m[end] + 1), vcat(0.0, a, 0.0))
+_empty(msg) = plot(; title=msg, legend=false)
+
+function _save(p, save_path)
+    if save_path !== nothing
+        Plots.savefig(p, save_path)
+        println("Saved: ", abspath(save_path))
+    end
+    return p
+end
+
+"""
+    plot_coil_sensitivities(sources; quantity=:shift, per_mm=true, coils=nothing, save_path=nothing)
+    plot_coil_sensitivities(h5path; kwargs...)
+
+Grouped bars of the per-coil-set dominant-mode sensitivity across runs, matched by coil set
+name: `quantity = :shift` (in-plane RMS `|∂δ/∂Δ|`, per mm when `per_mm`), `:tilt` (per 0.1°),
+or `:nominal` (`|δ_nominal|`). `coils` restricts and orders the coil sets shown.
+"""
+function plot_coil_sensitivities(sources::Sources; quantity::Symbol=:shift, per_mm::Bool=true, coils=nothing, save_path=nothing)
+    data = [(lbl, _load(path)) for (lbl, path) in sources]
+    any(d -> d[2].coil_names === nothing, data) && return _empty("No ErrorFields/CoilSensitivities data — run with an [ErrorFields] section")
+    names = coils === nothing ? data[1][2].coil_names : String.(collect(coils))
+    value(d, nm) = begin
+        i = findfirst(==(nm), d.coil_names)
+        i === nothing && return NaN
+        quantity === :shift ? (per_mm ? 1e-3 : 1.0) * d.shift_rms[i] :
+        quantity === :tilt ? 0.1 * d.tilt_rms[i] :
+        quantity === :nominal ? abs(d.delta_nominal[i]) : throw(ArgumentError("quantity must be :shift, :tilt, or :nominal"))
+    end
+    ylabel = quantity === :shift ? (per_mm ? "|∂δ/∂Δ| per mm" : "|∂δ/∂Δ| per m") : quantity === :tilt ? "|∂δ/∂θ| per 0.1°" : "|δ_nominal|"
+    title = quantity === :shift ? "Dominant-mode error field per shift" : quantity === :tilt ? "Dominant-mode error field per tilt" : "Nominal dominant-mode overlap"
+    n = length(names)
+    k = length(data)
+    width = 0.8 / k
+    p = plot(; xlabel="coil set", ylabel=ylabel, title=title, xticks=(1:n, names), xrotation=45, legend=:topright,
+        left_margin=12Plots.mm, bottom_margin=8Plots.mm)
+    for (j, (lbl, d)) in enumerate(data)
+        x = (1:n) .+ (j - (k + 1) / 2) * width
+        bar!(p, x, [value(d, nm) for nm in names]; bar_width=width, label=lbl, alpha=0.8)
+    end
+    return _save(p, save_path)
+end
+plot_coil_sensitivities(h5path::AbstractString; kwargs...) = plot_coil_sensitivities(_sources(h5path); kwargs...)
+
+"""
+    plot_tolerance_pdf(sources; corrected=true, normalize=false, xscale=:identity, save_path=nothing)
+    plot_tolerance_pdf(h5path; kwargs...)
+
+The Monte Carlo distributions of the dominant-mode overlap `|δ|` of each run, intrinsic and
+(when `corrected`) with error-field correction, with the as-designed overlap marked.
+"""
+function plot_tolerance_pdf(sources::Sources; corrected::Bool=true, normalize::Bool=false, xscale::Symbol=:identity, save_path=nothing)
+    p = plot(; xlabel="dominant-mode overlap |δ|", ylabel=normalize ? "probability density (normalized)" : "probability density",
+        title="Tolerance Monte Carlo: |δ| over sampled misalignments", legend=:topright, xscale=xscale,
+        left_margin=12Plots.mm, bottom_margin=6Plots.mm)
+    any_data = false
+    for (j, (lbl, path)) in enumerate(sources)
+        d = _load(path)
+        d.pdf === nothing && continue
+        any_data = true
+        c = _centers(d.bin_edges)
+        keep = xscale === :log10 ? c .> 0 : trues(length(c))
+        scale = normalize ? maximum(d.pdf) : 1.0
+        plot!(p, c[keep], d.pdf[keep] ./ scale; lw=2, c=j, label="$lbl intrinsic")
+        corrected && plot!(p, c[keep], d.pdf_efc[keep] ./ (normalize ? maximum(d.pdf_efc) : 1.0); lw=2, ls=:dash, c=j, label="$lbl corrected")
+        vline!(p, [d.mc_delta_nominal]; ls=:dot, c=j, label="$lbl as designed")
+    end
+    any_data || return _empty("No ErrorFields/MonteCarlo data — run with a tolerance_file")
+    return _save(p, save_path)
+end
+plot_tolerance_pdf(h5path::AbstractString; kwargs...) = plot_tolerance_pdf(_sources(h5path); kwargs...)
+
+"""
+    plot_locking_risk(sources; corrected=true, target_percent=nothing, save_path=nothing)
+    plot_locking_risk(h5path; kwargs...)
+
+Locking probability against tolerance scale from each run's `ErrorFields/Risk/ToleranceScan/`,
+intrinsic and (when `corrected`) with error-field correction, batch spread as error bars, and
+the allowable scale at `target_percent` marked where the scan reaches it.
+"""
+function plot_locking_risk(sources::Sources; corrected::Bool=true, target_percent=nothing, save_path=nothing)
+    p = plot(; xlabel="tolerance scale", ylabel="locking probability [%]", xscale=:log10, yscale=:log10, legend=:topleft,
+        title="Locking risk vs tolerance scale", left_margin=12Plots.mm, bottom_margin=6Plots.mm)
+    any_data = false
+    floor = 1e-4
+    for (j, (lbl, path)) in enumerate(sources)
+        d = _load(path)
+        d.scan_scale === nothing && continue
+        any_data = true
+        plot!(p, d.scan_scale, max.(d.scan_plock, floor); yerror=d.scan_spread ./ 2, marker=:circle, lw=2, c=j, label="$lbl intrinsic")
+        corrected && plot!(p, d.scan_scale, max.(d.scan_plock_efc, floor); yerror=d.scan_spread_efc ./ 2, marker=:square, lw=2, ls=:dash, c=j, label="$lbl corrected")
+        if target_percent !== nothing
+            scan = EF.ToleranceScan(d.scan_scale, d.scan_plock, d.scan_plock_efc, d.scan_spread, d.scan_spread_efc, 0.0)
+            for (corr, mk) in ((false, :diamond), (true, :star5))
+                (corr && !corrected) && continue
+                s = EF.allowable_tolerance(scan, target_percent; corrected=corr)
+                isnan(s) || scatter!(p, [s], [target_percent]; marker=mk, ms=8, c=j, label="$lbl allowable ($(corr ? "corrected" : "intrinsic"))")
+            end
+        end
+    end
+    any_data || return _empty("No ErrorFields/Risk/ToleranceScan data — set scan_scales in [ErrorFields.Risk]")
+    target_percent === nothing || hline!(p, [target_percent]; ls=:dash, c=:gray, label="target $(target_percent) %")
+    return _save(p, save_path)
+end
+plot_locking_risk(h5path::AbstractString; kwargs...) = plot_locking_risk(_sources(h5path); kwargs...)
+
+"""
+    plot_threshold_scaling(sources; save_path=nothing)
+    plot_threshold_scaling(h5path; kwargs...)
+
+The sampled penetration-threshold density and `P(lock|δ)` of each run against its overlap
+distributions, on a logarithmic `|δ|` axis, with the nominal threshold marked.
+"""
+function plot_threshold_scaling(sources::Sources; save_path=nothing)
+    p = plot(; xlabel="dominant-mode overlap |δ|", ylabel="normalized density  /  P(lock | δ)", xscale=:log10, legend=:topleft,
+        title="Overlap distribution vs penetration threshold", left_margin=12Plots.mm, bottom_margin=6Plots.mm)
+    any_data = false
+    for (j, (lbl, path)) in enumerate(sources)
+        d = _load(path)
+        d.threshold_pdf === nothing && continue
+        any_data = true
+        c = _centers(d.bin_edges)
+        keep = c .> 0
+        plot!(p, c[keep], d.pdf[keep] ./ maximum(d.pdf); lw=2, c=j, label="$lbl intrinsic |δ|")
+        plot!(p, c[keep], d.pdf_efc[keep] ./ maximum(d.pdf_efc); lw=2, ls=:dash, c=j, label="$lbl corrected |δ|")
+        plot!(p, c[keep], d.threshold_pdf[keep] ./ maximum(d.threshold_pdf); lw=2, ls=:dot, c=j, label="$lbl threshold")
+        plot!(p, d.bin_edges[2:end], d.p_lock_given_delta[2:end]; lw=1.5, ls=:dashdot, c=j, label="$lbl P(lock | δ)")
+        vline!(p, [d.threshold_nominal]; ls=:dot, c=:black, label=j == 1 ? "nominal threshold" : "")
+    end
+    any_data || return _empty("No ErrorFields/Risk data — run with an [ErrorFields.scenario] table")
+    return _save(p, save_path)
+end
+plot_threshold_scaling(h5path::AbstractString; kwargs...) = plot_threshold_scaling(_sources(h5path); kwargs...)
+
+"""
+    plot_dominant_mode_spectrum(sources; mode=1, save_path=nothing)
+    plot_dominant_mode_spectrum(h5path; kwargs...)
+
+The right singular vector of the full-window dominant coupling mode of each run, `|V[m, mode]|`
+against poloidal mode number (one series per toroidal mode), from
+`PerturbedEquilibrium/SingularCoupling/DominantMode/`.
+"""
+function plot_dominant_mode_spectrum(sources::Sources; mode::Int=1, save_path=nothing)
+    p = plot(; xlabel="poloidal mode m", ylabel="|V[m, $mode]|", title="Dominant resonant-coupling mode spectrum", legend=:topright,
+        left_margin=12Plots.mm, bottom_margin=6Plots.mm)
+    any_data = false
+    for (j, (lbl, path)) in enumerate(sources)
+        d = _load(path)
+        (d.dominant_v === nothing || d.mn_index === nothing) && continue
+        any_data = true
+        mode <= size(d.dominant_v, 2) || continue
+        for n in unique(d.mn_index[:, 2])
+            rows = findall(==(n), d.mn_index[:, 2])
+            me, ae = _step_series(d.mn_index[rows, 1], abs.(d.dominant_v[rows, mode]))
+            plot!(p, me, ae; seriestype=:steppre, lw=2, c=j, label="$lbl n=$n (σ = $(round(d.singular_values[mode]; sigdigits=3)))")
+        end
+    end
+    any_data || return _empty("No PerturbedEquilibrium/SingularCoupling/DominantMode data")
+    return _save(p, save_path)
+end
+plot_dominant_mode_spectrum(h5path::AbstractString; kwargs...) = plot_dominant_mode_spectrum(_sources(h5path); kwargs...)
+
+"""
+    plot_phasing_map(h5path, coil_names; psi_low=0.0, psi_high=1.0, mode=1, nphase=180, quantity=:delta_per_kat, save_path=nothing)
+    plot_phasing_map(map::EF.PhasingMap; quantity=:delta_per_kat, save_path=nothing)
+
+Contour map of the dominant-mode overlap per kilo-ampere-turn (`:delta_per_kat`) or of the
+resonant fraction of the applied field (`:overlap_percent`) against the relative phases of two
+or three coil arrays (`EF.phasing_map`). Two arrays give a line, three a filled contour whose
+axes are the phase of the middle array relative to the first and of the third relative to the
+middle; the extreme is marked.
+"""
+function plot_phasing_map(map::EF.PhasingMap; quantity::Symbol=:delta_per_kat, save_path=nothing)
+    arr =
+        quantity === :delta_per_kat ? map.delta_per_kat :
+        quantity === :overlap_percent ? map.overlap_percent :
+        throw(ArgumentError("quantity must be :delta_per_kat or :overlap_percent"))
+    label = quantity === :delta_per_kat ? "|δ| per kAt" : "resonant fraction [%]"
+    names = map.coil_names
+    if length(map.phase_deg) == 1
+        p = plot(map.phase_deg[1], vec(arr); lw=2, xlabel="Δφ($(names[2]) − $(names[1])) [deg]", ylabel=label, legend=false,
+            title="Two-array phasing", left_margin=12Plots.mm, bottom_margin=6Plots.mm)
+    elseif length(map.phase_deg) == 2
+        p = contourf(map.phase_deg[1], map.phase_deg[2], permutedims(arr); levels=12, xlabel="Δφ($(names[2]) − $(names[1])) [deg]",
+            ylabel="Δφ($(names[3]) − $(names[2])) [deg]", title="Three-array phasing: $label", colorbar_title=label, aspect_ratio=:equal,
+            left_margin=12Plots.mm, bottom_margin=6Plots.mm, size=(720, 640))
+        v, ph = EF.extreme_phasing(map; quantity)
+        scatter!(p, [ph[1]], [ph[2]]; marker=:star5, ms=10, c=:white, label="max $(round(v; sigdigits=3))")
+    else
+        throw(ArgumentError("plot_phasing_map draws maps of one or two relative phases (two or three arrays)"))
+    end
+    return _save(p, save_path)
+end
+function plot_phasing_map(h5path::AbstractString, coil_names::AbstractVector{<:AbstractString}; psi_low::Real=0.0, psi_high::Real=1.0, mode::Int=1,
+    nphase::Int=180, quantity::Symbol=:delta_per_kat, save_path=nothing)
+    return plot_phasing_map(EF.phasing_map(h5path, coil_names; psi_low, psi_high, mode, nphase); quantity, save_path)
+end
+
+"""
+    plot_error_field_summary(h5path; save_path=nothing)
+
+Four panels of a run's error-field assessment: coil sensitivities to shift, the tolerance
+Monte Carlo distributions, the overlap distribution against the threshold, and the locking
+risk against tolerance scale. Panels whose data the run did not produce say so.
+"""
+function plot_error_field_summary(h5path::AbstractString; save_path=nothing)
+    src = _sources(h5path)
+    p = plot(plot_coil_sensitivities(src), plot_tolerance_pdf(src), plot_threshold_scaling(src), plot_locking_risk(src);
+        layout=(2, 2), size=(1400, 1000))
+    return _save(p, save_path)
+end
+
+end # module ErrorFields

--- a/src/ErrorFields/ErrorFields.jl
+++ b/src/ErrorFields/ErrorFields.jl
@@ -25,6 +25,8 @@ plasma solve or a new Biot-Savart integration.
   with a `ToleranceSet` into intrinsic and corrected `|δ|` histograms
 - `Risk.jl`: the ITPA penetration-threshold scalings, `locking_risk` (the overlap distribution
   convolved with the threshold distribution), `tolerance_scan` and `allowable_tolerance`
+- `Phasing.jl`: `phasing_map`, the closed-form overlap of several coil arrays against their
+  relative current-pattern phases
 
 The stored primitive is the derivative of each coil set's root-area-weighted control-surface
 spectrum b̃, not a scalar: the overlap with any dominant mode is linear in b̃, so the ψ_N window,
@@ -51,6 +53,7 @@ include("ToleranceTOML.jl")
 include("Sampling.jl")
 include("MonteCarlo.jl")
 include("Risk.jl")
+include("Phasing.jl")
 include("Output.jl")
 
 export ErrorFieldsControl, CoilSensitivities, SensitivityTable
@@ -62,5 +65,6 @@ export disk_radius, sample_disk, sample_uncertainty, sample_additive, sample_cyl
 export MonteCarloControl, MonteCarloResult, run_monte_carlo
 export ThresholdScaling, ITPA_THRESHOLD_SCALINGS, threshold_scaling, ScenarioParameters, nominal_threshold, threshold_samples
 export RiskControl, RiskResult, locking_risk, ToleranceScan, tolerance_scan, allowable_tolerance
+export PhasingMap, phasing_map, extreme_phasing
 
 end # module ErrorFields

--- a/src/ErrorFields/Phasing.jl
+++ b/src/ErrorFields/Phasing.jl
@@ -40,10 +40,17 @@ end
 
 Scan the relative phases of the current patterns of the named coil arrays and evaluate, at
 each grid point, the dominant-mode overlap per kilo-ampere-turn and the resonant fraction of
-the applied field. Each array's spectrum is its stored nominal spectrum divided by its
-ampere-turns (`winding_multiplier × peak_current`); rotating a current pattern by `Δφ`
-multiplies the spectrum by `e^{iΔφ}` (the phase of the pattern itself, `n` times the toroidal
-angle it is rotated through). `nphase` points per phase axis, spanning `[0, 360)` degrees.
+the applied field. Rotating a current pattern by `Δφ` multiplies the spectrum by `e^{iΔφ}` (the
+phase of the pattern itself, `n` times the toroidal angle it is rotated through). `nphase`
+points per phase axis, spanning `[0, 360)` degrees.
+
+Each array's spectrum is its stored nominal spectrum divided by the magnitude of its
+ampere-turns, `|winding_multiplier| × peak_current`. The zero of each phase axis is therefore
+the array's current pattern exactly as the run specified it, with the winding sense of its
+geometry file included: a negative winding multiplier and a negated current pattern each
+remain in the map as the half-turn they physically are. Normalizing by the signed product
+would erase how the device defines positive current in that array, which is device-specific
+information the map must keep.
 """
 function phasing_map(sens::CoilSensitivities, dom::DominantCoupling, coil_names::AbstractVector{<:AbstractString}; mode::Int=1, nphase::Int=180)
     length(coil_names) >= 2 || throw(ArgumentError("phasing_map needs at least two coil arrays"))
@@ -53,7 +60,7 @@ function phasing_map(sens::CoilSensitivities, dom::DominantCoupling, coil_names:
     any(isnothing, idx) && throw(ArgumentError("coil arrays not in the sensitivities: $(join(coil_names[isnothing.(idx)], ", "))"))
     v = dom.right_singular_vectors[:, mode]
     N = length(idx)
-    kat = [sens.winding_multiplier[i] * sens.peak_current[i] / 1e3 for i in idx]
+    kat = [abs(sens.winding_multiplier[i]) * sens.peak_current[i] / 1e3 for i in idx]
     all(>(0), kat) || throw(ArgumentError("every array needs a non-zero current to normalize per kilo-ampere-turn"))
     spectra = [sens.nominal_field[:, i] ./ kat[j] for (j, i) in enumerate(idx)]   # b̃ per kAt
     deltas = [dot(v, b) / sens.b_t0 for b in spectra]                            # δ per kAt

--- a/src/ErrorFields/Phasing.jl
+++ b/src/ErrorFields/Phasing.jl
@@ -1,0 +1,100 @@
+"""
+    Phasing
+
+Coil-array phasing: how the dominant-mode overlap of several independently powered coil
+arrays (an error-field correction coil set's upper, middle and lower rows, say) depends on the
+relative toroidal phases of their current patterns. The overlap is linear in each array's
+field, so the map is the closed form `|Σ_k δ_k e^{iφ_k}|` on a grid of relative phases, per
+kilo-ampere-turn of each array, together with the fraction of the applied field that is
+resonant. No solve, no field evaluation, no optimizer: the extremes are read off the grid.
+"""
+
+"""
+    PhasingMap
+
+Dominant-mode overlap of `N` coil arrays against the `N − 1` relative phases of their current
+patterns, from [`phasing_map`](@ref). Array 1 sets the reference; array `k > 1` is rotated by
+the cumulative phase `Δφ_2 + … + Δφ_k`, so axis `k − 1` of the maps is the phase of array `k`
+relative to array `k − 1` (the two-row EFCC convention `Δφ_ML`, `Δφ_UM`).
+
+## Fields
+
+  - `coil_names`: the arrays in order `[N]`
+  - `phase_deg`: grid of each relative phase, degrees `[N − 1]` vectors
+  - `delta_per_kat`: `|δ|` per kilo-ampere-turn of every array at each grid point `[n_1 × … × n_{N−1}]`
+  - `overlap_percent`: `100·|Vᴴb̃| / ‖b̃‖`, the fraction of the applied root-area-weighted field
+    that lies along the dominant mode, at each grid point
+  - `delta_per_kat_each`: `|δ_k|` per kilo-ampere-turn of each array alone `[N]`
+"""
+struct PhasingMap
+    coil_names::Vector{String}
+    phase_deg::Vector{Vector{Float64}}
+    delta_per_kat::Array{Float64}
+    overlap_percent::Array{Float64}
+    delta_per_kat_each::Vector{Float64}
+end
+
+"""
+    phasing_map(sens::CoilSensitivities, dom::DominantCoupling, coil_names; mode=1, nphase=180) -> PhasingMap
+    phasing_map(h5path, coil_names; psi_low=0.0, psi_high=1.0, mode=1, nphase=180) -> PhasingMap
+
+Scan the relative phases of the current patterns of the named coil arrays and evaluate, at
+each grid point, the dominant-mode overlap per kilo-ampere-turn and the resonant fraction of
+the applied field. Each array's spectrum is its stored nominal spectrum divided by its
+ampere-turns (`winding_multiplier × peak_current`); rotating a current pattern by `Δφ`
+multiplies the spectrum by `e^{iΔφ}` (the phase of the pattern itself, `n` times the toroidal
+angle it is rotated through). `nphase` points per phase axis, spanning `[0, 360)` degrees.
+"""
+function phasing_map(sens::CoilSensitivities, dom::DominantCoupling, coil_names::AbstractVector{<:AbstractString}; mode::Int=1, nphase::Int=180)
+    length(coil_names) >= 2 || throw(ArgumentError("phasing_map needs at least two coil arrays"))
+    nphase >= 2 || throw(ArgumentError("nphase must be ≥ 2"))
+    1 <= mode <= length(dom.singular_values) || throw(ArgumentError("mode $mode is outside the decomposition"))
+    idx = [findfirst(==(String(nm)), sens.coil_names) for nm in coil_names]
+    any(isnothing, idx) && throw(ArgumentError("coil arrays not in the sensitivities: $(join(coil_names[isnothing.(idx)], ", "))"))
+    v = dom.right_singular_vectors[:, mode]
+    N = length(idx)
+    kat = [sens.winding_multiplier[i] * sens.peak_current[i] / 1e3 for i in idx]
+    all(>(0), kat) || throw(ArgumentError("every array needs a non-zero current to normalize per kilo-ampere-turn"))
+    spectra = [sens.nominal_field[:, i] ./ kat[j] for (j, i) in enumerate(idx)]   # b̃ per kAt
+    deltas = [dot(v, b) / sens.b_t0 for b in spectra]                            # δ per kAt
+    grid = collect(range(0.0, 360.0; length=nphase + 1))[1:end-1]
+    dims = ntuple(_ -> nphase, N - 1)
+    delta_map = zeros(dims)
+    overlap_map = zeros(dims)
+    b_sum = similar(spectra[1])
+    for I in CartesianIndices(dims)
+        fill!(b_sum, 0)
+        δ = deltas[1]
+        b_sum .+= spectra[1]
+        cumulative = 0.0
+        for k in 2:N
+            cumulative += deg2rad(grid[I[k-1]])
+            rot = cis(cumulative)
+            δ += deltas[k] * rot
+            b_sum .+= spectra[k] .* rot
+        end
+        delta_map[I] = abs(δ)
+        overlap_map[I] = 100 * abs(δ) * sens.b_t0 / norm(b_sum)
+    end
+    return PhasingMap(String.(collect(coil_names)), [copy(grid) for _ in 1:N-1], delta_map, overlap_map, abs.(deltas))
+end
+
+function phasing_map(h5path::AbstractString, coil_names::AbstractVector{<:AbstractString}; psi_low::Real=0.0, psi_high::Real=1.0, mode::Int=1, nphase::Int=180)
+    dom = dominant_coupling(ResonantCoupling(h5path); psi_low, psi_high)
+    return phasing_map(CoilSensitivities(h5path), dom, coil_names; mode, nphase)
+end
+
+"""
+    extreme_phasing(map::PhasingMap; quantity=:delta_per_kat, which=:max) -> (value, phases_deg)
+
+The largest (or smallest) value of a map and the relative phases, in degrees, where it occurs.
+"""
+function extreme_phasing(map::PhasingMap; quantity::Symbol=:delta_per_kat, which::Symbol=:max)
+    arr =
+        quantity === :delta_per_kat ? map.delta_per_kat :
+        quantity === :overlap_percent ? map.overlap_percent :
+        throw(ArgumentError("quantity must be :delta_per_kat or :overlap_percent"))
+    which in (:max, :min) || throw(ArgumentError("which must be :max or :min"))
+    I = which === :max ? argmax(arr) : argmin(arr)
+    return arr[I], [map.phase_deg[k][I[k]] for k in 1:length(map.phase_deg)]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,7 @@ else
     include("./runtests_sampling.jl")
     include("./runtests_monte_carlo.jl")
     include("./runtests_risk.jl")
+    include("./runtests_phasing.jl")
     include("./runtests_sing.jl")
     include("./runtests_innerlayer.jl")
     include("./runtests_tj_analytic.jl")

--- a/test/runtests_error_fields.jl
+++ b/test/runtests_error_fields.jl
@@ -1,6 +1,7 @@
 using HDF5
 using TOML
 using LinearAlgebra
+using Plots
 
 # The ErrorFields coil linearization: a closed-form check on the cancelling offset, then one
 # coil-forced Solovev run with an axisymmetric PF hoop (whose rigid-motion response is known
@@ -149,6 +150,26 @@ include("h5_metadata_check.jl")
             again = EF.locking_risk(h5path; n_e=12.0, nsample=20_000, nbatch=2, seed=5, nbins=100,
                 risk_ctrl=EF.RiskControl(; nsample_threshold=20_000, seed=3))
             @test again.plock == risk.plock
+
+            # Analysis plots: every ErrorFields plot renders from the file and saves; the phasing map
+            # of the two hoops is the closed form on their stored spectra.
+            AEF = GPEC.Analysis.ErrorFields
+            for (name, fn) in (("sens", AEF.plot_coil_sensitivities), ("pdf", AEF.plot_tolerance_pdf), ("risk", AEF.plot_locking_risk),
+                ("thr", AEF.plot_threshold_scaling), ("mode", AEF.plot_dominant_mode_spectrum))
+                png = joinpath(dir, "plot_$name.png")
+                @test fn(h5path; save_path=png) isa Plots.Plot
+                @test isfile(png)
+            end
+            @test AEF.plot_coil_sensitivities(["run" => h5path, "again" => h5path]; quantity=:tilt) isa Plots.Plot
+            @test AEF.plot_locking_risk(h5path; target_percent=1.0) isa Plots.Plot
+            @test AEF.plot_error_field_summary(h5path; save_path=joinpath(dir, "summary.png")) isa Plots.Plot
+            pmap = EF.phasing_map(h5path, ["hoop_tilted", "hoop_axi"]; nphase=36)
+            @test length(pmap.phase_deg) == 1 && size(pmap.delta_per_kat) == (36,)
+            kat = sens.winding_multiplier .* sens.peak_current ./ 1e3
+            δ_each = [dot(dom.right_singular_vectors[:, 1], sens.nominal_field[:, j]) / kat[j] / sens.b_t0 for j in 1:2]
+            @test pmap.delta_per_kat ≈ abs.(δ_each[1] .+ δ_each[2] .* cis.(deg2rad.(pmap.phase_deg[1])))
+            @test AEF.plot_phasing_map(pmap; save_path=joinpath(dir, "phasing.png")) isa Plots.Plot
+            @test AEF.plot_phasing_map(h5path, ["hoop_tilted", "hoop_axi"]; nphase=12) isa Plots.Plot
             from_file = EF.CoilSensitivities(h5path)
             @test from_file.coil_names == sens.coil_names
             @test from_file.m_modes == sens.m_modes && from_file.n_modes == sens.n_modes

--- a/test/runtests_phasing.jl
+++ b/test/runtests_phasing.jl
@@ -1,0 +1,64 @@
+using LinearAlgebra
+
+# Coil-array phasing maps on synthetic sensitivities: the closed-form two-array map, its
+# extremes, the three-array grid shape, the resonant-fraction bound, and the argument guards.
+@testset "coil-array phasing" begin
+    GPEC = GeneralizedPerturbedEquilibrium
+    EF = GPEC.ErrorFields
+    PE = GPEC.PerturbedEquilibrium
+
+    # A dominant mode on a 4-mode basis and three arrays with known spectra and ampere-turns.
+    v = normalize(ComplexF64[1, 2im, -1, 0.5])
+    dom = PE.DominantCoupling([3.0, 1.0], hcat(v, normalize(ComplexF64[0, 1, 1, 0])), ones(ComplexF64, 2, 2), [1, 2])
+    b1 = ComplexF64[1.0, 0.0, 0.0, 0.0] .* 2e-3
+    b2 = ComplexF64[0.0, 1.0, 0.0, 0.0] .* 3e-3
+    b3 = ComplexF64[0.5, 0.5, 0.5, 0.5] .* 1e-3
+    nominal = hcat(b1, b2, b3)
+    b_t0 = 2.0
+    sens = EF.CoilSensitivities(["L", "M", "U"], [1, 2, 3, 4], [1, 1, 1, 1], b_t0, nominal, zeros(ComplexF64, 4, 3, 3), zeros(ComplexF64, 4, 3, 3),
+        zeros(3, 3), zeros(3, 3), [1000.0, 2000.0, 500.0], [10.0, 5.0, 4.0])
+    kat = [10.0 * 1.0, 5.0 * 2.0, 4.0 * 0.5]           # kA·turns
+    δ = [dot(v, nominal[:, j]) / kat[j] / b_t0 for j in 1:3]
+
+    @testset "two arrays: closed form" begin
+        map = EF.phasing_map(sens, dom, ["L", "M"]; nphase=360)
+        @test length(map.phase_deg) == 1 && size(map.delta_per_kat) == (360,)
+        @test map.delta_per_kat_each ≈ abs.(δ[1:2])
+        φ = deg2rad.(map.phase_deg[1])
+        @test map.delta_per_kat ≈ abs.(δ[1] .+ δ[2] .* cis.(φ))
+        # Resonant fraction is bounded by Cauchy–Schwarz and equals |Vᴴb̃|/‖b̃‖ in percent.
+        @test all(0 .<= map.overlap_percent .<= 100 + 1e-9)
+        b = nominal[:, 1] ./ kat[1] .+ nominal[:, 2] ./ kat[2] .* cis(φ[10])
+        @test map.overlap_percent[10] ≈ 100 * abs(dot(v, b)) / norm(b)
+        # The maximum of |δ1 + δ2 e^{iφ}| is at φ = arg(δ1) − arg(δ2), value |δ1| + |δ2|.
+        vmax, ph = EF.extreme_phasing(map)
+        @test vmax ≈ abs(δ[1]) + abs(δ[2]) rtol = 1e-3
+        @test isapprox(mod(deg2rad(ph[1]) - (angle(δ[1]) - angle(δ[2])), 2π), 0; atol=deg2rad(1.01)) ||
+              isapprox(mod(deg2rad(ph[1]) - (angle(δ[1]) - angle(δ[2])), 2π), 2π; atol=deg2rad(1.01))
+        vmin, _ = EF.extreme_phasing(map; which=:min)
+        @test vmin ≈ abs(abs(δ[1]) - abs(δ[2])) rtol = 1e-2
+    end
+
+    @testset "three arrays: cumulative phases" begin
+        map = EF.phasing_map(sens, dom, ["L", "M", "U"]; nphase=90)
+        @test size(map.delta_per_kat) == (90, 90) && size(map.overlap_percent) == (90, 90)
+        i, j = 7, 31
+        φ1, φ2 = deg2rad(map.phase_deg[1][i]), deg2rad(map.phase_deg[2][j])
+        @test map.delta_per_kat[i, j] ≈ abs(δ[1] + δ[2] * cis(φ1) + δ[3] * cis(φ1 + φ2))
+        v_o, ph = EF.extreme_phasing(map; quantity=:overlap_percent)
+        @test 0 < v_o <= 100 + 1e-9 && length(ph) == 2
+    end
+
+    @testset "guards" begin
+        @test_throws ArgumentError EF.phasing_map(sens, dom, ["L"])
+        @test_throws ArgumentError EF.phasing_map(sens, dom, ["L", "X"])
+        @test_throws ArgumentError EF.phasing_map(sens, dom, ["L", "M"]; nphase=1)
+        @test_throws ArgumentError EF.phasing_map(sens, dom, ["L", "M"]; mode=3)
+        dead = EF.CoilSensitivities(sens.coil_names, sens.m_modes, sens.n_modes, b_t0, nominal, sens.shift_sensitivity, sens.tilt_sensitivity,
+            sens.shift_linearity_residual, sens.tilt_linearity_residual, [0.0, 2000.0, 500.0], sens.winding_multiplier)
+        @test_throws ArgumentError EF.phasing_map(dead, dom, ["L", "M"])
+        map = EF.phasing_map(sens, dom, ["L", "M"]; nphase=12)
+        @test_throws ArgumentError EF.extreme_phasing(map; quantity=:foo)
+        @test_throws ArgumentError EF.extreme_phasing(map; which=:median)
+    end
+end

--- a/test/runtests_phasing.jl
+++ b/test/runtests_phasing.jl
@@ -49,6 +49,17 @@ using LinearAlgebra
         @test 0 < v_o <= 100 + 1e-9 && length(ph) == 2
     end
 
+    @testset "winding sense is kept in the map" begin
+        # The same geometry with a negative winding multiplier is the same array wound the other
+        # way: its per-kAt spectrum flips sign, so the map is the original one rotated by 180°.
+        flipped = EF.CoilSensitivities(sens.coil_names, sens.m_modes, sens.n_modes, b_t0, hcat(b1, -b2, b3), sens.shift_sensitivity, sens.tilt_sensitivity,
+            sens.shift_linearity_residual, sens.tilt_linearity_residual, sens.peak_current, [10.0, -5.0, 4.0])
+        m0 = EF.phasing_map(sens, dom, ["L", "M"]; nphase=36)
+        m1 = EF.phasing_map(flipped, dom, ["L", "M"]; nphase=36)
+        @test m1.delta_per_kat ≈ circshift(m0.delta_per_kat, 18)
+        @test m1.delta_per_kat_each ≈ m0.delta_per_kat_each
+    end
+
     @testset "guards" begin
         @test_throws ArgumentError EF.phasing_map(sens, dom, ["L"])
         @test_throws ArgumentError EF.phasing_map(sens, dom, ["L", "X"])


### PR DESCRIPTION
Eighth PR of the OMFIT → Julia error-field tolerance migration, stacked on #452. It adds the plots of the assessment and the coil-array phasing map: everything the paper's figure scripts produced from the OMFIT project, as `Analysis.ErrorFields` functions that read `gpec.h5` and take `label => h5path` lists so coil-design revisions overplot.

**What it does**

- `src/ErrorFields/Phasing.jl` (compute side): `phasing_map(sens, dom, coil_names)` / `phasing_map("gpec.h5", coil_names; psi_low, psi_high, mode)` — the dominant-mode overlap per kilo-ampere-turn of N coil arrays against their N−1 relative current-pattern phases, `|Σ_k δ_k e^{iφ_k}|`, plus the resonant fraction of the applied field `100·|Vᴴb̃|/‖b̃‖`; `extreme_phasing` reads the extreme off the grid. Closed form on already-stored spectra, no optimizer, as in the paper's EFCC phasing figure.
- `src/Analysis/ErrorFields.jl` (plots; each takes `Vector{Pair{String,String}}` with a single-path wrapper): `plot_coil_sensitivities` (grouped bars matched by coil name: shift per mm, tilt per 0.1°, or nominal), `plot_tolerance_pdf` (intrinsic/corrected distributions, as-designed marks), `plot_locking_risk` (risk vs tolerance scale with batch spread and the allowable scale at a target marked), `plot_threshold_scaling` (threshold density and P(lock|δ) against the distributions), `plot_dominant_mode_spectrum` (`|V[m, mode]|`, `:steppre`), `plot_phasing_map` (line for two arrays, filled contour for three), `plot_error_field_summary` (2×2). Panels report missing data instead of erroring.
- The example's `analyze_example.jl` now uses these instead of hand-rolled plots.

**Verification**

- `test/runtests_phasing.jl` (synthetic spectra): two-array map equals `|δ_1 + δ_2 e^{iφ}|`, its maximum `|δ_1| + |δ_2|` at `arg δ_1 − arg δ_2`, minimum `||δ_1| − |δ_2||`; resonant fraction equals `100|Vᴴb̃|/‖b̃‖` and never exceeds 100; three-array grid uses cumulative phases; guards.
- The Solovev run test now smoke-tests every plot on the run's `gpec.h5` (returns a `Plots.Plot`, saves a PNG) including the two-hoop phasing line and the missing-data panels on a file without risk output.

**Convention worth a look (second commit):** `phasing_map` normalizes each array by the *magnitude* of its ampere-turns, `|nw| × max|I|`. The zero of each phase axis is then the array's current pattern exactly as the run specified it, with the winding sense of its geometry file included — a negative winding multiplier (the DIII-D C-coil file has `nw = −4`) or a negated current pattern shows up in the map as the half-turn it physically is. The OMFIT phasing script divided by the *signed* product, which erases how a device defines positive current in that array; it was right for the original device only because every array there had a positive multiplier. The first commit also rejected a negative product as "no current"; that guard now checks only the magnitude.

cc @matt-pharr

## Release note

- **Audience:** users
- **Numerical impact:** none _(harness @ 7b6962c5)_
- **Migration:** none

`Analysis.ErrorFields` plots the error-field assessment from `gpec.h5` — coil sensitivities, tolerance Monte Carlo distributions, locking risk vs tolerance, threshold scaling, the dominant mode, and coil-array phasing maps — with lists of `label => file` pairs to overplot design revisions; `ErrorFields.phasing_map` computes the phasing map itself.

## Regression report

```
Regression Report: diiid_n1
=================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
Ref 2: local  @ local (2026-09-11)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
-------------------------------------------------------------------------------------------------
Quantity                                      develop          local            Diff       Status
-------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01     0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05     0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00    0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00     0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01     0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]        0.0e+00    OK    
ODE steps (saved)                             2576             2576             0.0e+00    OK    
ODE steps (total)                             4572             4572             0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00     0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00     0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02     0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00     0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01     0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01     0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01     0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01     0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01     0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01     0.0e+00    OK    
# singular surfaces                           5                5                0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]         0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]         0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01     0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01     0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00     0.0e+00    OK    
mpert                                         35               35               0.0e+00    OK    
npert                                         1                1                0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00     0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01     0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00     0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00     0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...  identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...  identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...  identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...  identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...  identical  OK    
island half-widths                            [5 elem]         [5 elem]         0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]         0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04     0.0e+00    OK    
dominant-coupling singular values             N/A              [5 elem]         N/A        N/A   
|forcing overlap with dominant mode|          N/A              3.284975e-02     N/A        N/A   
|delta_nominal| of coil set 1                 N/A              1.637107e-02                N/A   
||ddelta/d(shift)|| over coil sets            N/A              2.998822e-02                N/A   
||ddelta/d(tilt)|| over coil sets             N/A              1.012616e-04                N/A   
PE plasma energy                              3.422677e+00     3.422677e+00     0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00     0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00     0.0e+00    OK    
PE toroidal torque                            5.087465e-02     5.087465e-02     0.0e+00    OK    
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01     0.0e+00    OK    
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02     0.0e+00    OK    
Runtime (s)                                   295.4s           336.8s                      --    
resonant area-weighted field b^r              [5 elem]         [5 elem]         0.0e+00    OK    
=================================================================================================
Summary: 47 unchanged, 5 missing/N/A
```

## Notes for reviewers

- Stacked on #452 (base branch `feature/errorfields-risk`).
- Pure post-processing plus one closed-form helper; nothing in the solve path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu

