### PR TITLE
ErrorFields - FEATURE - Add NTV-limited error-field correction analysis

### DIFF
--- a/docs/development/hdf5-conventions.md
+++ b/docs/development/hdf5-conventions.md
@@ -45,7 +45,7 @@ Top level (11 groups):
 | `SingularSurfaces/` | Per-rational-surface data: `rational_psi`/`rational_q`/`rational_m`/`rational_n`, GGJ coefficients, `Delta_prime_matrix`/`Delta_prime_raw`/`Delta_coil`/`pest3_A`/`pest3_B`/`pest3_Gamma` (Riccati or Galerkin alike), `Kinetic/` |
 | `PerturbedEquilibrium/` | `ForcingModes/`, `Response/`, `ResponseMatrices/`, `SingularCoupling/`, `Energies/`, control-surface spectra |
 | `KineticForces/` | `<method>/` (torque/energy profiles, `EnergyIntegrals/`, `KineticMatrices/`); multi-ion runs add `PerSpecies/<species>/<method>/` with the same per-method layout, summing to the top-level total |
-| `ErrorFields/` | `CoilSensitivities/` (per-coil-set control-surface spectra and their rigid shift/tilt derivatives, `DominantMode/` full-window projection); `MonteCarlo/` (intrinsic and corrected `\|δ\|` histograms over the sampled tolerances, per batch and averaged); `Risk/` (threshold density, `P(lock\|δ)`, locking probabilities, `ToleranceScan/`) |
+| `ErrorFields/` | `CoilSensitivities/` (per-coil-set control-surface spectra and their rigid shift/tilt derivatives, `DominantMode/` full-window projection); `MonteCarlo/` (intrinsic and corrected `\|δ\|` histograms over the sampled tolerances, per batch and averaged); `Risk/` (threshold density, `P(lock\|δ)`, locking probabilities, `ToleranceScan/`); `NTV/` (correction-coil overlap and NTV torque couplings per kAt) |
 | `Tearing/` | `PerSurface/` (+ `DpMatrix/`), `Roots/`, `LayerWidths/`, `Diagnostics/{ValidRoots,Poles,FilteredRoots}`, `Scan/Surface_<k>/` |
 | `SurfaceGeometries/` | `{Plasma,Wall}/{x,y,z}` point clouds |
 

--- a/docs/src/error_fields.md
+++ b/docs/src/error_fields.md
@@ -267,7 +267,12 @@ to a largest correctable overlap. `[ErrorFields.NTV]` names the correction array
 evaluates each one's `C_c`, resonant fraction, and NTV torque per kAt² for its whole field and
 for its field with the dominant mode projected out — two plasma-response evaluations of the
 unit-current spectrum followed by the kinetic torque, which needs a `[KineticForces]` section —
-and writes `ErrorFields/NTV/`. Torque budget, threshold and safety factor are analysis choices:
+and writes `ErrorFields/NTV/`. The spectrum is evaluated on the run's `[ForcingTerms]` boundary
+grid and normalized by the magnitude of the array's ampere-turns, `|nw| × max|I|`, so the winding
+sense and current pattern of the deck stay the phase reference; the torques are stored with their
+sign, and the limits consume the budget with their magnitude (the sign depends on the rotation
+and on conventions, so a negative torque is never read as no torque). Torque budget, threshold
+and safety factor are analysis choices:
 
 ```toml
 [ErrorFields.NTV]

--- a/docs/src/error_fields.md
+++ b/docs/src/error_fields.md
@@ -256,6 +256,32 @@ EF.extreme_phasing(pmap)                        # best |δ| per kAt and the phas
 AEF.plot_phasing_map(pmap; quantity=:overlap_percent)
 ```
 
+## NTV limits of error-field correction
+
+A correction coil cancels the dominant-mode overlap at `C_c` per kilo-ampere-turn, but the
+non-resonant remainder of its field drives a neoclassical toroidal viscosity (NTV) torque
+`T·I²` that a perfect correction does not remove. With a torque budget `T_0` and the threshold
+taken to fall in proportion to the torque spent, the current that corrects an intrinsic overlap
+`δ_EF` solves `δ_EF − C_c I = s δ_thresh (1 − T_residual I²/T_0)`, and real roots exist only up
+to a largest correctable overlap. `[ErrorFields.NTV]` names the correction arrays; the run
+evaluates each one's `C_c`, resonant fraction, and NTV torque per kAt² for its whole field and
+for its field with the dominant mode projected out — two plasma-response evaluations of the
+unit-current spectrum followed by the kinetic torque, which needs a `[KineticForces]` section —
+and writes `ErrorFields/NTV/`. Torque budget, threshold and safety factor are analysis choices:
+
+```toml
+[ErrorFields.NTV]
+efc_coils = ["d3d_c"]           # Coil set names of the correction arrays to evaluate
+method = "fgar"                 # KineticForces torque method (must be enabled in [KineticForces])
+```
+
+```julia
+couplings = EF.read_efc_couplings("gpec.h5")
+curve = EF.efc_current_curve(couplings[1]; delta_threshold=1.4e-4, torque_budget=4.0)
+EF.max_correctable_overlap(couplings[1]; delta_threshold=1.4e-4, torque_budget=4.0)
+AEF.plot_efc_ntv_limits("gpec.h5"; torque_budget=4.0)   # threshold from the run's Risk/ group
+```
+
 ## Analysis after the run
 
 Window the coupling to any range of rational surfaces and project onto any singular mode

--- a/examples/DIIID-like_error_field_example/analyze_example.jl
+++ b/examples/DIIID-like_error_field_example/analyze_example.jl
@@ -112,3 +112,13 @@ println("Saved: ", abspath(risk_path))
 # several `label => gpec.h5` pairs.
 p_summary = GeneralizedPerturbedEquilibrium.Analysis.ErrorFields.plot_error_field_summary(h5path; save_path=joinpath(@__DIR__, "error_field_summary.png"))
 display(p_summary)
+
+# How much intrinsic error field the C-coil could correct before its own NTV torque, at a
+# 4 N·m budget, costs the rotation that holds the penetration threshold up.
+p_ntv = GeneralizedPerturbedEquilibrium.Analysis.ErrorFields.plot_efc_ntv_limits(h5path; torque_budget=4.0, save_path=joinpath(@__DIR__, "efc_ntv_limits.png"))
+display(p_ntv)
+for c in ErrorFields.read_efc_couplings(h5path)
+    lim = ErrorFields.max_correctable_overlap(c; delta_threshold=thr_nom, torque_budget=4.0)
+    @printf("%s: |δ| = %.3e per kAt, resonant fraction %.1f %%, torque %.3e (full) / %.3e (residual) N·m per kAt²; correctable up to %.2f × threshold\n",
+        c.coil_name, c.delta_per_kat, c.overlap_percent, c.torque_full_per_kat2, c.torque_residual_per_kat2, lim.with_ntv / thr_nom)
+end

--- a/examples/DIIID-like_error_field_example/gpec.toml
+++ b/examples/DIIID-like_error_field_example/gpec.toml
@@ -226,3 +226,24 @@ dataset = "O,L"                         # ITPA dataset of the threshold fit: "O,
 fit = "WLS"                             # Fitting method: "OLS", "DSOLS", or "WLS"
 nsample_threshold = 1000000             # Threshold samples
 scan_scales = [0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0]   # Tolerance multipliers of the allowable-tolerance scan
+
+[ErrorFields.NTV]
+efc_coils = ["d3d_c"]                   # Coil set names of the correction arrays to evaluate (here the C-coil stands in for a correction coil)
+method = "fgar"                         # KineticForces torque method (must be enabled in [KineticForces])
+
+[KineticForces]
+kinetic_file = "../DIIID-like_ideal_example/TkMkr_D3Dlike_Hmode_kinetic.h5"  # GPEC HDF5 kinetic schema (psi,n_i,n_e,T_i,T_e,omega_E,+chi_e,chi_phi)
+nn = 1                                  # Toroidal mode number (matches nn_low/nn_high)
+nl = 6                                  # Bounce harmonics retained
+zi = 1                                  # Main-ion charge (deuterium)
+mi = 2                                  # Main-ion mass [proton masses]
+zimp = 6                                # Impurity charge (carbon)
+mimp = 12                               # Impurity mass [proton masses]
+electron = false                        # Ion-only NTV
+nutype = "harmonic"                     # Collision operator
+f0type = "maxwellian"                   # Equilibrium distribution
+moment = "pressure"                     # Pressure-moment NTV torque
+atol_xlmda = 1e-9                       # Absolute tolerance for inner pitch + energy integrations
+rtol_xlmda = 1e-5                       # Relative tolerance for inner pitch + energy integrations
+write_outputs_to_HDF5 = true            # Write outputs to the HDF5 file
+verbose = false                         # Enable verbose logging

--- a/src/Analysis/ErrorFields.jl
+++ b/src/Analysis/ErrorFields.jl
@@ -256,6 +256,36 @@ function plot_phasing_map(h5path::AbstractString, coil_names::AbstractVector{<:A
 end
 
 """
+    plot_efc_ntv_limits(h5path; torque_budget, delta_threshold=nothing, safety_factor=1.0, delta_max=15, save_path=nothing)
+    plot_efc_ntv_limits(couplings::Vector{EF.EFCCoupling}; delta_threshold, torque_budget, kwargs...)
+
+Correction current against intrinsic overlap for each correction array of a run
+(`ErrorFields/NTV/`): the linear single-mode current and the NTV-limited current whose residual
+torque lowers the threshold, with the largest correctable overlap marked. `delta_threshold`
+defaults to the run's nominal penetration threshold (`ErrorFields/Risk/threshold_nominal`);
+`torque_budget` is the torque, N·m, the rotation can afford to lose.
+"""
+function plot_efc_ntv_limits(couplings::Vector{EF.EFCCoupling}; delta_threshold::Real, torque_budget::Real, safety_factor::Real=1.0,
+    delta_max::Real=15, save_path=nothing)
+    p = plot(; xlabel="intrinsic overlap δ_EF / δ_thresh", ylabel="correction current [kAt]", legend=:topleft,
+        title="Error-field correction against its own NTV torque (budget $(torque_budget) N·m)", left_margin=12Plots.mm, bottom_margin=6Plots.mm)
+    for (j, c) in enumerate(couplings)
+        curve = EF.efc_current_curve(c; delta_threshold, torque_budget, safety_factor, delta_max)
+        x = curve.delta_ef ./ delta_threshold
+        plot!(p, x, curve.current_linear; lw=2, c=j, label="$(c.coil_name) single-mode")
+        plot!(p, x, curve.current_ntv; lw=2, ls=:dash, c=j, label="$(c.coil_name) with residual NTV")
+        isfinite(curve.with_ntv) && vline!(p, [curve.with_ntv / delta_threshold]; ls=:dot, c=j, label="$(c.coil_name) NTV limit")
+        isfinite(curve.torque_only) && scatter!(p, [curve.torque_only / delta_threshold], [0.0]; marker=:star5, ms=9, c=j, label="$(c.coil_name) torque-budget limit")
+    end
+    return _save(p, save_path)
+end
+function plot_efc_ntv_limits(h5path::AbstractString; torque_budget::Real, delta_threshold=nothing, kwargs...)
+    couplings = EF.read_efc_couplings(h5path)
+    δt = delta_threshold === nothing ? h5open(f -> read(f["ErrorFields/Risk/threshold_nominal"]), h5path, "r") : delta_threshold
+    return plot_efc_ntv_limits(couplings; delta_threshold=δt, torque_budget, kwargs...)
+end
+
+"""
     plot_error_field_summary(h5path; save_path=nothing)
 
 Four panels of a run's error-field assessment: coil sensitivities to shift, the tolerance

--- a/src/ErrorFields/ErrorFields.jl
+++ b/src/ErrorFields/ErrorFields.jl
@@ -27,6 +27,8 @@ plasma solve or a new Biot-Savart integration.
   convolved with the threshold distribution), `tolerance_scan` and `allowable_tolerance`
 - `Phasing.jl`: `phasing_map`, the closed-form overlap of several coil arrays against their
   relative current-pattern phases
+- `NTVLimits.jl`: how much error field a correction coil can cancel before its own NTV torque
+  costs the rotation that holds the threshold up (`EFCCoupling`, `correction_current`)
 
 The stored primitive is the derivative of each coil set's root-area-weighted control-surface
 spectrum b̃, not a scalar: the overlap with any dominant mode is linear in b̃, so the ψ_N window,
@@ -54,6 +56,7 @@ include("Sampling.jl")
 include("MonteCarlo.jl")
 include("Risk.jl")
 include("Phasing.jl")
+include("NTVLimits.jl")
 include("Output.jl")
 
 export ErrorFieldsControl, CoilSensitivities, SensitivityTable
@@ -66,5 +69,6 @@ export MonteCarloControl, MonteCarloResult, run_monte_carlo
 export ThresholdScaling, ITPA_THRESHOLD_SCALINGS, threshold_scaling, ScenarioParameters, nominal_threshold, threshold_samples
 export RiskControl, RiskResult, locking_risk, ToleranceScan, tolerance_scan, allowable_tolerance
 export PhasingMap, phasing_map, extreme_phasing
+export NTVControl, EFCCoupling, residual_spectrum, correction_current, max_correctable_overlap, efc_current_curve, read_efc_couplings
 
 end # module ErrorFields

--- a/src/ErrorFields/NTVLimits.jl
+++ b/src/ErrorFields/NTVLimits.jl
@@ -1,0 +1,121 @@
+"""
+    NTVLimits
+
+How much error field a correction coil can cancel before the neoclassical toroidal viscosity
+(NTV) torque of its own field costs the rotation that keeps the penetration threshold up. A
+correction coil array cancels the dominant-mode overlap at `C_c` per kilo-ampere-turn, but the
+non-resonant remainder of its field drives an NTV torque `T·I²` that does not go away when the
+resonant part is cancelled. With a torque budget `T_0` and the threshold taken to fall in
+proportion to the torque spent, the current needed to correct an intrinsic overlap `δ_EF` down
+to the (reduced) threshold solves
+
+```
+δ_EF − C_c·I = s·δ_thresh·(1 − T·I²/T_0)
+```
+
+whose real roots exist only up to a largest correctable overlap `δ_max`. The torque
+coefficients are quadratic forms of the applied spectrum, so each is one plasma-response
+evaluation per kilo-ampere-turn: `T_full` for the coil's whole field and `T_residual` for its
+field with the dominant mode projected out, the torque that survives a perfect correction.
+"""
+
+"""
+    NTVControl
+
+Settings of the correction-coil NTV evaluation, the `[ErrorFields.NTV]` TOML table.
+
+## Fields
+
+  - `efc_coils`: coil set names of the correction arrays to evaluate (empty: stage off)
+  - `method`: KineticForces torque method to use (`"fgar"` by default; it must be enabled in `[KineticForces]`)
+  - `verbose`: log per-array couplings
+"""
+Base.@kwdef struct NTVControl
+    efc_coils::Vector{String} = String[]
+    method::String = "fgar"
+    verbose::Bool = false
+end
+
+"""
+    EFCCoupling
+
+The couplings of one correction coil array, per kilo-ampere-turn of its current pattern.
+
+## Fields
+
+  - `coil_name`: the array
+  - `delta_per_kat`: dominant-mode overlap `|δ|` per kAt (`C_c`)
+  - `overlap_percent`: resonant fraction of the array's field, `100·|Vᴴb̃|/‖b̃‖`
+  - `torque_full_per_kat2`: NTV torque of the whole field per kAt², N·m
+  - `torque_residual_per_kat2`: NTV torque of the field with the dominant mode projected out, per kAt², N·m
+"""
+struct EFCCoupling
+    coil_name::String
+    delta_per_kat::Float64
+    overlap_percent::Float64
+    torque_full_per_kat2::Float64
+    torque_residual_per_kat2::Float64
+end
+
+"""
+    residual_spectrum(dom::DominantCoupling, b̃; mode=1) -> Vector{ComplexF64}
+
+The applied root-area-weighted spectrum with singular mode `mode` projected out,
+`b̃ − V_k (V_kᴴ b̃)`: what a perfect single-mode correction leaves behind.
+"""
+function residual_spectrum(dom::DominantCoupling, b̃::AbstractVector{<:Number}; mode::Int=1)
+    v = dom.right_singular_vectors[:, mode]
+    return Vector{ComplexF64}(b̃) .- v .* dot(v, b̃)
+end
+
+"""
+    correction_current(δ_ef, c::EFCCoupling; delta_threshold, torque_budget, safety_factor=1.0, ntv=true) -> Float64
+
+Correction current, kAt, that brings an intrinsic overlap `δ_ef` down to
+`safety_factor × delta_threshold`. Without NTV (`ntv = false`) that is the linear
+`(δ_ef − s·δ_thresh) / C_c`, zero when no correction is needed. With NTV the residual torque
+lowers the threshold in proportion to the fraction of `torque_budget` (N·m) it consumes, and the
+smaller root of the resulting quadratic is returned; `NaN` when no real root exists, i.e. the
+overlap is beyond [`max_correctable_overlap`](@ref).
+"""
+function correction_current(δ_ef::Real, c::EFCCoupling; delta_threshold::Real, torque_budget::Real, safety_factor::Real=1.0, ntv::Bool=true)
+    target = safety_factor * delta_threshold
+    excess = δ_ef - target
+    excess <= 0 && return 0.0
+    ntv || return excess / c.delta_per_kat
+    a = target * c.torque_residual_per_kat2 / torque_budget
+    a == 0 && return excess / c.delta_per_kat
+    disc = c.delta_per_kat^2 - 4a * excess
+    disc < 0 && return NaN
+    return (c.delta_per_kat - sqrt(disc)) / (2a)
+end
+
+"""
+    max_correctable_overlap(c::EFCCoupling; delta_threshold, torque_budget, safety_factor=1.0) -> (; with_ntv, torque_only)
+
+The largest intrinsic overlap the array can correct: `with_ntv`, where the quadratic of
+[`correction_current`](@ref) loses its real roots, `s·δ_thresh + C_c² T_0 / (4 s δ_thresh T_residual)`;
+and `torque_only`, the overlap cancelled by the current at which the whole field's torque alone
+exhausts the budget, `C_c √(T_0 / T_full)`.
+"""
+function max_correctable_overlap(c::EFCCoupling; delta_threshold::Real, torque_budget::Real, safety_factor::Real=1.0)
+    target = safety_factor * delta_threshold
+    with_ntv = c.torque_residual_per_kat2 > 0 ? target + c.delta_per_kat^2 * torque_budget / (4 * target * c.torque_residual_per_kat2) : Inf
+    torque_only = c.torque_full_per_kat2 > 0 ? c.delta_per_kat * sqrt(torque_budget / c.torque_full_per_kat2) : Inf
+    return (; with_ntv, torque_only)
+end
+
+"""
+    efc_current_curve(c::EFCCoupling; delta_threshold, torque_budget, safety_factor=1.0, delta_max=15, npoints=500) -> NamedTuple
+
+The correction current against intrinsic overlap, `δ_ef` from `0` to `delta_max × δ_thresh`:
+`delta_ef`, the linear `current_linear`, the NTV-limited `current_ntv` (`NaN` past the limit),
+and the two limits of [`max_correctable_overlap`](@ref).
+"""
+function efc_current_curve(c::EFCCoupling; delta_threshold::Real, torque_budget::Real, safety_factor::Real=1.0, delta_max::Real=15, npoints::Int=500)
+    δ = collect(range(0.0, delta_max * delta_threshold; length=npoints))
+    lin = [correction_current(d, c; delta_threshold, torque_budget, safety_factor, ntv=false) for d in δ]
+    ntv = [correction_current(d, c; delta_threshold, torque_budget, safety_factor, ntv=true) for d in δ]
+    limits = max_correctable_overlap(c; delta_threshold, torque_budget, safety_factor)
+    return (; delta_ef=δ, current_linear=lin, current_ntv=ntv, limits...)
+end

--- a/src/ErrorFields/NTVLimits.jl
+++ b/src/ErrorFields/NTVLimits.jl
@@ -46,8 +46,11 @@ The couplings of one correction coil array, per kilo-ampere-turn of its current 
   - `coil_name`: the array
   - `delta_per_kat`: dominant-mode overlap `|δ|` per kAt (`C_c`)
   - `overlap_percent`: resonant fraction of the array's field, `100·|Vᴴb̃|/‖b̃‖`
-  - `torque_full_per_kat2`: NTV torque of the whole field per kAt², N·m
-  - `torque_residual_per_kat2`: NTV torque of the field with the dominant mode projected out, per kAt², N·m
+  - `torque_full_per_kat2`: NTV torque of the whole field per kAt², N·m, with its sign
+  - `torque_residual_per_kat2`: NTV torque of the field with the dominant mode projected out, per kAt², N·m, with its sign
+
+The sign of an NTV torque depends on the rotation and on conventions; the limits below consume
+the budget with the torque's magnitude and never treat a negative torque as no torque.
 """
 struct EFCCoupling
     coil_name::String
@@ -83,7 +86,7 @@ function correction_current(δ_ef::Real, c::EFCCoupling; delta_threshold::Real, 
     excess = δ_ef - target
     excess <= 0 && return 0.0
     ntv || return excess / c.delta_per_kat
-    a = target * c.torque_residual_per_kat2 / torque_budget
+    a = target * abs(c.torque_residual_per_kat2) / torque_budget
     a == 0 && return excess / c.delta_per_kat
     disc = c.delta_per_kat^2 - 4a * excess
     disc < 0 && return NaN
@@ -100,8 +103,9 @@ exhausts the budget, `C_c √(T_0 / T_full)`.
 """
 function max_correctable_overlap(c::EFCCoupling; delta_threshold::Real, torque_budget::Real, safety_factor::Real=1.0)
     target = safety_factor * delta_threshold
-    with_ntv = c.torque_residual_per_kat2 > 0 ? target + c.delta_per_kat^2 * torque_budget / (4 * target * c.torque_residual_per_kat2) : Inf
-    torque_only = c.torque_full_per_kat2 > 0 ? c.delta_per_kat * sqrt(torque_budget / c.torque_full_per_kat2) : Inf
+    t_res, t_full = abs(c.torque_residual_per_kat2), abs(c.torque_full_per_kat2)
+    with_ntv = t_res > 0 ? target + c.delta_per_kat^2 * torque_budget / (4 * target * t_res) : Inf
+    torque_only = t_full > 0 ? c.delta_per_kat * sqrt(torque_budget / t_full) : Inf
     return (; with_ntv, torque_only)
 end
 

--- a/src/ErrorFields/Output.jl
+++ b/src/ErrorFields/Output.jl
@@ -242,3 +242,51 @@ function ToleranceScan(h5path::AbstractString)
             read(g["plock_efc_spread_percent"]), read(f[_RISK_GROUP*"/plock_nominal_percent"]))
     end
 end
+
+const _NTV_GROUP = "ErrorFields/NTV"
+
+# Metadata table for ErrorFields/NTV/ (paths relative to the group): per correction-coil array,
+# per kilo-ampere-turn of its current pattern.
+const NTV_H5_ANNOTATIONS = [
+    "coil_name" => (; long_name="name of each correction coil array"),
+    "delta_per_kat" => (; long_name="dominant-mode overlap |δ| of each array per kilo-ampere-turn", units="1/kAt"),
+    "overlap_percent" => (; long_name="resonant fraction of each array's field, 100·|Vᴴb̃|/‖b̃‖", units="%"),
+    "torque_full_per_kat2" => (; long_name="NTV torque of each array's whole field per kilo-ampere-turn squared", units="N*m/kAt^2"),
+    "torque_residual_per_kat2" => (; long_name="NTV torque of each array's field with the dominant mode projected out, per kilo-ampere-turn squared", units="N*m/kAt^2")
+]
+
+"""
+    write_to_hdf5!(h5file::HDF5.File, couplings::Vector{EFCCoupling})
+
+Write the correction-coil couplings to `ErrorFields/NTV/`. The torque budget, threshold and
+safety factor that turn them into a correction-current curve are analysis choices left to
+[`efc_current_curve`](@ref). An existing group is replaced.
+"""
+function write_to_hdf5!(h5file::HDF5.File, couplings::Vector{EFCCoupling})
+    haskey(h5file, _NTV_GROUP) && delete_object(h5file, _NTV_GROUP)
+    g = create_group(h5file, _NTV_GROUP)
+    g["coil_name"] = [c.coil_name for c in couplings]
+    g["delta_per_kat"] = [c.delta_per_kat for c in couplings]
+    g["overlap_percent"] = [c.overlap_percent for c in couplings]
+    g["torque_full_per_kat2"] = [c.torque_full_per_kat2 for c in couplings]
+    g["torque_residual_per_kat2"] = [c.torque_residual_per_kat2 for c in couplings]
+    Utilities.HDF5Annotations.annotate!(g, NTV_H5_ANNOTATIONS)
+    return g
+end
+
+"""
+    read_efc_couplings(h5path::AbstractString) -> Vector{EFCCoupling}
+
+Read a run's correction-coil couplings back from `ErrorFields/NTV/`.
+"""
+function read_efc_couplings(h5path::AbstractString)
+    h5open(h5path, "r") do f
+        haskey(f, _NTV_GROUP) || throw(ArgumentError("$h5path has no $_NTV_GROUP group (set efc_coils in [ErrorFields.NTV])"))
+        g = f[_NTV_GROUP]
+        names = read(g["coil_name"])
+        return [
+            EFCCoupling(names[i], read(g["delta_per_kat"])[i], read(g["overlap_percent"])[i], read(g["torque_full_per_kat2"])[i], read(g["torque_residual_per_kat2"])[i])
+            for i in eachindex(names)
+        ]
+    end
+end

--- a/src/GeneralizedPerturbedEquilibrium.jl
+++ b/src/GeneralizedPerturbedEquilibrium.jl
@@ -6,6 +6,7 @@ using TOML
 using Printf
 using HDF5
 using FastInterpolations
+import LinearAlgebra: dot, norm
 import IMASdd
 import AdaptiveArrayPools: @with_pool
 
@@ -266,15 +267,15 @@ function main_from_inputs(
     if ctrl.force_termination
         slayer_result = run_slayer_stage(ffs_result, inputs, nothing)
         @info "\n$_BANNER\n  GPEC completed successfully in $(@sprintf("%.3f", time() - total_start)) s\n$_BANNER"
-        return (; ffs=ffs_result, pe=nothing, slayer=slayer_result, coil_sensitivities=nothing, monte_carlo=nothing, locking_risk=nothing)
+        return (; ffs=ffs_result, pe=nothing, slayer=slayer_result, coil_sensitivities=nothing, monte_carlo=nothing, locking_risk=nothing, efc_couplings=nothing)
     end
 
     pe_state = run_perturbed_equilibrium(ffs_result, inputs, forcing_modes_snapshot, preloaded_coil_sets)
 
     run_kinetic_forces(inputs, ffs_result, pe_state, kf_ctrl, kinetic_profiles, kf_species)
 
-    error_fields = run_error_fields(inputs, ffs_result, pe_state, preloaded_coil_sets)
-    coil_sensitivities, monte_carlo, locking_risk = error_fields === nothing ? (nothing, nothing, nothing) : error_fields
+    error_fields = run_error_fields(inputs, ffs_result, pe_state, preloaded_coil_sets, kf_ctrl, kinetic_profiles)
+    coil_sensitivities, monte_carlo, locking_risk, efc_couplings = error_fields === nothing ? (nothing, nothing, nothing, nothing) : error_fields
 
     # SLAYER runs after PE so it appends to the PE output file; it falls back to the
     # ForceFreeStates file when PE did not run.
@@ -293,7 +294,7 @@ function main_from_inputs(
 
     # TODO: Do not allow perturbed equilibrium calculations if zero crossings are found
 
-    return (; ffs=ffs_result, pe=pe_state, slayer=slayer_result, coil_sensitivities, monte_carlo, locking_risk)
+    return (; ffs=ffs_result, pe=pe_state, slayer=slayer_result, coil_sensitivities, monte_carlo, locking_risk, efc_couplings)
 
 end
 
@@ -994,7 +995,7 @@ function forcing_terms_control(inputs::Dict{String,Any})
 end
 
 """
-    run_error_fields(inputs, result, pe_state, preloaded_coil_sets) -> (sensitivities, monte_carlo, risk) or nothing
+    run_error_fields(inputs, result, pe_state, preloaded_coil_sets, kf_ctrl, kinetic_profiles) -> (sensitivities, monte_carlo, risk, couplings) or nothing
 
 Linearize every coil set's resonant drive with respect to its rigid shifts and tilts and write
 `ErrorFields/CoilSensitivities/` when the deck carries an `[ErrorFields]` section. When the
@@ -1002,7 +1003,9 @@ section names a `tolerance_file`, read, validate and echo it, then run the toler
 Carlo on the full-window dominant mode with the `[ErrorFields.MonteCarlo]` settings and write
 `ErrorFields/MonteCarlo/`; with an `[ErrorFields.scenario]` table as well, evaluate the locking
 risk (and the tolerance scan when `[ErrorFields.Risk]` names `scan_scales`) and write
-`ErrorFields/Risk/`. Stages not requested return `nothing`. Needs the
+`ErrorFields/Risk/`; with `[ErrorFields.NTV]` naming correction arrays, evaluate their overlap and NTV
+torque couplings per kilo-ampere-turn (needs the kinetic context) and write `ErrorFields/NTV/`.
+Stages not requested return `nothing`. Needs the
 perturbed-equilibrium state's singular-coupling matrix and coil-format forcing, and errors
 otherwise: a deck asking for error-field sensitivities without them is a misconfiguration, not a
 case to skip silently. Coil geometry is rebuilt from the deck unless a replay injected it.
@@ -1011,7 +1014,9 @@ function run_error_fields(
     inputs::Dict{String,Any},
     result::ForceFreeStatesResult,
     pe_state,
-    preloaded_coil_sets::Union{Nothing,Vector{ForcingTerms.CoilSet}}
+    preloaded_coil_sets::Union{Nothing,Vector{ForcingTerms.CoilSet}},
+    kf_ctrl::KineticForces.KineticForcesControl=KineticForces.KineticForcesControl(),
+    kinetic_profiles=nothing
 )
     ("ErrorFields" in keys(inputs)) || return nothing
 
@@ -1021,11 +1026,12 @@ function run_error_fields(
     # [ErrorFields.MonteCarlo], [ErrorFields.Risk] and [ErrorFields.scenario] are nested tables,
     # excluded from the control-struct splat.
     ef_raw = inputs["ErrorFields"]
-    nested = ("MonteCarlo", "Risk", "scenario")
+    nested = ("MonteCarlo", "Risk", "scenario", "NTV")
     ef_ctrl = ErrorFields.ErrorFieldsControl(; (Symbol(k) => v for (k, v) in ef_raw if !(k in nested))...)
     mc_ctrl = ErrorFields.MonteCarloControl(; (Symbol(k) => v for (k, v) in get(ef_raw, "MonteCarlo", Dict{String,Any}()))...)
     risk_ctrl = ErrorFields.RiskControl(; (Symbol(k) => v for (k, v) in get(ef_raw, "Risk", Dict{String,Any}()))...)
     scenario_raw = get(ef_raw, "scenario", nothing)
+    ntv_ctrl = ErrorFields.NTVControl(; (Symbol(k) => v for (k, v) in get(ef_raw, "NTV", Dict{String,Any}()))...)
     pe_state === nothing && error("[ErrorFields] needs a [PerturbedEquilibrium] section with compute_singular_coupling = true")
     ft_ctrl = forcing_terms_control(inputs)
     ft_ctrl.forcing_data_format == "coil" ||
@@ -1077,6 +1083,17 @@ function run_error_fields(
         end
     end
 
+    # Correction-coil couplings: overlap per kAt and the NTV torque of the full and residual fields.
+    couplings = nothing
+    if !isempty(ntv_ctrl.efc_coils)
+        efc_sets = [cs for cs in coil_sets if cs.name in ntv_ctrl.efc_coils]
+        missing = setdiff(ntv_ctrl.efc_coils, [cs.name for cs in efc_sets])
+        isempty(missing) || error("[ErrorFields.NTV] efc_coils not among the run's coil sets: $(join(missing, ", "))")
+        ntv_start = time()
+        couplings = efc_couplings(result, efc_sets, rc, dom, kf_ctrl, kinetic_profiles; method=ntv_ctrl.method, verbose=ntv_ctrl.verbose)
+        @info "NTV couplings of $(length(couplings)) correction arrays in $(@sprintf("%.1f", time() - ntv_start)) s"
+    end
+
     if ef_ctrl.write_outputs_to_HDF5
         output_file = isempty(ef_ctrl.output_filename) ? result.control.HDF5_filename : ef_ctrl.output_filename
         h5open(joinpath(result.dir_path, output_file), "cw") do h5file
@@ -1085,13 +1102,82 @@ function run_error_fields(
             tolerances === nothing || ErrorFields.write_tolerance_snapshot!(h5file, tolerances)
             monte_carlo === nothing || ErrorFields.write_to_hdf5!(h5file, monte_carlo)
             risk === nothing || ErrorFields.write_to_hdf5!(h5file, risk; scan)
+            couplings === nothing || ErrorFields.write_to_hdf5!(h5file, couplings)
         end
         @info "Results written to $output_file"
     end
 
     @info "ErrorFields completed in $(@sprintf("%.3f", time() - ef_start)) s"
 
-    return sens, monte_carlo, risk
+    return sens, monte_carlo, risk, couplings
+end
+
+"""
+    efc_couplings(ffs, coil_sets, rc, dom, kf_ctrl, kinetic_profiles; mode=1, method="fgar", verbose=false) -> Vector{ErrorFields.EFCCoupling}
+
+The couplings of each correction coil array in `coil_sets` per kilo-ampere-turn: its
+dominant-mode overlap and resonant fraction from its spectrum on the control surface, and its
+NTV torque for the whole field and for the field with mode `mode` of `dom` projected out. The
+torque is a quadratic form of the applied spectrum, so each is one plasma-response evaluation
+of the unit-current spectrum (injected as forcing modes, nothing written) followed by the
+kinetic torque of `method`; both scale exactly with the square of the current. `rc` must be
+the coupling of `ffs`'s own solve and `kinetic_profiles` its kinetic context.
+"""
+function efc_couplings(
+    ffs::ForceFreeStatesResult,
+    coil_sets::Vector{ForcingTerms.CoilSet},
+    rc::PerturbedEquilibrium.ResonantCoupling,
+    dom::PerturbedEquilibrium.DominantCoupling,
+    kf_ctrl::KineticForces.KineticForcesControl,
+    kinetic_profiles;
+    mode::Int=1,
+    method::AbstractString="fgar",
+    verbose::Bool=false
+)
+    kinetic_profiles === nothing && error("efc_couplings needs kinetic profiles: add a [KineticForces] section with a kinetic_file")
+    getfield(kf_ctrl, Symbol(method * "_flag")) || error("efc_couplings: KineticForces method \"$method\" is not enabled in the control")
+    cfg = ForcingTerms.CoilConfig(; mtheta_coil=480, nzeta_coil=0)
+    grids = [(n, ForcingTerms.CoilForcingGrid(ffs.equil, cfg, n; psi=ffs.psilim)) for n in sort(unique(rc.n_modes))]
+    m_low, m_high = extrema(rc.m_modes)
+    v = dom.right_singular_vectors[:, mode]
+    kf_intr = KineticForces.KineticForcesInternal(ffs.equil; verbose=verbose)
+    quiet = PerturbedEquilibrium.PerturbedEquilibriumControl(; compute_response=true, compute_singular_coupling=false, verbose=verbose, write_outputs_to_HDF5=false)
+
+    function torque_of(modes::Vector{ForcingTerms.ForcingMode})
+        pe_intr = PerturbedEquilibrium.PerturbedEquilibriumInternal(; dir_path=ffs.dir_path)
+        pe_intr.inner_bpen = ffs.bpen
+        pe_intr.forcing_modes = modes
+        pe_state = PerturbedEquilibrium.compute_perturbed_equilibrium(ffs, ForcingTerms.RMPField(ForcingTerms.ForcingTermsControl()), quiet, pe_intr)
+        KineticForces.set_perturbation_data!(kf_intr, pe_state, ffs, ffs.equil, ffs.metric)
+        kf_state = KineticForces.KineticForcesState()
+        KineticForces.compute_torque_all_methods!(kf_state, kf_intr, kf_ctrl, ffs.equil, kinetic_profiles)
+        return real(kf_state.method_results[String(method)].total_torque)
+    end
+
+    out = ErrorFields.EFCCoupling[]
+    for cs in coil_sets
+        kat = abs(cs.nw) * maximum(abs, cs.currents) / 1e3
+        kat > 0 || error("efc_couplings: coil set \"$(cs.name)\" carries no current")
+        # Unit-current spectrum: per kilo-ampere-turn of the array's current pattern.
+        modes = ForcingTerms.ForcingMode[]
+        for (n, grid) in grids
+            append!(modes, ForcingTerms.coil_forcing_modes(cs, grid, n, m_low, m_high))
+        end
+        modes = [ForcingTerms.ForcingMode(; n=m.n, m=m.m, amplitude=m.amplitude / kat) for m in modes]
+        b̃ = PerturbedEquilibrium.rootarea_field(rc, modes)
+        δ = dot(v, b̃) / ffs.equil.params.bt0
+        overlap = 100 * abs(dot(v, b̃)) / norm(b̃)
+        # The residual field as forcing modes: back through the conform operator to Φ_x.
+        Φ_res = rc.flux_conform * ErrorFields.residual_spectrum(dom, b̃; mode)
+        residual_modes = [ForcingTerms.ForcingMode(; n=rc.n_modes[k], m=rc.m_modes[k], amplitude=Φ_res[k]) for k in eachindex(Φ_res)]
+        t_start = time()
+        T_full = torque_of(modes)
+        T_res = torque_of(residual_modes)
+        verbose && @info "  $(cs.name): |δ| = $(@sprintf("%.3e", abs(δ))) per kAt, resonant fraction $(@sprintf("%.1f", overlap)) %, " *
+              "torque $(@sprintf("%.3e", T_full)) N·m per kAt² (residual $(@sprintf("%.3e", T_res))) in $(@sprintf("%.1f", time() - t_start)) s"
+        push!(out, ErrorFields.EFCCoupling(cs.name, abs(δ), overlap, T_full, T_res))
+    end
+    return out
 end
 
 """

--- a/src/GeneralizedPerturbedEquilibrium.jl
+++ b/src/GeneralizedPerturbedEquilibrium.jl
@@ -1090,7 +1090,7 @@ function run_error_fields(
         missing = setdiff(ntv_ctrl.efc_coils, [cs.name for cs in efc_sets])
         isempty(missing) || error("[ErrorFields.NTV] efc_coils not among the run's coil sets: $(join(missing, ", "))")
         ntv_start = time()
-        couplings = efc_couplings(result, efc_sets, rc, dom, kf_ctrl, kinetic_profiles; method=ntv_ctrl.method, verbose=ntv_ctrl.verbose)
+        couplings = efc_couplings(result, efc_sets, rc, dom, cfg, kf_ctrl, kinetic_profiles; method=ntv_ctrl.method, verbose=ntv_ctrl.verbose)
         @info "NTV couplings of $(length(couplings)) correction arrays in $(@sprintf("%.1f", time() - ntv_start)) s"
     end
 
@@ -1113,21 +1113,26 @@ function run_error_fields(
 end
 
 """
-    efc_couplings(ffs, coil_sets, rc, dom, kf_ctrl, kinetic_profiles; mode=1, method="fgar", verbose=false) -> Vector{ErrorFields.EFCCoupling}
+    efc_couplings(ffs, coil_sets, rc, dom, cfg, kf_ctrl, kinetic_profiles; mode=1, method="fgar", verbose=false) -> Vector{ErrorFields.EFCCoupling}
 
 The couplings of each correction coil array in `coil_sets` per kilo-ampere-turn: its
 dominant-mode overlap and resonant fraction from its spectrum on the control surface, and its
 NTV torque for the whole field and for the field with mode `mode` of `dom` projected out. The
 torque is a quadratic form of the applied spectrum, so each is one plasma-response evaluation
 of the unit-current spectrum (injected as forcing modes, nothing written) followed by the
-kinetic torque of `method`; both scale exactly with the square of the current. `rc` must be
-the coupling of `ffs`'s own solve and `kinetic_profiles` its kinetic context.
+kinetic torque of `method`; both scale exactly with the square of the current. `cfg` is the
+run's `[ForcingTerms]` coil configuration, so the boundary grid matches the one the run's
+sensitivities were evaluated on; `rc` must be the coupling of `ffs`'s own solve and
+`kinetic_profiles` its kinetic context. The spectrum is normalized by the magnitude of the
+array's ampere-turns, `|nw| × max|I|`, keeping its winding sense and current pattern as the
+phase reference; the torque is stored with its sign.
 """
 function efc_couplings(
     ffs::ForceFreeStatesResult,
     coil_sets::Vector{ForcingTerms.CoilSet},
     rc::PerturbedEquilibrium.ResonantCoupling,
     dom::PerturbedEquilibrium.DominantCoupling,
+    cfg::ForcingTerms.CoilConfig,
     kf_ctrl::KineticForces.KineticForcesControl,
     kinetic_profiles;
     mode::Int=1,
@@ -1136,7 +1141,6 @@ function efc_couplings(
 )
     kinetic_profiles === nothing && error("efc_couplings needs kinetic profiles: add a [KineticForces] section with a kinetic_file")
     getfield(kf_ctrl, Symbol(method * "_flag")) || error("efc_couplings: KineticForces method \"$method\" is not enabled in the control")
-    cfg = ForcingTerms.CoilConfig(; mtheta_coil=480, nzeta_coil=0)
     grids = [(n, ForcingTerms.CoilForcingGrid(ffs.equil, cfg, n; psi=ffs.psilim)) for n in sort(unique(rc.n_modes))]
     m_low, m_high = extrema(rc.m_modes)
     v = dom.right_singular_vectors[:, mode]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ else
     include("./runtests_monte_carlo.jl")
     include("./runtests_risk.jl")
     include("./runtests_phasing.jl")
+    include("./runtests_ntv_limits.jl")
     include("./runtests_sing.jl")
     include("./runtests_innerlayer.jl")
     include("./runtests_tj_analytic.jl")

--- a/test/runtests_error_fields.jl
+++ b/test/runtests_error_fields.jl
@@ -216,7 +216,7 @@ include("h5_metadata_check.jl")
             curve = EF.efc_current_curve(c; delta_threshold=risk.threshold_nominal, torque_budget=1.0)
             @test length(curve.delta_ef) == 500 && all(curve.current_linear .>= 0)
             @test GPEC.Analysis.ErrorFields.plot_efc_ntv_limits(h5path; torque_budget=1.0, save_path=joinpath(dir, "ntv.png")) isa Plots.Plot
-            @test_throws ErrorException GPEC.efc_couplings(ffs, sets, rc, dom, GPEC.KineticForces.KineticForcesControl(), nothing)
+            @test_throws ErrorException GPEC.efc_couplings(ffs, sets, rc, dom, cfg, GPEC.KineticForces.KineticForcesControl(), nothing)
 
             # Central differences: doubling the step moves the derivatives at O(h²).
             coarse = EF.compute_coil_sensitivities(sets, rc, ffs.equil, cfg,

--- a/test/runtests_error_fields.jl
+++ b/test/runtests_error_fields.jl
@@ -51,11 +51,15 @@ include("h5_metadata_check.jl")
                 "compute_response" => true, "compute_singular_coupling" => true,
                 "verbose" => false, "write_outputs_to_HDF5" => true)
             cp(joinpath(@__DIR__, "test_data", "ErrorFields", "tolerances_two_hoops.toml"), joinpath(dir, "tolerances.toml"))
+            # Kinetic profiles consistent with this Solovev pressure, for the NTV torque couplings.
+            cp(joinpath(@__DIR__, "..", "examples", "Solovev_kinetic_NTV_example", "kinetic.dat"), joinpath(dir, "kinetic.dat"))
+            inputs["KineticForces"] = Dict{String,Any}("kinetic_file" => "kinetic.dat", "verbose" => false, "write_outputs_to_HDF5" => true)
             inputs["ErrorFields"] = Dict{String,Any}("verbose" => false, "tolerance_file" => "tolerances.toml",
                 "MonteCarlo" => Dict{String,Any}("nsample" => 20_000, "nbatch" => 2, "seed" => 5, "nbins" => 100),
                 # Density chosen so the ITPA threshold sits near the fixture's nominal overlap: risk neither 0 nor saturated.
                 "scenario" => Dict{String,Any}("n_e" => 12.0),
-                "Risk" => Dict{String,Any}("nsample_threshold" => 20_000, "seed" => 3, "scan_scales" => [0.5, 1.0, 2.0]))
+                "Risk" => Dict{String,Any}("nsample_threshold" => 20_000, "seed" => 3, "scan_scales" => [0.5, 1.0, 2.0]),
+                "NTV" => Dict{String,Any}("efc_coils" => ["hoop_tilted"]))
             open(io -> TOML.print(io, inputs), toml_path, "w")
 
             res = GPEC.main([dir])
@@ -191,6 +195,28 @@ include("h5_metadata_check.jl")
             @test post_hoc.nominal_field ≈ sens.nominal_field rtol = 1e-10
             @test post_hoc.shift_sensitivity ≈ sens.shift_sensitivity rtol = 1e-10
             @test post_hoc.tilt_sensitivity ≈ sens.tilt_sensitivity rtol = 1e-10
+
+            # Correction-coil couplings: the tilted hoop as the correction array. Its overlap per kAt is
+            # the table's nominal overlap over its ampere-turns; the residual field carries no dominant
+            # mode; the torques are finite and written with the metadata contract.
+            couplings = res.efc_couplings
+            @test couplings isa Vector{EF.EFCCoupling} && length(couplings) == 1
+            c = couplings[1]
+            kat = sets[1].nw * 2.0e3 / 1e3
+            @test c.coil_name == "hoop_tilted"
+            @test c.delta_per_kat ≈ abs(table.delta_nominal[1]) / kat rtol = 1e-6
+            @test 0 < c.overlap_percent <= 100
+            @test isfinite(c.torque_full_per_kat2) && isfinite(c.torque_residual_per_kat2)
+            @test abs(dot(dom.right_singular_vectors[:, 1], EF.residual_spectrum(dom, sens.nominal_field[:, 1]))) < 1e-12
+            @test EF.read_efc_couplings(h5path)[1] == c
+            h5open(h5path, "r") do f
+                @test haskey(f, "ErrorFields/NTV/torque_residual_per_kat2")
+                @test isempty(_collect_metadata_violations(f))
+            end
+            curve = EF.efc_current_curve(c; delta_threshold=risk.threshold_nominal, torque_budget=1.0)
+            @test length(curve.delta_ef) == 500 && all(curve.current_linear .>= 0)
+            @test GPEC.Analysis.ErrorFields.plot_efc_ntv_limits(h5path; torque_budget=1.0, save_path=joinpath(dir, "ntv.png")) isa Plots.Plot
+            @test_throws ErrorException GPEC.efc_couplings(ffs, sets, rc, dom, GPEC.KineticForces.KineticForcesControl(), nothing)
 
             # Central differences: doubling the step moves the derivatives at O(h²).
             coarse = EF.compute_coil_sensitivities(sets, rc, ffs.equil, cfg,

--- a/test/runtests_ntv_limits.jl
+++ b/test/runtests_ntv_limits.jl
@@ -1,0 +1,60 @@
+using LinearAlgebra
+
+# The NTV-limited error-field-correction model on hand-built couplings: the residual spectrum
+# projection, the linear and NTV-limited correction currents against the closed-form quadratic,
+# and the two correctable-overlap limits.
+@testset "NTV limits of error-field correction" begin
+    GPEC = GeneralizedPerturbedEquilibrium
+    EF = GPEC.ErrorFields
+    PE = GPEC.PerturbedEquilibrium
+
+    @testset "residual spectrum" begin
+        v = normalize(ComplexF64[1, 2im, -1, 0.5])
+        dom = PE.DominantCoupling([3.0, 1.0], hcat(v, normalize(ComplexF64[0, 1, 1, 0])), ones(ComplexF64, 2, 2), [1, 2])
+        b = ComplexF64[0.3, -0.2im, 0.7, 1.0]
+        r = EF.residual_spectrum(dom, b)
+        @test abs(dot(v, r)) < 1e-14                       # nothing left along the mode
+        @test r + v * dot(v, b) ≈ b                        # the projection is exact
+        @test EF.residual_spectrum(dom, v) ≈ zeros(4) atol = 1e-14
+    end
+
+    c = EF.EFCCoupling("efcc", 2.0e-5, 40.0, 0.05, 0.02)    # δ per kAt, %, N·m per kAt² (full, residual)
+    δt, T0 = 1.0e-4, 4.0
+
+    @testset "correction current" begin
+        # Below the threshold nothing is needed; the linear current is (δ − δ_t)/C_c.
+        @test EF.correction_current(0.5δt, c; delta_threshold=δt, torque_budget=T0) == 0.0
+        @test EF.correction_current(3δt, c; delta_threshold=δt, torque_budget=T0, ntv=false) ≈ 2δt / c.delta_per_kat
+        # With NTV the current is the smaller root of a I² − C I + (δ − δ_t) = 0, a = δ_t T_r / T_0.
+        a = δt * c.torque_residual_per_kat2 / T0
+        I = EF.correction_current(2δt, c; delta_threshold=δt, torque_budget=T0)
+        @test a * I^2 - c.delta_per_kat * I + δt ≈ 0 atol = 1e-18
+        @test I > δt / c.delta_per_kat                     # NTV always costs extra current
+        # Safety factor scales the target; zero residual torque recovers the linear current.
+        @test EF.correction_current(3δt, c; delta_threshold=δt, torque_budget=T0, safety_factor=2.0, ntv=false) ≈ δt / c.delta_per_kat
+        c0 = EF.EFCCoupling("x", c.delta_per_kat, 40.0, 0.05, 0.0)
+        @test EF.correction_current(3δt, c0; delta_threshold=δt, torque_budget=T0) ≈ 2δt / c.delta_per_kat
+        # Beyond the correctable limit there is no real root.
+        lim = EF.max_correctable_overlap(c; delta_threshold=δt, torque_budget=T0)
+        @test isnan(EF.correction_current(1.01 * lim.with_ntv, c; delta_threshold=δt, torque_budget=T0))
+        @test !isnan(EF.correction_current(0.99 * lim.with_ntv, c; delta_threshold=δt, torque_budget=T0))
+    end
+
+    @testset "limits and curve" begin
+        lim = EF.max_correctable_overlap(c; delta_threshold=δt, torque_budget=T0)
+        @test lim.with_ntv ≈ δt + c.delta_per_kat^2 * T0 / (4 * δt * c.torque_residual_per_kat2)
+        @test lim.torque_only ≈ c.delta_per_kat * sqrt(T0 / c.torque_full_per_kat2)
+        # At the NTV limit the discriminant vanishes and the current tends to C_c / (2a).
+        a = δt * c.torque_residual_per_kat2 / T0
+        @test EF.correction_current((1 - 1e-6) * lim.with_ntv, c; delta_threshold=δt, torque_budget=T0) ≈ c.delta_per_kat / (2a) rtol = 1e-2
+        curve = EF.efc_current_curve(c; delta_threshold=δt, torque_budget=T0, delta_max=20, npoints=200)
+        @test length(curve.delta_ef) == 200 && curve.delta_ef[end] ≈ 20δt
+        @test all(curve.current_linear .>= 0)
+        @test all(isnan.(curve.current_ntv[curve.delta_ef.>lim.with_ntv]))
+        @test all(.!isnan.(curve.current_ntv[curve.delta_ef.<lim.with_ntv]))
+        @test all(curve.current_ntv[.!isnan.(curve.current_ntv)] .>= curve.current_linear[.!isnan.(curve.current_ntv)] .- 1e-12)
+        @test curve.with_ntv == lim.with_ntv && curve.torque_only == lim.torque_only
+        no_torque = EF.EFCCoupling("y", c.delta_per_kat, 40.0, 0.0, 0.0)
+        @test EF.max_correctable_overlap(no_torque; delta_threshold=δt, torque_budget=T0) == (; with_ntv=Inf, torque_only=Inf)
+    end
+end

--- a/test/runtests_ntv_limits.jl
+++ b/test/runtests_ntv_limits.jl
@@ -54,6 +54,10 @@ using LinearAlgebra
         @test all(.!isnan.(curve.current_ntv[curve.delta_ef.<lim.with_ntv]))
         @test all(curve.current_ntv[.!isnan.(curve.current_ntv)] .>= curve.current_linear[.!isnan.(curve.current_ntv)] .- 1e-12)
         @test curve.with_ntv == lim.with_ntv && curve.torque_only == lim.torque_only
+        # A negative torque (the other rotation sense) consumes the budget like a positive one.
+        negative = EF.EFCCoupling("z", c.delta_per_kat, 40.0, -c.torque_full_per_kat2, -c.torque_residual_per_kat2)
+        @test EF.max_correctable_overlap(negative; delta_threshold=δt, torque_budget=T0) == lim
+        @test EF.correction_current(2δt, negative; delta_threshold=δt, torque_budget=T0) == EF.correction_current(2δt, c; delta_threshold=δt, torque_budget=T0)
         no_torque = EF.EFCCoupling("y", c.delta_per_kat, 40.0, 0.0, 0.0)
         @test EF.max_correctable_overlap(no_torque; delta_threshold=δt, torque_budget=T0) == (; with_ntv=Inf, torque_only=Inf)
     end


### PR DESCRIPTION
Tenth and last PR of the OMFIT → Julia error-field tolerance migration, stacked on #453: how much error field a correction coil can cancel before the NTV torque of its own field costs the rotation that holds the penetration threshold up — the paper's "NTV limits of EFC" figure, without a new KineticForces API.

**What it does**

- `src/ErrorFields/NTVLimits.jl`: `EFCCoupling` (per kilo-ampere-turn of an array: overlap `C_c`, resonant fraction, NTV torque of the whole field and of the field with the dominant mode projected out), `residual_spectrum`, `correction_current` (linear `(δ_EF − s δ_t)/C_c`, or the smaller root of `a I² − C_c I + (δ_EF − s δ_t) = 0`, `a = s δ_t T_residual / T_0`, when the residual torque lowers the threshold in proportion to the budget it spends), `max_correctable_overlap` (`with_ntv`, where the roots vanish; `torque_only`, where the whole field's torque alone exhausts the budget), `efc_current_curve`.
- `efc_couplings(ffs, coil_sets, rc, dom, kf_ctrl, kinetic_profiles)` (driver level): the torque is a quadratic form of the applied spectrum, so each coupling is one plasma-response evaluation of the unit-current spectrum, injected as forcing modes with nothing written, followed by the kinetic torque — two evaluations per array instead of a current scan. `[ErrorFields.NTV] efc_coils = [...]` runs it after the risk stage and writes `ErrorFields/NTV/`; torque budget, threshold and safety factor stay analysis choices (`read_efc_couplings`, `Analysis.ErrorFields.plot_efc_ntv_limits`).
- The DIII-D example gains a `[KineticForces]` section and treats its C-coil as the correction array; `analyze_example.jl` plots the current-vs-overlap curves with the NTV limit.

**Verification**

- `test/runtests_ntv_limits.jl` (21): projection removes the mode exactly; linear current; the NTV current satisfies the quadratic and exceeds the linear one; safety factor; zero residual torque recovers the linear current; `NaN` past the limit; the closed-form limits; curve shape.
- Solovev run test: the tilted hoop as correction array — its `delta_per_kat` equals the table's nominal overlap over its ampere-turns, residual field orthogonal to the mode, finite torques, HDF5 round trip with the metadata contract, plot, and the kinetic-context guard.

cc @matt-pharr

## Release note

- **Audience:** users
- **Numerical impact:** none _(harness @ 55ef4ba5)_
- **Migration:** none

`[ErrorFields.NTV]` evaluates, per correction coil array, the dominant-mode overlap and the NTV torque of its full and residual fields per kilo-ampere-turn, and `correction_current` / `max_correctable_overlap` / `plot_efc_ntv_limits` turn them into the error field a correction system can cancel within a torque budget.

## Regression report

```
Regression Report: diiid_n1
=================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
Ref 2: local  @ local (2026-09-11)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 112 threads/1 BLAS
-------------------------------------------------------------------------------------------------
Quantity                                      develop          local            Diff       Status
-------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01     0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05     0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00    0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00     0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01     0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]        0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]        0.0e+00    OK    
ODE steps (saved)                             2576             2576             0.0e+00    OK    
ODE steps (total)                             4572             4572             0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00     0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00     0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02     0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00     0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01     0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01     0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01     0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01     0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01     0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01     0.0e+00    OK    
# singular surfaces                           5                5                0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]         0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]         0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01     0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01     0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00     0.0e+00    OK    
mpert                                         35               35               0.0e+00    OK    
npert                                         1                1                0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00     0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01     0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00     0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00     0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...  identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...  identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...  identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...  identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...  identical  OK    
island half-widths                            [5 elem]         [5 elem]         0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]         0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04     0.0e+00    OK    
dominant-coupling singular values             N/A              [5 elem]         N/A        N/A   
|forcing overlap with dominant mode|          N/A              3.284975e-02     N/A        N/A   
|delta_nominal| of coil set 1                 N/A              1.637107e-02                N/A   
||ddelta/d(shift)|| over coil sets            N/A              2.998822e-02                N/A   
||ddelta/d(tilt)|| over coil sets             N/A              1.012616e-04                N/A   
PE plasma energy                              3.422677e+00     3.422677e+00     0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00     0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00     0.0e+00    OK    
PE toroidal torque                            5.087465e-02     5.087465e-02     0.0e+00    OK    
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01     0.0e+00    OK    
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02     0.0e+00    OK    
Runtime (s)                                   295.4s           304.6s                      --    
resonant area-weighted field b^r              [5 elem]         [5 elem]         0.0e+00    OK    
=================================================================================================
Summary: 47 unchanged, 5 missing/N/A
```

## Notes for reviewers

- Stacked on #453 (base branch `feature/errorfields-analysis-plots`), including its winding-sense normalization fix; `efc_couplings` uses the same magnitude normalization.
- Two device-specific assumptions were removed after the first draft: `efc_couplings` now takes the run's `[ForcingTerms]` `CoilConfig` instead of a hard-coded boundary grid (the sensitivities and the correction spectra are evaluated on the same grid), and the NTV torques are stored with their sign while the limits use their magnitude (OMFIT's script only worked because the original device's torques happened to be positive; a negative torque is budget spent, not no torque).
- The DIII-D example now runs KineticForces (its own stage plus two evaluations for the C-coil), which adds a few minutes to that example; the harness case is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu

