### PR TITLE
ForcingTerms - BUGFIX! - Take the coil-grid helicity from the equilibrium file's current sign

### DIFF
--- a/src/Analysis/CoilForcing.jl
+++ b/src/Analysis/CoilForcing.jl
@@ -238,11 +238,7 @@ function plot_mode_spectrum(forcing_modes; mlow=nothing, mhigh=nothing, save_pat
 end
 
 # Helicity = sign(Bt)·sign(Ip); the SFL→machine toroidal-angle handedness.
-function _equil_helicity(equil)
-    bt = isnothing(equil.params.bt_sign) ? 1 : Int(sign(equil.params.bt_sign))
-    ip = isnothing(equil.params.crnt) ? 1 : Int(sign(equil.params.crnt))
-    return bt * ip
-end
+_equil_helicity(equil) = equil.params.bt_sign * equil.params.ip_sign
 
 # Unpack `modes` (a Vector of ForcingMode-like objects filtered to toroidal mode `n`,
 # or a `(m_vals, amplitudes)` tuple) into parallel m and complex-amplitude vectors.

--- a/src/Equilibrium/AnalyticEquilibrium.jl
+++ b/src/Equilibrium/AnalyticEquilibrium.jl
@@ -242,10 +242,10 @@ Reference: R. Fitzpatrick, TJ code, https://github.com/rfitzp/TJ
 function tj_analytic_f1(x::Float64, nu::Float64, qc::Float64)
     if x < 0.1
         x2 = x * x
-        return x2 * (1 - (nu-1)*x2/2 + (nu-1)*(nu-2)*x2*x2/6 -
-                      (nu-1)*(nu-2)*(nu-3)*x2*x2*x2/24) / qc
+        return x2 * (1 - (nu - 1) * x2 / 2 + (nu - 1) * (nu - 2) * x2 * x2 / 6 -
+                     (nu - 1) * (nu - 2) * (nu - 3) * x2 * x2 * x2 / 24) / qc
     else
-        return (1 - (1 - x*x)^nu) / (nu * qc)
+        return (1 - (1 - x * x)^nu) / (nu * qc)
     end
 end
 
@@ -259,10 +259,10 @@ parameterization.
 function tj_analytic_f1p(x::Float64, nu::Float64, qc::Float64)
     if x < 0.1
         x2 = x * x
-        return 2*x * (1 - (nu-1)*x2 + (nu-1)*(nu-2)*x2*x2/2 -
-                       (nu-1)*(nu-2)*(nu-3)*x2*x2*x2/6) / qc
+        return 2 * x * (1 - (nu - 1) * x2 + (nu - 1) * (nu - 2) * x2 * x2 / 2 -
+                        (nu - 1) * (nu - 2) * (nu - 3) * x2 * x2 * x2 / 6) / qc
     else
-        return 2*x * (1 - x*x)^(nu-1) / qc
+        return 2 * x * (1 - x * x)^(nu - 1) / qc
     end
 end
 
@@ -273,10 +273,11 @@ GPEC adaptation of the analytic shape ODE used in R. Fitzpatrick's TJ code
 `tj_analytic_run_direct` call so both pipelines share identical numerics.
 
 Fields:
+
   - physical: a, R0, qc, mu, pc, B0
   - derived:  epsa2 = (a/R0)²
   - near-axis BC constants: rmin, x0 = rmin, r0 = rmin·a, f1c = 1/qc,
-                             p2ppc = d²p₂/dx²|_0 = −2·μ·pc
+    p2ppc = d²p₂/dx²|_0 = −2·μ·pc
 """
 struct TJAnalyticShapeParams
     a::Float64
@@ -293,15 +294,15 @@ struct TJAnalyticShapeParams
     p2ppc::Float64
 end
 
-function TJAnalyticShapeParams(tj::TJAnalyticConfig; rmin::Float64 = 1e-4)
+function TJAnalyticShapeParams(tj::TJAnalyticConfig; rmin::Float64=1e-4)
     a, R0 = tj.lar_a, tj.lar_r0
-    mu    = max(tj.mu, 1.001)
+    mu = max(tj.mu, 1.001)
     return TJAnalyticShapeParams(
         a, R0, tj.qc, mu, tj.pc, tj.B0,
         (a / R0)^2,
         rmin, rmin, rmin * a,
         1.0 / tj.qc,
-        -2.0 * mu * tj.pc,
+        -2.0 * mu * tj.pc
     )
 end
 
@@ -315,9 +316,9 @@ The params argument carries TJAnalyticShapeParams fields plus the current `nu`.
 """
 function tj_analytic_shape_rhs!(dy, y, params, r)
     (; a, B0, qc, mu, pc, epsa2, nu) = params
-    x    = r / a
+    x = r / a
     xfac = max(1 - x^2, 0.0)
-    f1   = tj_analytic_f1(x, nu, qc)
+    f1 = tj_analytic_f1(x, nu, qc)
     f1px = tj_analytic_f1p(x, nu, qc)
     p2px = -2 * mu * pc * x * xfac^(mu - 1)
 
@@ -340,16 +341,19 @@ function tj_analytic_shape_rhs!(dy, y, params, r)
     # f₃'(x) for Hₙ = Vₙ = 0 (n ≥ 2 harmonics rescaled to zero, as in the
     # TJ-analytic benchmark configuration of Fitzpatrick's TJ code).
     g2, f3 = y[2], y[5]
-    f3p_x = -f3 * f1px / f1 -
-             f1 * (3 * x^2 / 2 - 2 * x * H1p + H1p^2) / x +
-             f1px * (g2 - 3 * x^2 / 4 + H1 + 3 * H1p^2 / 2) +
-             x^2 * p2px * (g2 + x^2 / 2 - 3 * x * H1p - 2 * H1) / f1
+    f3p_x =
+        -f3 * f1px / f1 -
+        f1 * (3 * x^2 / 2 - 2 * x * H1p + H1p^2) / x +
+        f1px * (g2 - 3 * x^2 / 4 + H1 + 3 * H1p^2 / 2) +
+        x^2 * p2px * (g2 + x^2 / 2 - 3 * x * H1p - 2 * H1) / f1
     dy[5] = f3p_x / a
     return nothing
 end
 
-"""Initial conditions at x = x0, matching the TJ-analytic model's near-axis
-expansion (cf. R. Fitzpatrick's TJ code, https://github.com/rfitzp/TJ)."""
+"""
+Initial conditions at x = x0, matching the TJ-analytic model's near-axis
+expansion (cf. R. Fitzpatrick's TJ code, https://github.com/rfitzp/TJ).
+"""
 function tj_analytic_shape_initial(p::TJAnalyticShapeParams, nu::Float64)
     f1_0 = tj_analytic_f1(p.x0, nu, p.qc)
     y0 = zeros(5)
@@ -368,14 +372,14 @@ downstream Hₙ / ψ splines sit on uniform nodes); leave it `nothing` for
 the default adaptive save pattern used by `tj_analytic_run`.
 """
 function tj_analytic_shape_solve(p::TJAnalyticShapeParams, nu::Float64;
-                        reltol::Float64 = 1e-7, abstol::Float64 = 1e-8,
-                        saveat = nothing)
-    rhs_params = (; p.a, p.B0, p.qc, p.mu, p.pc, p.epsa2, nu = nu)
+    reltol::Float64=1e-7, abstol::Float64=1e-8,
+    saveat=nothing)
+    rhs_params = (; p.a, p.B0, p.qc, p.mu, p.pc, p.epsa2, nu=nu)
     prob = ODEProblem(tj_analytic_shape_rhs!, tj_analytic_shape_initial(p, nu), (p.r0, p.a), rhs_params)
     if saveat === nothing
-        return solve(prob, Vern9(); reltol, abstol, maxiters = 10000, dense = false)
+        return solve(prob, Vern9(); reltol, abstol, maxiters=10000, dense=false)
     else
-        return solve(prob, Vern9(); reltol, abstol, maxiters = 10000, saveat = saveat)
+        return solve(prob, Vern9(); reltol, abstol, maxiters=10000, saveat=saveat)
     end
 end
 
@@ -389,9 +393,9 @@ O(εa²) correction relative to the lowest-order guess ν = qa/qc, which
 matters for the TJ-analytic benchmark at large ε.  Falls back to the
 lowest-order ν if the bracket search diverges.
 """
-function tj_analytic_find_nu(p::TJAnalyticShapeParams, qa_target::Float64; reltol::Float64 = 1e-7)
+function tj_analytic_find_nu(p::TJAnalyticShapeParams, qa_target::Float64; reltol::Float64=1e-7)
     function q2_edge(nu::Float64)
-        sol   = tj_analytic_shape_solve(p, nu; reltol)
+        sol = tj_analytic_shape_solve(p, nu; reltol)
         g2end = sol.u[end][2]
         f3end = sol.u[end][5]
         f1end = tj_analytic_f1(1.0, nu, p.qc)
@@ -400,7 +404,7 @@ function tj_analytic_find_nu(p::TJAnalyticShapeParams, qa_target::Float64; relto
     nu_guess = qa_target / p.qc
     return try
         find_zero(nu -> q2_edge(nu) - qa_target, (0.5 * nu_guess, 2 * nu_guess);
-                  atol = 1e-8, rtol = 1e-10)
+            atol=1e-8, rtol=1e-10)
     catch err
         @warn "ν root-find failed for TJ-analytic equilibrium; falling back to lowest-order ν = qa/qc" error = err
         nu_guess
@@ -443,16 +447,16 @@ included; they are zero in the TJ-analytic benchmark scans.
 Reference: R. Fitzpatrick, TJ code, https://github.com/rfitzp/TJ
 """
 function tj_analytic_run(equil_input::EquilibriumConfig, tj::TJAnalyticConfig)
-    a, R0  = tj.lar_a, tj.lar_r0
+    a, R0 = tj.lar_a, tj.lar_r0
     qc, mu = tj.qc, max(tj.mu, 1.001)
     pc, B0 = tj.pc, tj.B0
     ma, mtau = tj.ma, tj.mtau
     p = TJAnalyticShapeParams(tj)
-    epsa2     = p.epsa2
-    p00_phys  = B0^2 * epsa2 * pc          # μ₀P = B₀²·εa²·p₂ at axis
+    epsa2 = p.epsa2
+    p00_phys = B0^2 * epsa2 * pc          # μ₀P = B₀²·εa²·p₂ at axis
 
-    nu  = tj_analytic_find_nu(p, tj.qa; reltol = equil_input.etol)
-    sol = tj_analytic_shape_solve(p, nu; reltol = equil_input.etol)
+    nu = tj_analytic_find_nu(p, tj.qa; reltol=equil_input.etol)
+    sol = tj_analytic_shape_solve(p, nu; reltol=equil_input.etol)
 
     r_arr = sol.t
     y_mat = reduce(hcat, sol.u)'
@@ -468,7 +472,7 @@ function tj_analytic_run(equil_input::EquilibriumConfig, tj::TJAnalyticConfig)
         xfac = max(1 - x^2, 0.0)
         f1 = tj_analytic_f1(x, nu, qc)
 
-        ψ  = y_mat[i, 1]
+        ψ = y_mat[i, 1]
         g2 = y_mat[i, 2]
         H1 = y_mat[i, 3]
         f3 = y_mat[i, 5]
@@ -507,7 +511,7 @@ function tj_analytic_run(equil_input::EquilibriumConfig, tj::TJAnalyticConfig)
         f = spl(r; hint=hint)
         # f[1]=F, f[2]=P, f[3]=q, f[4]=ψ, f[5]=g₂, f[6]=H₁
 
-        sq_xs[ia]    = f[4] / psio
+        sq_xs[ia] = f[4] / psio
         sq_fs[ia, 1] = f[1]           # F
         sq_fs[ia, 2] = f[2]           # P
         sq_fs[ia, 3] = f[3]           # q
@@ -525,7 +529,7 @@ function tj_analytic_run(equil_input::EquilibriumConfig, tj::TJAnalyticConfig)
         for itau in 1:(mtau+1)
             θ = 2π * (itau - 1) / mtau
             rzphi_fs_nodes[ia, itau, 1] = R0 + Δ + α * r * cos(θ)
-            rzphi_fs_nodes[ia, itau, 2] =          α * r * sin(θ)
+            rzphi_fs_nodes[ia, itau, 2] = α * r * sin(θ)
         end
     end
 
@@ -579,38 +583,38 @@ ODE (g₂, H₁, H₁', f₃), the `GetPSIvac` / `GetHHvac` vacuum extension, an
 EFIT-writer (R, Z) → (r, w) Newton inversion that this routine adapts.
 """
 function tj_analytic_run_direct(equil_input::EquilibriumConfig, tj::TJAnalyticConfig;
-                       nrbox::Int = 257, nzbox::Int = 257, rc::Float64 = 1.2)
-    a, R0  = tj.lar_a, tj.lar_r0
+    nrbox::Int=257, nzbox::Int=257, rc::Float64=1.2)
+    a, R0 = tj.lar_a, tj.lar_r0
     qc, mu = tj.qc, max(tj.mu, 1.001)
     pc, B0 = tj.pc, tj.B0
     p = TJAnalyticShapeParams(tj)
     epsa, epsa2 = p.a / p.R0, p.epsa2
-    p00_phys    = B0^2 * epsa2 * pc
+    p00_phys = B0^2 * epsa2 * pc
 
     # ν root-find (cf. Fitzpatrick TJ's Setnu): q₂(1) = qa_target.
-    nu = tj_analytic_find_nu(p, tj.qa; reltol = equil_input.etol)
+    nu = tj_analytic_find_nu(p, tj.qa; reltol=equil_input.etol)
 
     # Dense saveat so the downstream splines (H₁, g₂, f₃, ψ) are evaluated on
     # a fine uniform r grid rather than the ~30 adaptive Vern9 steps — otherwise
     # the (R, Z) → (r, w) Newton iteration hits spline interpolation artifacts.
-    dense_r = collect(range(p.r0, p.a; length = 1024))
-    sol     = tj_analytic_shape_solve(p, nu; reltol = equil_input.etol,
-                              abstol = 1e-10, saveat = dense_r)
-    r_arr   = sol.t
-    y_mat   = reduce(hcat, sol.u)'
+    dense_r = collect(range(p.r0, p.a; length=1024))
+    sol = tj_analytic_shape_solve(p, nu; reltol=equil_input.etol,
+        abstol=1e-10, saveat=dense_r)
+    r_arr = sol.t
+    y_mat = reduce(hcat, sol.u)'
 
     # Radial splines in the TJ-analytic dimensionless x = r/a on a clean grid for H₁ etc.
     x_nodes = r_arr ./ a
-    ψ_of_r   = cubic_interp(r_arr, y_mat[:, 1]; extrap=ExtendExtrap())
-    H1_of_x  = cubic_interp(x_nodes, y_mat[:, 3]; extrap=ExtendExtrap())
+    ψ_of_r = cubic_interp(r_arr, y_mat[:, 1]; extrap=ExtendExtrap())
+    H1_of_x = cubic_interp(x_nodes, y_mat[:, 3]; extrap=ExtendExtrap())
     H1p_of_x = cubic_interp(x_nodes, y_mat[:, 4]; extrap=ExtendExtrap())
-    g2_of_x  = cubic_interp(x_nodes, y_mat[:, 2]; extrap=ExtendExtrap())
-    f3_of_x  = cubic_interp(x_nodes, y_mat[:, 5]; extrap=ExtendExtrap())
+    g2_of_x = cubic_interp(x_nodes, y_mat[:, 2]; extrap=ExtendExtrap())
+    f3_of_x = cubic_interp(x_nodes, y_mat[:, 5]; extrap=ExtendExtrap())
 
     # Edge values needed by GetPSIvac
-    f1a  = tj_analytic_f1(1.0, nu, qc)
-    f3a  = f3_of_x(1.0)
-    H1a  = H1_of_x(1.0)
+    f1a = tj_analytic_f1(1.0, nu, qc)
+    f3a = f3_of_x(1.0)
+    H1a = H1_of_x(1.0)
     H1ap = H1p_of_x(1.0)
     psio = ψ_of_r(a)   # ψ at r = a (boundary)
 
@@ -644,7 +648,7 @@ function tj_analytic_run_direct(equil_input::EquilibriumConfig, tj::TJAnalyticCo
             return f_R_shift(rc - 1e-8, w) * r^2 / rc^2
         end
         H1 = (r < 1.0) ? H1_of_x(r) : H1_vac(r)
-        L  = r^3 / 8 - r * H1 / 2
+        L = r^3 / 8 - r * H1 / 2
         return epsa2 * H1 + epsa2 * epsa * L * cos(w)
     end
     function f_Z_shift(r::Float64, w::Float64)
@@ -652,7 +656,7 @@ function tj_analytic_run_direct(equil_input::EquilibriumConfig, tj::TJAnalyticCo
             return f_Z_shift(rc - 1e-8, w) * r^2 / rc^2
         end
         H1 = (r < 1.0) ? H1_of_x(r) : H1_vac(r)
-        L  = r^3 / 8 - r * H1 / 2
+        L = r^3 / 8 - r * H1 / 2
         return -epsa2 * epsa * L * sin(w)
     end
 
@@ -699,9 +703,9 @@ function tj_analytic_run_direct(equil_input::EquilibriumConfig, tj::TJAnalyticCo
     # Grid spans R₀ ± rc·a × ±rc·a (where rc is the vacuum-shell radius in
     # units of a), giving a comfortable margin for the separatrix finder.
     r_span = rc * a
-    psi_in_xs = collect(range(R0 - r_span, R0 + r_span; length = nrbox))
-    psi_in_ys = collect(range(-r_span, r_span; length = nzbox))
-    psi_rz    = zeros(Float64, nrbox, nzbox)
+    psi_in_xs = collect(range(R0 - r_span, R0 + r_span; length=nrbox))
+    psi_in_ys = collect(range(-r_span, r_span; length=nzbox))
+    psi_rz = zeros(Float64, nrbox, nzbox)
 
     for i in 1:nrbox, j in 1:nzbox
         R_norm = psi_in_xs[i] / R0
@@ -724,8 +728,10 @@ function tj_analytic_run_direct(equil_input::EquilibriumConfig, tj::TJAnalyticCo
     # 1D profile spline, same layout as read_efit (4 columns).  Use the
     # TJ-analytic q₂ on the radial grid so that the prescribed q is
     # consistent with the ψ(R,Z) we just constructed.
-    psi_norm_grid = range(0.0, 1.0; length = nrbox)
-    F_nodes  = zeros(nrbox); P_nodes = zeros(nrbox); q_nodes = zeros(nrbox)
+    psi_norm_grid = range(0.0, 1.0; length=nrbox)
+    F_nodes = zeros(nrbox)
+    P_nodes = zeros(nrbox)
+    q_nodes = zeros(nrbox)
     for i in 1:nrbox
         ψN = psi_norm_grid[i]
         # Invert ψN = (ψ_plasma(r) - 0) / psio  ⇒  find r such that ψ_plasma(r) = ψN·psio.
@@ -746,7 +752,7 @@ function tj_analytic_run_direct(equil_input::EquilibriumConfig, tj::TJAnalyticCo
         F_nodes[i] = R0 * B0 * (1 + epsa2 * g2_val)
         P_nodes[i] = p00_phys * xfac^mu
         q_nodes[i] = (x > 1e-10) ? x^2 * (1 + epsa2 * g2_val) *
-                                    exp(-epsa2 * f3_val / f1) / f1 : qc
+                                   exp(-epsa2 * f3_val / f1) / f1 : qc
     end
     sq_fs_nodes = hcat(F_nodes, P_nodes, q_nodes, sqrt.(collect(psi_norm_grid)))
     sq_in = cubic_interp(collect(psi_norm_grid), Series(sq_fs_nodes); extrap=ExtendExtrap())
@@ -756,7 +762,7 @@ function tj_analytic_run_direct(equil_input::EquilibriumConfig, tj::TJAnalyticCo
 
     # Analytic: ingest=nothing — replay regenerates from the [TJ_ANALYTIC_INPUT] TOML section.
     return DirectRunInput(equil_input, sq_in, psi_in, psi_in_xs, psi_in_ys,
-                          rmin_grid, rmax_grid, zmin_grid, zmax_grid, psio, 1, nothing)
+        rmin_grid, rmax_grid, zmin_grid, zmax_grid, psio, 1, 1, nothing)
 end
 
 """
@@ -836,7 +842,6 @@ function sol_run(equil_inputs::EquilibriumConfig, sol_inputs::SolovevConfig)
     @info "Generating Solovev equilibrium: mr=$mr, mz=$mz, ma=$ma, e=$(@sprintf("%.3f", e)), a=$(@sprintf("%.3f", a)), r0=$(@sprintf("%.3f", r0)), q0=$(@sprintf("%.3f", q0))"
 
     # 1 is bt_sign=+1: Solovev has positive Bt by construction (f0 = r0 * b0fac > 0).
-    # No ip_sign field is needed; sign(crnt) is recovered from params.crnt downstream.
-    # Analytic: ingest=nothing — replay regenerates from the [SOL_INPUT] TOML section.
-    return DirectRunInput(equil_inputs, sq_in, psi_in, psi_in_xs, psi_in_ys, rmin, rmax, zmin, zmax, psio, 1, nothing)
+    # Analytic equilibria carry positive field and current; ingest=nothing — replay regenerates from the [SOL_INPUT] TOML section.
+    return DirectRunInput(equil_inputs, sq_in, psi_in, psi_in_xs, psi_in_ys, rmin, rmax, zmin, zmax, psio, 1, 1, nothing)
 end

--- a/src/Equilibrium/DirectEquilibrium.jl
+++ b/src/Equilibrium/DirectEquilibrium.jl
@@ -654,6 +654,7 @@ robustness.
 
     params = EquilibriumParameters()
     params.bt_sign = raw_profile.bt_sign
+    params.ip_sign = raw_profile.ip_sign
     params.psihigh_resolved = psihigh
 
     return PlasmaEquilibrium(raw_profile.config, params, profiles, geometry,

--- a/src/Equilibrium/EquilibriumTypes.jl
+++ b/src/Equilibrium/EquilibriumTypes.jl
@@ -245,7 +245,9 @@ A mutable struct holding parameters for the Large Aspect Ratio (LAR) plasma equi
     zeroth::Bool = false
 end
 
-"Build a `LargeAspectRatioConfig` from a parsed `[LAR_INPUT]` TOML table."
+"""
+Build a `LargeAspectRatioConfig` from a parsed `[LAR_INPUT]` TOML table.
+"""
 function LargeAspectRatioConfig(input_dict::Dict{String,Any})
     return LargeAspectRatioConfig(; symbolize_keys(input_dict)...)
 end
@@ -285,7 +287,9 @@ Reference: R. Fitzpatrick, TJ code, https://github.com/rfitzp/TJ
     zeroth::Bool = false       # If true, suppress Shafranov shift
 end
 
-"Build a `TJAnalyticConfig` from a parsed `[TJ_ANALYTIC_INPUT]` TOML table."
+"""
+Build a `TJAnalyticConfig` from a parsed `[TJ_ANALYTIC_INPUT]` TOML table.
+"""
 function TJAnalyticConfig(input_dict::Dict{String,Any})
     return TJAnalyticConfig(; symbolize_keys(input_dict)...)
 end
@@ -321,7 +325,9 @@ A mutable struct holding parameters for the Solev'ev (SOL) plasma equilibrium mo
     f0fac::Float64 = 1       # scale toroidal field at constant pressure (s*f. beta,q changes. Phi,p,bp constant)
 end
 
-"Build a `SolovevConfig` from a parsed `[SOL_INPUT]` TOML table."
+"""
+Build a `SolovevConfig` from a parsed `[SOL_INPUT]` TOML table.
+"""
 function SolovevConfig(input_dict::Dict{String,Any})
     return SolovevConfig(; symbolize_keys(input_dict)...)
 end
@@ -346,6 +352,7 @@ not serializable; they are reconstructed from these nodes by `build_direct_from_
   - `rmin/rmax/zmin/zmax::Float64` — computational-grid bounds [m]
   - `psio::Float64` — total flux difference |ψ_axis - ψ_boundary| [Wb/rad]
   - `bt_sign::Int` — sign of the toroidal field (+1 or -1)
+  - `ip_sign::Int` — sign of the plasma current (+1 or -1) as the source file states it
 """
 struct DirectIngest
     sq_xs::Vector{Float64}
@@ -359,6 +366,7 @@ struct DirectIngest
     zmax::Float64
     psio::Float64
     bt_sign::Int
+    ip_sign::Int
 end
 
 """
@@ -438,6 +446,10 @@ raw equilibrium data and preparing the initial splines.
   - `zmax::Float64` — Maximum Z-coordinate of the computational grid [m]
   - `psio::Float64` — Total flux difference `|ψ_axis - ψ_boundary|` [Wb/rad]
   - `bt_sign::Int` — Sign of the toroidal field (+1 or -1); read from fpol sign in EFIT g-files
+  - `ip_sign::Int` — Sign of the plasma current (+1 or -1); read from the `current` header value
+    in EFIT g-files and `global_quantities.ip` in IMAS. The internal flux is always made
+    positive at the axis, so the sign is kept here (never recovered from the computed current)
+    and fixes the SFL→machine toroidal-angle handedness `helicity = bt_sign × ip_sign`.
   - `ingest::EquilibriumIngest` — captured raw arrays for the `gpec.h5` rerun snapshot
     (a [`DirectIngest`](@ref) for file-based reads, or `nothing` for analytic equilibria)
   - `psihigh_resolved::Float64` — outer flux limit the equilibrium is formed on: `config.psihigh`
@@ -459,6 +471,7 @@ mutable struct DirectRunInput{S<:FastInterpolations.CubicSeriesInterpolant,I2D<:
     zmax::Float64    # Maximum Z-coordinate of the computational grid [m].
     psio::Float64    # The total flux difference |ψ_axis - ψ_boundary| [Weber / radian].
     bt_sign::Int     # Sign of the toroidal field: +1 or -1 (from fpol sign in g-file)
+    ip_sign::Int     # Sign of the plasma current: +1 or -1 (from the g-file current / IMAS ip)
     ingest::EquilibriumIngest
     psihigh_resolved::Float64
 end
@@ -466,9 +479,9 @@ end
 # Readers construct without a resolved psihigh; it starts at the request and `resolve_psihigh!`
 # clamps it for efit-family equilibria.
 DirectRunInput(config::EquilibriumConfig, sq_in, psi_in, psi_in_xs, psi_in_ys,
-    rmin, rmax, zmin, zmax, psio, bt_sign, ingest) =
+    rmin, rmax, zmin, zmax, psio, bt_sign, ip_sign, ingest) =
     DirectRunInput(config, sq_in, psi_in, psi_in_xs, psi_in_ys,
-        rmin, rmax, zmin, zmax, psio, bt_sign, ingest, config.psihigh)
+        rmin, rmax, zmin, zmax, psio, bt_sign, ip_sign, ingest, config.psihigh)
 
 """
     InverseRunInput(...)
@@ -610,6 +623,7 @@ A mutable struct containing computed equilibrium parameters and diagnostic flags
     bt0::Union{Nothing,Float64} = nothing # Toroidal magnetic field at the axis [T] (always positive; sign in bt_sign)
     crnt::Union{Nothing,Float64} = nothing # Plasma current at the axis [A]
     bt_sign::Int = 1 # Sign of the toroidal field: +1 (positive Bt) or -1 (negative Bt, e.g. DIII-D standard)
+    ip_sign::Int = 1 # Sign of the plasma current as the source file states it: +1 or -1 (crnt is always positive)
     bwall::Union{Nothing,Float64} = nothing # Toroidal magnetic field at the wall [T]
     verbose::Bool = false # Whether to print verbose output
     diagnose_src::Bool = false # Whether to diagnose source data
@@ -749,7 +763,7 @@ function GeometryProfileSplines(xs::Vector{Float64},
 
     GeometryProfileSplines{typeof(area_spline)}(
         xs, npts, npts - 1,
-        area_spline, avg_r_spline, avg_R_spline,
+        area_spline, avg_r_spline, avg_R_spline
     )
 end
 
@@ -828,7 +842,7 @@ function KineticProfileSplines(xs::Vector{Float64},
         xs, npts, npts - 1,
         ni_spline, ne_spline, Ti_spline, Te_spline,
         omegaE_spline, loglam_spline, nui_spline, nue_spline, zeff_spline,
-        ni_deriv, ne_deriv, Ti_deriv, Te_deriv,
+        ni_deriv, ne_deriv, Ti_deriv, Te_deriv
     )
 end
 

--- a/src/Equilibrium/ReadEquilibrium.jl
+++ b/src/Equilibrium/ReadEquilibrium.jl
@@ -67,6 +67,8 @@ function read_efit(config::EquilibriumConfig)
     header_vals = _read_1d_gfile_format(lines[2:5], 20)
     rdim, zdim, rcentr, rleft, zmid = header_vals[1:5]
     rmaxis, zmaxis, simag, sibry = header_vals[6:9]
+    ip_sign = Int(sign(header_vals[11]))  # the g-file's plasma current; its sign sets the helicity
+    ip_sign == 0 && (ip_sign = 1)
 
     # --- Parse Data Blocks ---
     current_line_idx = 6
@@ -120,9 +122,9 @@ function read_efit(config::EquilibriumConfig)
 
     # Capture the raw arrays that reconstruct sq_in and psi_in, so the rerun path
     # (gpec.h5 → setup_equilibrium) can skip the g-file parse entirely.
-    ingest = DirectIngest(sq_xs, sq_fs_nodes, psi_in_xs, psi_in_ys, psi_proc, rmin, rmax, zmin, zmax, psio, fpol_sign)
+    ingest = DirectIngest(sq_xs, sq_fs_nodes, psi_in_xs, psi_in_ys, psi_proc, rmin, rmax, zmin, zmax, psio, fpol_sign, ip_sign)
 
-    return DirectRunInput(config, sq_in, psi_in, psi_in_xs, psi_in_ys, rmin, rmax, zmin, zmax, psio, fpol_sign, ingest)
+    return DirectRunInput(config, sq_in, psi_in, psi_in_xs, psi_in_ys, rmin, rmax, zmin, zmax, psio, fpol_sign, ip_sign, ingest)
 end
 
 
@@ -152,7 +154,7 @@ function read_chease_binary(config::EquilibriumConfig)
 
         # 1D array allocation
         zcpr, zcppr, zq, zdq, ztmf, ztp, zfb, zfbp, zpsi, zpsim =
-            [zeros(i == 1 || i == 10 ? npsi1-1 : npsi1) for i in 1:10]
+            [zeros(i == 1 || i == 10 ? npsi1 - 1 : npsi1) for i in 1:10]
 
         for arr in (zcpr, zcppr, zq, zdq, ztmf, ztp, zfb, zfbp, zpsi, zpsim)
             read(io, UInt32)
@@ -275,7 +277,7 @@ function read_chease_ascii(config::EquilibriumConfig)
         data = Float64[]
         for line in lines[lines_range]
             for i in 0:4
-                s = strip(line[(22*i+1):min(end, 22*(i+1))])
+                s = strip(line[(22*i+1):min(end, 22 * (i + 1))])
                 if !isempty(s)
                     push!(data, parse(Float64, s))
                 end
@@ -405,7 +407,7 @@ function build_direct_from_ingest(config::EquilibriumConfig, ingest::DirectInges
     sq_in = cubic_interp(ingest.sq_xs, Series(ingest.sq_fs); extrap=ExtendExtrap())
     psi_in = cubic_interp((ingest.psi_xs, ingest.psi_ys), ingest.psi_rz; extrap=ExtendExtrap())
     return DirectRunInput(config, sq_in, psi_in, ingest.psi_xs, ingest.psi_ys,
-        ingest.rmin, ingest.rmax, ingest.zmin, ingest.zmax, ingest.psio, ingest.bt_sign, ingest)
+        ingest.rmin, ingest.rmax, ingest.zmin, ingest.zmax, ingest.psio, ingest.bt_sign, ingest.ip_sign, ingest)
 end
 
 """
@@ -432,15 +434,18 @@ Load an equilibrium from an IMAS data dictionary and return a `DirectRunInput`.
 The `dd.equilibrium.time_slice[]` is used (active time slice). Poloidal flux is
 converted from the IMAS COCOS convention (set by `config.imas_cocos`) to the
 internal COCOS 2 convention:
+
   - `imas_cocos = 11` (default, IMAS standard): divide ψ by 2π
   - `imas_cocos = 2` (GPEC internal): no conversion
 
 ## Arguments
-- `config`: `EquilibriumConfig` with `eq_type = "imas"` and `imas_cocos` set.
-- `dd`: populated `IMASdd.dd` with `dd.equilibrium.time_slice[]` containing:
-  - `global_quantities.psi_axis`, `global_quantities.psi_boundary`
-  - `profiles_1d.psi`, `profiles_1d.f`, `profiles_1d.pressure`, `profiles_1d.q`
-  - `profiles_2d[1].grid.dim1` (R), `profiles_2d[1].grid.dim2` (Z), `profiles_2d[1].psi`
+
+  - `config`: `EquilibriumConfig` with `eq_type = "imas"` and `imas_cocos` set.
+  - `dd`: populated `IMASdd.dd` with `dd.equilibrium.time_slice[]` containing:
+
+      + `global_quantities.psi_axis`, `global_quantities.psi_boundary`
+      + `profiles_1d.psi`, `profiles_1d.f`, `profiles_1d.pressure`, `profiles_1d.q`
+      + `profiles_2d[1].grid.dim1` (R), `profiles_2d[1].grid.dim2` (Z), `profiles_2d[1].psi`
 """
 function read_imas(config::EquilibriumConfig, dd)
     @info "Processing IMAS equilibrium at global_time = $(dd.global_time) s"
@@ -480,6 +485,9 @@ function read_imas(config::EquilibriumConfig, dd)
     # Capture toroidal-field sign from the boundary F value before abs() below.
     bt_sign = isempty(f_1d) ? 1 : Int(sign(f_1d[end]))
     bt_sign == 0 && (bt_sign = 1)
+    # Plasma-current sign from the IMAS global quantity (missing or zero → +1).
+    ip_imas = hasproperty(eqt.global_quantities, :ip) ? eqt.global_quantities.ip : 0.0
+    ip_sign = ismissing(ip_imas) || ip_imas == 0 ? 1 : Int(sign(ip_imas))
 
     nw = length(psi_1d)
     psi_norm_grid = range(0.0, 1.0; length=nw)
@@ -528,7 +536,7 @@ function read_imas(config::EquilibriumConfig, dd)
           "\n    Z ∈ [$(round(zmin; sigdigits=4)), $(round(zmax; sigdigits=4))] m"
 
     # Capture the raw arrays so an IMAS run can be replayed from gpec.h5 without the dd source.
-    ingest = DirectIngest(sq_xs, sq_fs_nodes, psi_in_xs, psi_in_ys, Matrix(psi_proc), rmin, rmax, zmin, zmax, psio, bt_sign)
+    ingest = DirectIngest(sq_xs, sq_fs_nodes, psi_in_xs, psi_in_ys, Matrix(psi_proc), rmin, rmax, zmin, zmax, psio, bt_sign, ip_sign)
 
-    return DirectRunInput(config, sq_in, psi_in, psi_in_xs, psi_in_ys, rmin, rmax, zmin, zmax, psio, bt_sign, ingest)
+    return DirectRunInput(config, sq_in, psi_in, psi_in_xs, psi_in_ys, rmin, rmax, zmin, zmax, psio, bt_sign, ip_sign, ingest)
 end

--- a/src/ForcingTerms/CoilFourier.jl
+++ b/src/ForcingTerms/CoilFourier.jl
@@ -100,14 +100,15 @@ via periodic cubic splines on the resulting R(θ_norm), Z(θ_norm) data.
 
 The toroidal grid direction follows the Fortran GPEC convention:
 `phi_j = -helicity × 2π × j/nzeta`   where `helicity = sign(Bt) × sign(Ip)`.
-This is derived from `equil.params.bt_sign` and `equil.params.crnt`.
+This is derived from `equil.params.bt_sign` and `equil.params.ip_sign` (the signs the equilibrium
+file states; the computed current `crnt` is always positive and carries no direction).
 For DIII-D (Bt < 0, Ip > 0 → helicity = -1): phi increases with j (standard direction).
 For positive-helicity machines (Bt > 0, Ip > 0 → helicity = +1): phi decreases with j.
 """
 function sample_boundary_grid(equil::Equilibrium.PlasmaEquilibrium, mtheta::Int, nzeta::Int;
     psi::Float64=equil.rzphi_xs[end])
     # Build uniform theta grid (same convention as equil.rzphi_ys, but potentially finer)
-    theta_grid = range(0; length=mtheta, step=1.0/mtheta)
+    theta_grid = range(0; length=mtheta, step=1.0 / mtheta)
 
     R_arr = zeros(mtheta)
     Z_arr = zeros(mtheta)
@@ -136,10 +137,8 @@ function sample_boundary_grid(equil::Equilibrium.PlasmaEquilibrium, mtheta::Int,
 
     # Helicity sets the direction of the toroidal angle grid to match Fortran convention:
     #   phi_j = -helicity × 2π × j/nzeta,  helicity = sign(Bt) × sign(Ip)
-    bt_sign = !isnothing(equil.params.bt_sign) ? equil.params.bt_sign : 1
-    ip_sign = !isnothing(equil.params.crnt) ? Int(sign(equil.params.crnt)) : 1
-    helicity = bt_sign * ip_sign
-    phi_grid = collect(range(0; length=nzeta, step=(-helicity * 2π/nzeta)))
+    helicity = equil.params.bt_sign * equil.params.ip_sign
+    phi_grid = collect(range(0; length=nzeta, step=(-helicity * 2π / nzeta)))
 
     # Toroidal angle offset ν(ψ, θ_SFL): in SFL coordinates the physical toroidal angle at
     # grid point (θ_SFL, ζ_SFL) is  φ_phys = -helicity*(2π*ζ_SFL + ν(ψ,θ_SFL)).

--- a/src/HDF5Schema.jl
+++ b/src/HDF5Schema.jl
@@ -44,6 +44,7 @@ const EQUIL_H5_NAMES = Dict(
     :li2 => "l_i_2",
     :li3 => "l_i_3",
     :bt_sign => "B_T_sign",
+    :ip_sign => "I_p_sign",
     :psio => "psi_total"
 )
 const EQUIL_H5_SKIP = Set([:psi0, :psi_axis, :psi_axis_norm, :zsep, :verbose, :diagnose_src, :diagnose_maxima])
@@ -98,6 +99,7 @@ const MAIN_H5_ANNOTATIONS = [
     "Equilibrium/l_i_3" => (; long_name="internal inductance (definition 3)"),
     "Equilibrium/volume" => (; long_name="plasma volume", units="m^3"),
     "Equilibrium/B_T_sign" => (; long_name="sign of the toroidal field"),
+    "Equilibrium/I_p_sign" => (; long_name="sign of the plasma current as stated by the equilibrium file"),
     "Equilibrium/psi_norm" => (; long_name="normalized poloidal flux at the magnetic axis (0 by definition of ψ_N)"),
     "Equilibrium/psi_boundary" => (; long_name="poloidal flux at the plasma boundary in the internal normalized convention (1 by construction, not a Wb/rad datum)"),
     "Equilibrium/psi_boundary_norm" => (; long_name="normalized poloidal flux at the plasma boundary (1 by definition of ψ_N)"),
@@ -245,7 +247,7 @@ const MAIN_H5_ANNOTATIONS = [
     "SurfaceGeometries/Plasma/z" => (; long_name="Cartesian z of plasma-surface point cloud", units="m"),
     "SurfaceGeometries/Wall/x" => (; long_name="Cartesian x of wall point cloud", units="m"),
     "SurfaceGeometries/Wall/y" => (; long_name="Cartesian y of wall point cloud", units="m"),
-    "SurfaceGeometries/Wall/z" => (; long_name="Cartesian z of wall point cloud", units="m"),
+    "SurfaceGeometries/Wall/z" => (; long_name="Cartesian z of wall point cloud", units="m")
 ]
 
 # Euler-Lagrange operator matrices: same wording per letter, Ideal/ and Kinetic/ variants.
@@ -258,7 +260,7 @@ const _ELM_IDEAL_LETTERS = [
     ("H", "Euler-Lagrange primitive coefficient matrix H"),
     ("F", "Euler-Lagrange derived coefficient matrix F"),
     ("K", "Euler-Lagrange derived coefficient matrix K"),
-    ("G", "Euler-Lagrange derived coefficient matrix G"),
+    ("G", "Euler-Lagrange derived coefficient matrix G")
 ]
 # The kinetic branch overwrites only A, B, C, K, G and adds f0; D, E, H, F are shared
 # unchanged from the ideal set and are not re-emitted.
@@ -268,14 +270,19 @@ const _ELM_KINETIC_LETTERS = [
     ("C", "Euler-Lagrange primitive coefficient matrix C"),
     ("K", "Euler-Lagrange derived coefficient matrix K"),
     ("G", "Euler-Lagrange derived coefficient matrix G"),
-    ("f0", "raw kinetic component matrix f0"),
+    ("f0", "raw kinetic component matrix f0")
 ]
 const ELM_H5_ANNOTATIONS = vcat(
     ["ForceFreeStates/EulerLagrangeMatrices/psi" => (; long_name="normalized poloidal flux ψ_N grid of the operator matrices", scale="psi")],
-    ["ForceFreeStates/EulerLagrangeMatrices/Ideal/$l" =>
-        (; long_name="ideal " * d, dims=("psi", "mode_row", "mode_col"), attach=(1 => "ForceFreeStates/EulerLagrangeMatrices/psi",)) for (l, d) in _ELM_IDEAL_LETTERS],
-    ["ForceFreeStates/EulerLagrangeMatrices/Kinetic/$l" =>
-        (; long_name="kinetic-modified " * d, dims=("psi", "mode_row", "mode_col"), attach=(1 => "ForceFreeStates/EulerLagrangeMatrices/psi",)) for (l, d) in _ELM_KINETIC_LETTERS]
+    [
+        "ForceFreeStates/EulerLagrangeMatrices/Ideal/$l" =>
+            (; long_name="ideal " * d, dims=("psi", "mode_row", "mode_col"), attach=(1 => "ForceFreeStates/EulerLagrangeMatrices/psi",)) for (l, d) in _ELM_IDEAL_LETTERS
+    ],
+    [
+        "ForceFreeStates/EulerLagrangeMatrices/Kinetic/$l" =>
+            (; long_name="kinetic-modified " * d, dims=("psi", "mode_row", "mode_col"), attach=(1 => "ForceFreeStates/EulerLagrangeMatrices/psi",)) for
+        (l, d) in _ELM_KINETIC_LETTERS
+    ]
 )
 
 """

--- a/src/Rerun.jl
+++ b/src/Rerun.jl
@@ -37,12 +37,15 @@ function read_equilibrium_ingest(in_h5)
     haskey(in_h5, group_path) || return nothing
     group = in_h5[group_path]
     kind = read(group, "ingest_kind")
-    T = kind == "direct" ? Equilibrium.DirectIngest :
+    T =
+        kind == "direct" ? Equilibrium.DirectIngest :
         kind == "inverse" ? Equilibrium.InverseIngest :
         error("Unknown equilibrium ingest_kind in gpec.h5: $kind (expected \"direct\" or \"inverse\")")
     # Positional reconstruction: relies on the default constructor, so `fieldnames(T)` order
     # must match the struct definition and the field-by-field write in write_outputs_to_HDF5.
-    return T((read(group, String(f)) for f in fieldnames(T))...)
+    # Files written before the plasma-current sign was stored carry no ip_sign; they were all
+    # positive-current runs in effect, so that field defaults to +1.
+    return T((haskey(group, String(f)) ? read(group, String(f)) : (f == :ip_sign ? 1 : error("missing equilibrium ingest field $f in gpec.h5")) for f in fieldnames(T))...)
 end
 
 """
@@ -90,7 +93,7 @@ function parse_override_flag(expr::AbstractString)
         # Warn instead of silently stringifying a bare word, which would otherwise only fail
         # much later where the field expects a number/bool.
         @warn "Could not parse --override value as a TOML literal; storing it as a string. " *
-              "Quote it explicitly if a string was intended." key=lhs value=rhs error=e
+              "Quote it explicitly if a string was intended." key = lhs value = rhs error = e
         rhs
     end
 
@@ -281,9 +284,11 @@ function build_inputs_from_h5(args::Vector{String})
     elseif ingest isa Equilibrium.InverseIngest
         Equilibrium.build_inverse_from_ingest(eq_config, ingest)
     else
-        error("gpec.h5 has no equilibrium ingest and eq_type=$(eq_config.eq_type) is not analytic — cannot replay. " *
-              "A file-based eq_type needs a stored ingest (pre-ingest snapshots lack one); a new analytic kind must be " *
-              "registered in Equilibrium.ANALYTIC_EQ.")
+        error(
+            "gpec.h5 has no equilibrium ingest and eq_type=$(eq_config.eq_type) is not analytic — cannot replay. " *
+            "A file-based eq_type needs a stored ingest (pre-ingest snapshots lack one); a new analytic kind must be " *
+            "registered in Equilibrium.ANALYTIC_EQ."
+        )
     end
 
     return inputs, eq_config, additional_input, output_dir, current_git, preloaded_forcing, preloaded_coils

--- a/test/runtests_coils.jl
+++ b/test/runtests_coils.jl
@@ -1,6 +1,7 @@
 using Test
 using TOML
 using Statistics
+using Printf
 using HDF5
 using GeneralizedPerturbedEquilibrium
 using GeneralizedPerturbedEquilibrium.ForcingTerms
@@ -553,4 +554,35 @@ end
         @test byname["hoopA"].x ≈ sets_in[1].x
         @test byname["wp"].ncoil == 3
     end
+end
+
+# ---------------------------------------------------------------------------
+@testset "CoilFourier: helicity follows the g-file current sign" begin
+    # The internal flux is made positive at the axis, so the computed current is always
+    # positive; the handedness of the toroidal grid must come from the file's stated signs.
+    gfile = joinpath(@__DIR__, "..", "examples", "DIIID-like_ideal_example", "TkMkr_D3Dlike_Hmode.geqdsk")
+    lines = readlines(gfile)
+    flipped = tempname() * ".geqdsk"
+    open(flipped, "w") do io
+        for (i, l) in enumerate(lines)
+            if i == 4   # header line 4 starts with the plasma current
+                vals = [l[j:min(j + 15, end)] for j in 1:16:length(l)]
+                cur = -parse(Float64, strip(vals[1]))
+                l = @sprintf("%16.9E", cur) * l[17:end]
+            end
+            println(io, l)
+        end
+    end
+    cfg(path) = Equilibrium.EquilibriumConfig(; eq_filename=path, eq_type="efit", jac_type="hamada", grid_type="ldp", psilow=0.01, psihigh=0.99, mpsi=32, mtheta=64)
+    eq_pos = Equilibrium.setup_equilibrium(cfg(gfile))
+    eq_neg = Equilibrium.setup_equilibrium(cfg(flipped))
+    @test eq_pos.params.ip_sign == 1 && eq_neg.params.ip_sign == -1
+    @test eq_pos.params.bt_sign == eq_neg.params.bt_sign == -1
+    @test eq_pos.params.crnt > 0 && eq_neg.params.crnt > 0          # the computed current carries no sign
+    g_pos = ForcingTerms.sample_boundary_grid(eq_pos, 16, 8; psi=0.9)
+    g_neg = ForcingTerms.sample_boundary_grid(eq_neg, 16, 8; psi=0.9)
+    @test g_pos.phi_grid[2] ≈ 2π / 8                                # helicity −1: φ increases with j
+    @test g_neg.phi_grid[2] ≈ -2π / 8                               # helicity +1: φ decreases with j
+    @test g_neg.phi_offset ≈ -g_pos.phi_offset
+    rm(flipped)
 end


### PR DESCRIPTION
The toroidal handedness of the coil boundary grid, `helicity = sign(B_T) × sign(I_p)` (Fortran's `phi = -helicity*(2π ζ + ν)`), took the current sign from `equil.params.crnt`. That current is computed from the flux after the reader has made ψ positive at the axis, so it is always positive: every equilibrium file with a negative plasma current got the mirror image of its coil field. The DIII-D examples (positive I_p) were unaffected, which is why nothing caught it.

Found while benchmarking the error-field assessment of the original OMFIT project against its Fortran GPEC run: with everything else matched, the large axisymmetric coil sets' spectra correlated with Fortran's `Phi_coil` at only 0.5–0.8 while a toroidally localized set matched to four digits. With the sign taken from the file, every coil set's spectrum matches to four digits (correlation 1.0000, norms within 0.2 %).

**What changes**

- `DirectIngest`, `DirectRunInput` and `EquilibriumParameters` carry `ip_sign`, read from the g-file's `current` header value (`read_efit`) and from `global_quantities.ip` for IMAS; analytic equilibria are +1. `DirectEquilibrium` copies it into the parameters and `HDF5Schema` writes it as `Equilibrium/I_p_sign` next to `B_T_sign`.
- `ForcingTerms.sample_boundary_grid` and `Analysis.CoilForcing` form the helicity from `bt_sign × ip_sign`; the computed current is no longer consulted for a direction.
- `Rerun.read_equilibrium_ingest` accepts snapshots written before the field existed (they default to +1, which is what those runs effectively used).
- `test/runtests_coils.jl`: a DIII-D g-file and a copy with the current negated give `ip_sign` ±1, the same positive computed current, and opposite toroidal grid directions.

**What moves**: nothing for positive-current files (the harness case is DIII-D). Negative-current files get the correct coil spectra; their previous results were mirrored.

cc @matt-pharr

## Release note

- **Audience:** users
- **Numerical impact:** coil spectra of negative-I_p equilibria change _(harness @ 9674e1ef (message-only rewrite of 990dea6e): unchanged)_
- **Migration:** none

The coil boundary grid's helicity now takes the plasma-current sign from the equilibrium file (`Equilibrium/I_p_sign` in `gpec.h5`) instead of the computed current, which is always positive; negative-current equilibria previously received the mirror image of their coil field.

## Regression report

```
Regression Report: diiid_n1
================================================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 16 threads/16 BLAS
Ref 2: bugfix/forcingterms-helicity-from-current-sign  @ 990dea6e (2026-09-12)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 16 threads/16 BLAS
--------------------------------------------------------------------------------------------------------------------------------
Quantity                                      develop          bugfix/forcingterms-helicity-from-current-sign  Diff       Status
--------------------------------------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01                                    0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05                                    0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00                                   0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00                                    0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01                                    0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]                                       0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]                                       0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]                                       0.0e+00    OK    
ODE steps (saved)                             2576             2576                                            0.0e+00    OK    
ODE steps (total)                             4572             4572                                            0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00                                    0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00                                    0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02                                    0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00                                    0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01                                    0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01                                    0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01                                    0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01                                    0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01                                    0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01                                    0.0e+00    OK    
# singular surfaces                           5                5                                               0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]                                        0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]                                        0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01                                    0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01                                    0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00                                    0.0e+00    OK    
mpert                                         35               35                                              0.0e+00    OK    
npert                                         1                1                                               0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00                                    0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01                                    0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00                                    0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00                                    0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...                                 identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...                                 identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...                                 identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...                                 identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...                                 identical  OK    
island half-widths                            [5 elem]         [5 elem]                                        0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]                                        0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04                                    0.0e+00    OK    
dominant-coupling singular values             N/A              N/A                                             N/A        N/A   
|forcing overlap with dominant mode|          N/A              N/A                                             N/A        N/A   
|delta_nominal| of coil set 1                 N/A              N/A                                             N/A        N/A   
||ddelta/d(shift)|| over coil sets            N/A              N/A                                             N/A        N/A   
||ddelta/d(tilt)|| over coil sets             N/A              N/A                                             N/A        N/A   
PE plasma energy                              3.422677e+00     3.422677e+00                                    0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00                                    0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00                                    0.0e+00    OK    
PE toroidal torque                            5.087465e-02     5.087465e-02                                    0.0e+00    OK    
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01                                    0.0e+00    OK    
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02                                    0.0e+00    OK    
resonant area-weighted field b^r              [5 elem]         [5 elem]                                        0.0e+00    OK    
================================================================================================================================
Summary: 47 unchanged, 5 missing/N/A
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu



