### PR TITLE
Equilibrium - BUGFIX! - Build the root-area weight with the inverse Fourier transform

### DIFF
--- a/regression-harness/cases/diiid_n1.toml
+++ b/regression-harness/cases/diiid_n1.toml
@@ -411,3 +411,14 @@ extract = "value"
 label = "Runtime (s)"
 noise_threshold = 0.0
 order = 999
+
+# Root-area-weighted (coordinate-invariant) forcing field b̃ on the control surface: the
+# applied coil spectrum pushed through the √(J|∇ψ|) weight operator. Tracks the field-space
+# conversion that every ResponseMatrices/ field-space output depends on.
+[quantities.forcing_b_rootarea_norm]
+h5path = "PerturbedEquilibrium/forcing_b_root_area"
+type = "complex_vector"
+extract = "norm"
+label = "||forcing b~|| (root-area-weighted)"
+noise_threshold = 1e-10
+order = 1000

--- a/src/Equilibrium/CoordinateInvariant.jl
+++ b/src/Equilibrium/CoordinateInvariant.jl
@@ -54,13 +54,14 @@ w(θ) = √(J·|∇ψ|).
 
 Operationally, sqrtamat is the mode-space √weight operator: for a field b with
 Fourier coefficients b_fft, it satisfies the identity
-`‖sqrtamat·b_fft‖² = N² · ∫ |b|² · J|∇ψ| dθ`
-which is Jacobian-invariant on a given flux surface (see
-`scripts/test_power_norm_invariance.jl`).
+`‖sqrtamat·b_fft‖² = ∫ |b|² · J|∇ψ| dθ`  (θ normalized to [0, 1))
+which is Jacobian-invariant on a given flux surface. Its diagonal is the θ-average of
+√(J|∇ψ|), so `sqrtamat/√jarea` has a diagonal close to (and never above) one; this is the
+matrix Fortran GPEC writes as `J_surf_2` after that division.
 
-The backward step uses exp(−imθ)/(1/N) normalization paired with the Julia
-forward FT exp(+imθ) so that round-trip = identity and the convolution
-structure is correct.
+Each column is the unit mode e^{+i m_k θ} taken to θ-space with the inverse transform
+(`adjoint(basis)`, no 1/N), weighted pointwise, and brought back with the forward transform
+(`basis/N`), so the round trip is the identity and the convolution structure is correct.
 """
 function compute_sqrtamat(
     equil::PlasmaEquilibrium,
@@ -78,8 +79,8 @@ function compute_sqrtamat(
         e_k .= 0.0
         e_k[k] = 1.0 + 0.0im
 
-        # Standard backward FT: f(θ_j) = (1/N) Σ_m c_m exp(-imθ_j) = (transpose(basis) * c) / N
-        theta_vec = (transpose(ft.basis) * e_k) ./ mtheta
+        # Inverse FT of the unit mode: f(θ_j) = exp(+i m_k θ_j) (adjoint(basis) * c, see FourierTransforms)
+        theta_vec = adjoint(ft.basis) * e_k
 
         # Multiply pointwise by √(J·|∇ψ|) in theta-space
         theta_vec .*= sqrt_jdp

--- a/src/Equilibrium/CoordinateInvariant.jl
+++ b/src/Equilibrium/CoordinateInvariant.jl
@@ -59,9 +59,9 @@ which is Jacobian-invariant on a given flux surface. Its diagonal is the θ-aver
 √(J|∇ψ|), so `sqrtamat/√jarea` has a diagonal close to (and never above) one; this is the
 matrix Fortran GPEC writes as `J_surf_2` after that division.
 
-Each column is the unit mode e^{+i m_k θ} taken to θ-space with the inverse transform
-(`adjoint(basis)`, no 1/N), weighted pointwise, and brought back with the forward transform
-(`basis/N`), so the round trip is the identity and the convolution structure is correct.
+Each column is the unit mode e^{+i m_k θ} taken to θ-space with `FourierTransforms.inverse`,
+weighted pointwise, and brought back with the forward transform `ft(...)`, the same pair whose
+round trip is the identity, so the convolution structure is correct.
 """
 function compute_sqrtamat(
     equil::PlasmaEquilibrium,
@@ -79,8 +79,8 @@ function compute_sqrtamat(
         e_k .= 0.0
         e_k[k] = 1.0 + 0.0im
 
-        # Inverse FT of the unit mode: f(θ_j) = exp(+i m_k θ_j) (adjoint(basis) * c, see FourierTransforms)
-        theta_vec = adjoint(ft.basis) * e_k
+        # Inverse FT of the unit mode, f(θ_j) = exp(+i m_k θ_j), through the library's own inverse
+        theta_vec = Utilities.FourierTransforms.inverse(ft, e_k)
 
         # Multiply pointwise by √(J·|∇ψ|) in theta-space
         theta_vec .*= sqrt_jdp

--- a/test/runtests_coordinate_invariant.jl
+++ b/test/runtests_coordinate_invariant.jl
@@ -43,31 +43,31 @@ end
     fm = PE.field_space_response_matrices(Λ, L, P, ϱ, S, jarea)
 
     @testset "Flux recovery contract (round-trip via R = S·A)" begin
-        @test R * fm.permeability / R ≈ P                rtol = 1e-10
-        @test R * fm.surface_inductance * R' ≈ L         rtol = 1e-10
-        @test R * fm.plasma_inductance * R' ≈ Λ          rtol = 1e-10
-        @test (R') \ fm.reluctance / R ≈ ϱ               rtol = 1e-10
+        @test R * fm.permeability / R ≈ P rtol = 1e-10
+        @test R * fm.surface_inductance * R' ≈ L rtol = 1e-10
+        @test R * fm.plasma_inductance * R' ≈ Λ rtol = 1e-10
+        @test (R') \ fm.reluctance / R ≈ ϱ rtol = 1e-10
     end
 
     @testset "Area-weighted (b̄) recovery via S (= flux/A²)" begin
         # b̄-space inductance L_b̄ = S·L̃·S† = L/A² since S·R⁻¹ = A⁻¹·I.
-        @test S * fm.surface_inductance * S' ≈ L ./ jarea^2   rtol = 1e-10
-        @test S * fm.plasma_inductance * S' ≈ Λ ./ jarea^2    rtol = 1e-10
-        @test S * fm.permeability / S ≈ P                     rtol = 1e-10   # similarity: A cancels
+        @test S * fm.surface_inductance * S' ≈ L ./ jarea^2 rtol = 1e-10
+        @test S * fm.plasma_inductance * S' ≈ Λ ./ jarea^2 rtol = 1e-10
+        @test S * fm.permeability / S ≈ P rtol = 1e-10   # similarity: A cancels
     end
 
     @testset "Internal consistency of the b̃ transform rules" begin
-        @test fm.permeability ≈ fm.plasma_inductance / fm.surface_inductance      rtol = 1e-10
+        @test fm.permeability ≈ fm.plasma_inductance / fm.surface_inductance rtol = 1e-10
         L̃inv = inv(fm.surface_inductance)
-        @test fm.reluctance ≈ L̃inv * (fm.plasma_inductance - fm.surface_inductance) * L̃inv  rtol = 1e-10
+        @test fm.reluctance ≈ L̃inv * (fm.plasma_inductance - fm.surface_inductance) * L̃inv rtol = 1e-10
     end
 
     @testset "Energy-scalar invariance (flux ↔ b̃)" begin
         Φ = ComplexF64[cis(0.3k) / k for k in 1:n]
         b̃ = R \ Φ                          # root-area-weighted field
-        @test dot(Φ, L \ Φ) ≈ dot(b̃, fm.surface_inductance \ b̃)   rtol = 1e-10
-        @test dot(Φ, Λ \ Φ) ≈ dot(b̃, fm.plasma_inductance \ b̃)    rtol = 1e-10
-        @test dot(Φ, ϱ * Φ) ≈ dot(b̃, fm.reluctance * b̃)           rtol = 1e-10
+        @test dot(Φ, L \ Φ) ≈ dot(b̃, fm.surface_inductance \ b̃) rtol = 1e-10
+        @test dot(Φ, Λ \ Φ) ≈ dot(b̃, fm.plasma_inductance \ b̃) rtol = 1e-10
+        @test dot(Φ, ϱ * Φ) ≈ dot(b̃, fm.reluctance * b̃) rtol = 1e-10
     end
 
     @testset "Three-field vector relations (b, b̃, b̄; flux = A·b̄)" begin
@@ -75,9 +75,9 @@ end
         b̄ = S * b̃                          # area-weighted field
         b = (S .* sqrt(jarea)) \ b̃          # bare field b = Σ⁻¹·b̃
         Φ = R * b̃                           # poloidal flux
-        @test Φ ≈ jarea .* b̄               rtol = 1e-12   # Φ = A·b̄
-        @test b̄ ≈ Φ ./ jarea               rtol = 1e-12
-        @test (S .* sqrt(jarea)) * b ≈ b̃    rtol = 1e-12   # Σ·b = b̃
+        @test Φ ≈ jarea .* b̄ rtol = 1e-12   # Φ = A·b̄
+        @test b̄ ≈ Φ ./ jarea rtol = 1e-12
+        @test (S .* sqrt(jarea)) * b ≈ b̃ rtol = 1e-12   # Σ·b = b̃
     end
 end
 
@@ -96,4 +96,41 @@ end
     e_new = sort(real.(eigvals(jarea .* (M' * W * M))))
     e_old = sort(real.(eigvals(Mold' * W * Mold)))
     @test e_new ≈ e_old rtol = 1e-12
+end
+
+# The √weight operator on a real flux surface: its diagonal is the θ-average of √(J|∇ψ|), it is
+# Hermitian, it carries the area-weighted field energy exactly (Parseval with the weight), and
+# it inverts against area_to_rootarea_weight. A wrong transform convention (sign of the
+# exponent or a stray 1/N) fails every one of these.
+@testset "sqrtamat on the Solovev surface" begin
+    using TOML
+    EQ = GeneralizedPerturbedEquilibrium.Equilibrium
+    equil_dir = joinpath(@__DIR__, "..", "examples", "Solovev_ideal_example")
+    inputs = TOML.parsefile(joinpath(equil_dir, "gpec.toml"))
+    eq_config = EQ.EquilibriumConfig(inputs["Equilibrium"], equil_dir)
+    equil = EQ.setup_equilibrium(eq_config, EQ.SolovevConfig(inputs["SOL_INPUT"]))
+    psi = equil.rzphi_xs[end]
+    mtheta = length(equil.rzphi_ys)
+    mpert, mlow = 21, -8
+    ft = GeneralizedPerturbedEquilibrium.Utilities.FourierTransforms.FourierTransform(mtheta, mpert, mlow)
+    w = EQ.compute_sqrt_jac_delpsi(equil, psi, mtheta)
+    jarea = EQ.flux_surface_area(equil, psi, mtheta)
+    Σ = EQ.compute_sqrtamat(equil, psi, ft)
+    S = EQ.rootarea_to_area_weight(equil, psi, ft)
+    @test size(Σ) == (mpert, mpert)
+    @test all(isapprox.(diag(Σ), sum(w) / mtheta; rtol=1e-12))
+    @test norm(Σ - Σ') / norm(Σ) < 1e-12
+    @test all(0 .< real.(diag(S)) .<= 1)          # Cauchy–Schwarz: ⟨√(J|∇ψ|)⟩ ≤ √⟨J|∇ψ|⟩
+    @test S ≈ Σ ./ sqrt(jarea)
+    # Each column is the forward transform of the weighted unit mode (the definition).
+    b = ComplexF64[cis(0.7k) * (1 + 0.1k) for k in 1:mpert]
+    @test Σ * b ≈ ft(w .* (adjoint(ft.basis) * b)) rtol = 1e-12
+    # Weighted Parseval on the complete basis (mpert = mtheta, no truncation):
+    # ‖Σ·b‖² = (1/N) Σ_j J|∇ψ|_j |f_j|², f the θ-space field of b (θ ∈ [0,1)).
+    ft_full = GeneralizedPerturbedEquilibrium.Utilities.FourierTransforms.FourierTransform(mtheta, mtheta, -(mtheta ÷ 2))
+    Σ_full = EQ.compute_sqrtamat(equil, psi, ft_full)
+    b_full = ComplexF64[cis(0.3k) / (1 + abs(k - mtheta ÷ 2)) for k in 1:mtheta]
+    f_full = adjoint(ft_full.basis) * b_full
+    @test sum(abs2, Σ_full * b_full) ≈ sum(w .^ 2 .* abs2.(f_full)) / mtheta rtol = 1e-10
+    @test S * EQ.area_to_rootarea_weight(equil, psi, ft) ≈ I atol = 1e-10
 end


### PR DESCRIPTION
# ⚠️ NEEDS CAREFUL REVIEW: this changes the Fourier convention used inside one routine

**Nothing in `Utilities/FourierTransforms.jl` changes.** The forward transform `ft(data) = basis·data/N` with `basis = exp(−i(mθ − nν))` and the inverse `inverse(ft, modes) = adjoint(basis)·modes` are untouched, and their round-trip test still passes (20/20). What changes is that `compute_sqrtamat` stops rolling its own backward step and calls that inverse.

**History of the routine, so the reviewer can judge whether it was ever right:**

| commit | date | backward step in `compute_sqrtamat` | library inverse at that time |
| --- | --- | --- | --- |
| `02b0f0b7` (first version) | 2026-06-11 | `(1/N) Σ_m c_m exp(−imθ_j)` via `cslth`/`snlth` | `exp(+imθ)` (forward was `exp(−imθ)/N`, Fortran `iscdftf`) |
| `ece3e442` (complex overhaul) | 2026-06-30 | `(basis · c)/N` = the same `exp(−imθ)/N` | `conj(basis)·modes` = `exp(+imθ)` |
| `1c955043` (basis transposed) | 2026-06-30 | `(transpose(basis) · c)/N`, mechanically adjusted | `adjoint(basis)·modes` = `exp(+imθ)` |
| this PR | | `inverse(ft, c)` | unchanged |

At every step the routine's backward kernel was the **forward** kernel `exp(−imθ)` with a 1/N, while the library's inverse was `exp(+imθ)` without one. The two refactors carried the hand-rolled line across faithfully; the mismatch dates from the first version. The routine was never tested directly: the develop `runtests_coordinate_invariant.jl` uses "a generic invertible complex operator standing in for the √weight", and the `scripts/test_power_norm_invariance.jl` the old docstring cited is not in the tree.

**Why the early benchmarks could not see it.** Reflecting m → −m is unitary and the 1/N is a scalar, so every norm or Parseval-type identity holds for the old operator up to a constant. The difference only shows in the structure. On the DIII-D example surface (ψ_N 0.99, mtheta 256, 35 modes; script in the review package):

| check | old operator | this PR |
| --- | --- | --- |
| `S_old[:, m] == S_new[:, −m] / N` over the 25 mirrored modes | max relative residual **0.0** | |
| diagonal | max 0.027 | mean 6.8129 = ⟨√(J∣∇ψ∣)⟩ = 6.8129 |
| Hermitian residual | 0.34 | 1.5e-16 |
| ‖S b‖² / ∫∣b∣² w² dθ | 1.1e-5 (≈ 1/N²) | 0.996 (truncated basis; 1.0 on the complete basis in the test) |
| vs Fortran `J_surf_2` on the benchmark surface | zero diagonal, norm ~300× small | correlation 1.0000, diagonal within 0.05 % |

The first row is the whole bug in one line: the old column for mode m is the correct column for mode −m divided by N, exactly. The Fortran operator is the independent reference for which of the two is right.

---

`compute_sqrtamat` builds the √(J|∇ψ|) convolution operator Σ that the coordinate-invariant field space rests on: the b̃→b̄ operator S = Σ/√A, the flux conform R = S·A, `field_space_response_matrices`, the root-area-weighted forcing and response fields written to `PerturbedEquilibrium/`, and the conformed singular-coupling matrices. It took each unit mode to θ-space with `transpose(basis)/N` instead of the inverse transform `adjoint(basis)`, so the matrix came out with its rows reflected in m and scaled by 1/mtheta: a zero diagonal and a norm about 300× too small, where Fortran GPEC's `J_surf_2` is a near-identity weight (diagonal ≈ 0.92).

Found while benchmarking the error-field assessment of the original OMFIT project against its Fortran GPEC run, where the dominant-mode singular values were 190× too small and every per-coil overlap was off by factors of 10–900. With the fix the operator matches the Fortran `J_surf_2` on that surface to the grid difference (correlation 1.0000, diagonal within 0.05 %) and the per-coil overlaps land on the Fortran values (median ratio 0.95; the remaining scatter is a separate helicity bug fixed in its own PR).

**What changes**

- `src/Equilibrium/CoordinateInvariant.jl`: the inverse step of `compute_sqrtamat` uses `adjoint(ft.basis)` (the documented inverse transform) with no 1/N; the docstring now states the correct identity and the Fortran correspondence.
- `test/runtests_coordinate_invariant.jl`: a testset on the Solovev surface checks the diagonal equals ⟨√(J|∇ψ|)⟩, Hermiticity, each column as the transform of the weighted unit mode, the weighted Parseval identity on the complete basis, and `rootarea_to_area_weight · area_to_rootarea_weight = I`. The old code fails all but Hermiticity.
- `regression-harness/cases/diiid_n1.toml`: tracks `‖forcing b̃‖` (`PerturbedEquilibrium/forcing_b_root_area`), since no tracked quantity on develop depended on the operator.

**What moves**: every field-space output (`ResponseMatrices/` field-space matrices, `forcing_b_root_area`, `forcing_b_area`, `response_b_*`, `SingularCoupling/C_*` as stored) and anything read from them. Flux-space quantities and the harness's existing 47 quantities are unchanged.

Review package (the operator before/after on the DIII-D example surface and the reflection check): linked in the comments as a claude.ai artifact.

cc @matt-pharr

## Release note

- **Audience:** users
- **Numerical impact:** field-space outputs change _(harness @ 76808dfb (message-only rewrite of 244b2e62): 47 unchanged, 1 changed — the new ‖forcing b̃‖ quantity, 30.6 → 4.683e-4; identical to the run at 26db56c8)_
- **Migration:** none

The root-area weight operator (Σ/√A, Fortran's `J_surf_2`) was built with the wrong inverse transform, reflecting it in m and scaling it by 1/mtheta; all coordinate-invariant field-space outputs and the conformed singular-coupling matrices were wrong. Fixed and tested against the weighted Parseval identity and against Fortran GPEC.

## Regression report

```
Regression Report: diiid_n1
==============================================================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 16 threads/16 BLAS
Ref 2: bugfix/equilibrium-sqrtamat-inverse-fourier  @ 26db56c8 (2026-09-12)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 16 threads/16 BLAS
----------------------------------------------------------------------------------------------------------------------------------------------
Quantity                                      develop          bugfix/equilibrium-sqrtamat-inverse-fourier  Diff                 Status       
----------------------------------------------------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01                                 0.0e+00              OK           
total energy Im(et[1])                        4.142529e-05     4.142529e-05                                 0.0e+00              OK           
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00                                0.0e+00              OK           
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00                                 0.0e+00              OK           
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01                                 0.0e+00              OK           
plasma energy (all)                           [35 elem]        [35 elem]                                    0.0e+00              OK           
vacuum energy (all)                           [35 elem]        [35 elem]                                    0.0e+00              OK           
total energy (all)                            [35 elem]        [35 elem]                                    0.0e+00              OK           
ODE steps (saved)                             2576             2576                                         0.0e+00              OK           
ODE steps (total)                             4572             4572                                         0.0e+00              OK           
q0                                            1.204212e+00     1.204212e+00                                 0.0e+00              OK           
q95                                           4.781723e+00     4.781723e+00                                 0.0e+00              OK           
beta_t                                        1.327024e-02     1.327024e-02                                 0.0e+00              OK           
beta_n                                        1.372511e+00     1.372511e+00                                 0.0e+00              OK           
internal inductance li1                       8.842392e-01     8.842392e-01                                 0.0e+00              OK           
internal inductance li2                       7.080847e-01     7.080847e-01                                 0.0e+00              OK           
internal inductance li3                       7.304433e-01     7.304433e-01                                 0.0e+00              OK           
poloidal beta betap1                          6.680744e-01     6.680744e-01                                 0.0e+00              OK           
poloidal beta betap2                          5.349834e-01     5.349834e-01                                 0.0e+00              OK           
poloidal beta betap3                          5.518761e-01     5.518761e-01                                 0.0e+00              OK           
# singular surfaces                           5                5                                            0.0e+00              OK           
singular psi locations                        [5 elem]         [5 elem]                                     0.0e+00              OK           
singular q values                             [5 elem]         [5 elem]                                     0.0e+00              OK           
current beta betaj                            4.236478e-01     4.236478e-01                                 0.0e+00              OK           
plasma volume                                 1.829472e+01     1.829472e+01                                 0.0e+00              OK           
plasma current                                1.152130e+00     1.152130e+00                                 0.0e+00              OK           
mpert                                         35               35                                           0.0e+00              OK           
npert                                         1                1                                            0.0e+00              OK           
toroidal field bt0                            2.006573e+00     2.006573e+00                                 0.0e+00              OK           
wall field bwall                              3.880145e-01     3.880145e-01                                 0.0e+00              OK           
aspect ratio                                  2.845746e+00     2.845746e+00                                 0.0e+00              OK           
elongation kappa                              1.708350e+00     1.708350e+00                                 0.0e+00              OK           
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...                              identical            OK           
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...                              identical            OK           
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...                              identical            OK           
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...                              identical            OK           
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...                              identical            OK           
island half-widths                            [5 elem]         [5 elem]                                     0.0e+00              OK           
Chirikov parameter                            [5 elem]         [5 elem]                                     0.0e+00              OK           
||resonant area-weighted field||              5.189179e-04     5.189179e-04                                 0.0e+00              OK           
PE plasma energy                              3.422677e+00     3.422677e+00                                 0.0e+00              OK           
PE vacuum energy                              3.174510e+00     3.174510e+00                                 0.0e+00              OK           
PE surface energy                             5.826684e+00     5.826684e+00                                 0.0e+00              OK           
PE toroidal torque                            5.087465e-02     5.087465e-02                                 0.0e+00              OK           
NTV torque FGAR [N·m]                         5.296762e-01     5.296762e-01                                 0.0e+00              OK           
NTV kinetic energy dW FGAR [J]                7.924971e-02     7.924971e-02                                 0.0e+00              OK           
||forcing b~|| (root-area-weighted)           3.062518e+01     4.683328e-04                                 3.062e+01 (100.00%)  ** CHANGED **
resonant area-weighted field b^r              [5 elem]         [5 elem]                                     0.0e+00              OK           
==============================================================================================================================================
Summary: 1 changed, 47 unchanged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu





