### PR TITLE
Repo - DOCS - Document harness run isolation and regression vocabulary

### DIFF
--- a/.claude/agents/regression-guardian.md
+++ b/.claude/agents/regression-guardian.md
@@ -1,6 +1,6 @@
 ---
 name: regression-guardian
-description: "Use this agent to run the GPEC regression harness and report whether a code change moved any tracked numerical quantity. Invoke it before merging any substantive change (the project mandates the harness every PR), when the user asks whether results changed, or when new code touches a quantity that may need a new regression case.\\n\\n<example>\\nContext: A developer has finished a change to the singular coupling calculation and is preparing a PR.\\nuser: \"I think the SingularCoupling change is done — can we merge?\"\\nassistant: \"Before merging, let me run the regression-guardian agent to compare your working tree against develop and report the regression table.\"\\n<commentary>\\nCLAUDE.md requires the regression harness on every PR; launch regression-guardian to produce the report.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: A developer changed an ODE tolerance and wants to know the numerical impact.\\nuser: \"I tightened the integrator tolerance in Ode.jl. Did anything move?\"\\nassistant: \"I'll use the regression-guardian agent to run the diiid_n1 and solovev cases comparing local vs develop and report which quantities changed.\"\\n</example>\\n\\n<example>\\nContext: A developer added a brand-new diagnostic output not covered by any case.\\nuser: \"I added a new island-overlap metric to the perturbed equilibrium output.\"\\nassistant: \"Let me launch the regression-guardian agent — it will check whether this quantity is tracked and propose a new regression case if it isn't.\"\\n</example>"
+description: "Use this agent to run the GPEC regression harness and report whether a code change moved any tracked numerical quantity. Invoke it before merging any substantive change (the project mandates the harness every PR), when the user asks whether results changed, or when new code touches a quantity that may need a new regression case.\\n\\n<example>\\nContext: A developer has finished a change to the singular coupling calculation and is preparing a PR.\\nuser: \"I think the SingularCoupling change is done — can we merge?\"\\nassistant: \"Before merging, let me run the regression-guardian agent to compare your feature branch against develop and report the regression table.\"\\n<commentary>\\nCLAUDE.md requires the regression harness on every PR; launch regression-guardian to produce the report.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: A developer changed an ODE tolerance and wants to know the numerical impact.\\nuser: \"I tightened the integrator tolerance in Ode.jl. Did anything move?\"\\nassistant: \"I'll use the regression-guardian agent to run the diiid_n1 and solovev cases comparing your branch against develop and report which quantities changed.\"\\n</example>\\n\\n<example>\\nContext: A developer added a brand-new diagnostic output not covered by any case.\\nuser: \"I added a new island-overlap metric to the perturbed equilibrium output.\"\\nassistant: \"Let me launch the regression-guardian agent — it will check whether this quantity is tracked and propose a new regression case if it isn't.\"\\n</example>"
 model: sonnet
 color: magenta
 ---
@@ -18,7 +18,8 @@ You operate under a hard budget to protect the user's token quota:
 - **One concrete deliverable**: the regression report (the harness table) plus a short verdict
   and, if warranted, a proposal for new cases.
 - **No open-ended exploration**: the invoking prompt tells you which case(s) and refs to compare.
-  If it doesn't, default to the cases relevant to the changed module and compare `local` vs `develop`.
+  If it doesn't, default to the cases relevant to the changed module and compare the feature branch
+  against `develop` (see "Which refs to compare" below).
 - **If a harness run exceeds budget or errors, stop and report** the partial table, the command
   you ran, and what remains. Never silently re-run a hung harness.
 
@@ -34,8 +35,9 @@ Useful invocations:
 - `--list-cases` — enumerate available cases. **Always run this first** to get the current set;
   cases are added over time, so never assume the list. (At time of writing it included
   `diiid_n1`, `solovev_n1`, `solovev_multi_n`, `solovev_kinetic_calculated`, `ggj_reference`.)
-- `--cases <case[,case]> --refs <refA,refB>` — compare two refs (branches/commits). Use `local`
-  for the uncommitted working tree (e.g. `--refs develop,local`).
+- `--cases <case[,case]> --refs <refA,refB>` — compare two refs (branches/commits), e.g.
+  `--refs develop,my-feature-branch`. `local` names the uncommitted working tree; prefer a branch
+  ref (see "Which refs to compare" below).
 - `--show <quantity> --case <case>` — track one quantity across cached commits.
 - `--ref-range <a..b>` — git-bisect-style scan across a commit range.
 - Flags: `--force` (re-run even if cached), `--verbose` (GPEC subprocess output),
@@ -49,9 +51,26 @@ Pick the case(s) by the module touched:
 
 When in doubt, run `diiid_n1` plus whichever case targets the module you changed.
 
+## Which refs to compare
+
+Default to `--refs develop,<feature-branch>`, and ask the user to commit outstanding work first if
+the branch is behind the working tree.
+
+Each git ref runs in its own detached worktree, so a branch-ref comparison is immune to edits made
+while it runs. The `local` ref is not: it runs GPEC in the live checkout, one fresh `julia`
+subprocess per case, each loading `src/` from disk as it starts. An edit landing between two cases
+produces a single report whose rows were built from different code, and nothing in the table says
+so. Full account in `docs/development/regression-harness.md` ("Run isolation").
+
+So: use `local` only for a quick spot check the user explicitly asked for on uncommitted work, and
+say plainly in your report which ref you ran. Never silently substitute one for the other.
+
+While any run is live, do not edit the repository, and say so when you start — the invoking session
+may be waiting on you and editing meanwhile.
+
 ## Your workflow
 
-1. Determine the case(s) and the two refs to compare (default `develop,local`).
+1. Determine the case(s) and the two refs to compare (default `develop,<feature-branch>`).
 2. Run the harness. Prefer `--no-instantiate` if the environment is already resolved; fall back
    to a plain run if it complains about dependencies.
 3. **Report the regression table verbatim** — do not summarize away the numbers.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,11 @@ Conventions: docs/development/naming.md
 Required on every PR (docs/development/regression-harness.md). Paste the report below and
 put the commit you ran it at in the harness stamp above; CI fails if src/ changed afterwards.
 
-    regress --cases diiid_n1 --refs develop,local
+Commit your work and compare branch refs: each git ref runs in its own worktree, so the run is
+unaffected by anything you edit while it is going. `local` runs in the live checkout instead,
+one subprocess per case, and an edit mid-run silently mixes code versions within one report.
+
+    regress --cases diiid_n1 --refs develop,<your-branch>
 -->
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,10 +63,12 @@ Use the generic benchmarking tool at `benchmarks/benchmark_git_branches.jl` to c
 ```bash
 alias regress='julia --project=regression-harness regression-harness/regress.jl'
 regress --list-cases
-regress --cases diiid_n1 --refs develop,local   # working tree vs develop
+regress --cases diiid_n1 --refs develop,my-branch   # commit first; each ref runs in its own worktree
 ```
 
 Full command reference (comparing branches/commits, tracking a quantity's history, git-bisect-style scans, sample report output) is in **[`docs/development/regression-harness.md`](docs/development/regression-harness.md)**.
+
+**Commit before you run it, and compare branch refs.** Only the `local` ref runs in the live checkout, one `julia` subprocess per case — an edit landing between two cases yields one report whose rows came from different code, with nothing in the table to say so. The same doc's *Run isolation* section covers the matching hazards in `test/runtests.jl` (in-process, so a mid-run `src/` edit reports green for code no longer on disk) and the output-path collisions between concurrent runs in one checkout, and *Three things named "regression"* disentangles the harness from `test/test_data/regression_*` and the golden-value tests.
 
 ## Architecture
 

--- a/docs/development/regression-harness.md
+++ b/docs/development/regression-harness.md
@@ -104,6 +104,53 @@ regress --cases solovev_n1 --ref-range develop~10..develop
 
 GPEC subprocesses run with `-t auto` (all cores) so GPEC's threaded kernels are active; set `GPEC_REGRESS_THREADS=1` to force single-threaded runs. Tracked quantities are thread-count independent, and the count each run actually used is recorded in its environment fingerprint (shown in the report's `env:` lines). Thread count is deliberately not part of the cache key, so `Runtime (s)` rows cached from single-threaded runs are not comparable to threaded ones — re-baseline with `--force` if runtime tracking matters.
 
+On a machine you share with other people or with your own parallel sessions, `-t auto` is antisocial: set `GPEC_REGRESS_THREADS` to a bounded count, and `JULIA_NUM_PRECOMPILE_TASKS` alongside it, since `Pkg.instantiate()` otherwise fans out to `Sys.CPU_THREADS + 1` precompile workers at the start of every ref. If the machine has a batch scheduler, submit the run through it and pin both variables to the allocation.
+
+## Three things named "regression"
+
+They share the word and nothing else, which is a reliable source of confusion:
+
+- **This harness** (`regression-harness/`) tracks numerical quantities across commits. Its cases
+  live in `regression-harness/cases/*.toml` and point at decks under `examples/`. This is what the
+  pull-request checklist means by "the regression harness".
+- **`test/test_data/regression_*/`** are *input decks for the unit tests* — a `gpec.toml`, and a
+  `kinetic.dat` for the kinetic ones. They are not harness cases and the harness never reads them.
+- **`test/runtests_*.jl`** are the unit and golden-value tests. Their expected numbers live in the
+  test files themselves, so moving one is a hand edit that has to be justified in review.
+
+## Run isolation
+
+Every git ref in a comparison is checked out into its own detached worktree, so a harness run is
+already insulated from whatever you do to the working tree while it runs. The `local` ref is the
+exception: it runs GPEC in the live checkout.
+
+That matters more than it first appears, because each case runs as a **fresh `julia` subprocess**
+that loads `src/` from disk when it starts. A multi-case `--refs develop,local` run therefore reads
+the source once per case, and an edit landing between two cases yields a single report whose rows
+were produced by different code — with nothing in the output to say so.
+
+For anything you intend to cite — a pull-request report, a bisect, a number you will act on —
+commit the work to the feature branch and compare branch refs:
+
+```bash
+regress --cases diiid_n1 --refs develop,my-feature-branch
+```
+
+`local` stays the right tool for a quick spot check on uncommitted work, provided you leave the tree
+alone until it finishes.
+
+Two related hazards outside the harness, for the same reason:
+
+- **`test/runtests.jl` loads GPEC once, in-process, then `include`s its test files in sequence.**
+  Editing `src/` mid-run changes nothing the run sees, so it reports green for code no longer on
+  disk; editing a `test/runtests_*.jl` file *is* picked up when the run reaches it, so the report
+  mixes old and new. Neither failure is loud.
+- **Concurrent runs in one checkout collide over output paths.** `runtests_fullruns.jl` writes and
+  then deletes `test/test_data/regression_*/gpec.h5`; direct example runs and the harness `local`
+  ref write `examples/<case>/gpec.h5`. Two runs in the same clone delete each other's output. Give
+  the second one its own worktree (`git worktree add --detach <path> HEAD`, copying `Manifest.toml`
+  across so both resolve the same package set).
+
 ## Making source code the only variable
 
 `Manifest.toml` is untracked, so a worktree checked out at an old commit used to resolve whatever


### PR DESCRIPTION
## Release note

- **Audience:** developers
- **Numerical impact:** none
- **Migration:** none

Editing the working tree while a regression-harness or test run is live does not fail loudly — it silently produces a report you cannot trust. This documents the three mechanisms that cause it, switches the default harness invocation from the `local` ref to a branch ref (which the harness already isolates in its own worktree), and disentangles the three separate things in this repository that are called "regression".

## Regression report

Not run: this change touches no files under `src/`, so no tracked quantity can move. `.github/workflows/pr-conventions.yaml:44-51` scopes the harness-stamp requirement to PRs that change `src/`, and this PR is outside it.

## Notes for reviewers

The failure modes below were verified in this repository, not assumed:

- **`local` ref** — `regression-harness/src/runner.jl` (`run_local`) spawns a fresh `julia` subprocess per case against the live checkout. Each one loads `src/` from disk as it starts, so an edit landing between case 1 and case 2 yields a *single* report whose rows were built from different code, with nothing in the table to indicate it. Every other ref is checked out into a detached worktree and is immune.
- **`test/runtests.jl`** — loads GPEC once, in-process, then `include`s ~33 test files in sequence. A mid-run `src/` edit is therefore invisible to the run: it goes green for code that is no longer on disk. A mid-run edit to a `test/runtests_*.jl` file is the opposite — picked up when the driver reaches it, mixing old and new within one report.
- **Output-path collisions** — `runtests_fullruns.jl` writes then deletes `test/test_data/regression_*/gpec.h5`; direct example runs and the harness `local` ref write `examples/<case>/gpec.h5`. Two runs in one clone delete each other's output, with no editing involved. This one bites anyone with more than one session open on a shared machine.

Changes follow from those facts: `docs/development/regression-harness.md` gains a *Run isolation* section as the single source of truth, and the PR template, `CLAUDE.md`, and the `regression-guardian` agent (which hard-defaulted to `local` in three places) now default to `develop,<branch>` and point at it. `local` remains documented for quick spot checks on uncommitted work.

Also added: a short *Three things named "regression"* section separating the harness (`regression-harness/`, cases pointing at `examples/`) from the unit-test input decks (`test/test_data/regression_*/`, which the harness never reads) from the golden-value tests (`test/runtests_*.jl`, expected numbers inline). The shared name is a recurring source of confusion.

One extra paragraph notes that harness subprocesses default to `-t auto`; on a shared machine, `GPEC_REGRESS_THREADS` and `JULIA_NUM_PRECOMPILE_TASKS` should both be bounded, and the run submitted through the scheduler if there is one. Deliberately kept machine-agnostic — no site-specific paths or partition names.

Note `.github/copilot-instructions.md` is a symlink to `CLAUDE.md`, so it tracks automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrJ6WyQom9CJWVBxpWkmV9