### PR TITLE
ForceFreeStates - BUGFIX! - Use the fixed start for integrations that begin away from the axis

### DIFF
--- a/src/ForceFreeStates/CoreTypes.jl
+++ b/src/ForceFreeStates/CoreTypes.jl
@@ -123,6 +123,7 @@ gpec.toml.
   - `mthvac::Int` - Number of vacuum poloidal grid points (corresponds to `mtheta` in VacuumInput)
   - `nzvac::Int` - Number of vacuum toroidal grid points (corresponds to `nzeta` in VacuumInput3D)
   - `sing_start::Int` - Start integration at the `sing_start`-th singular surface
+  - `frobenius_psi_max::Float64` - Largest starting ψ_N at which the Frobenius start is used. The Frobenius start [Glasser 2016 Eq. 51] is a power series about the magnetic axis that picks the regular solution of every mode; it is only meaningful near the axis, so when the integration starts above this value (an interior start such as `psilow` raised to skip a q < 1 core, or `qlow` above q₀) every solution starts instead with zero displacement and unit "momentum" (U₁ = 0, U₂ = I), the initialization Fortran DCON always uses, and a warning says so. `0` selects the fixed start everywhere, silently. Default 0.01: on a DIII-D case the two starts differ in the innermost resonant coupling by 1 % at ψ_N = 0.01, 4 % at 0.03, 24 % at 0.1 and a factor 2 at 0.3, so the default keeps every axis-started example unchanged and switches anything that starts inside the plasma.
   - `nn_low::Int` - Lower bound for toroidal modes
   - `nn_high::Int` - Upper bound for toroidal modes
   - `delta_mlow::Int` - Expands lower bound of Fourier harmonics by delta_mlow
@@ -220,5 +221,5 @@ gpec.toml.
     gal_rho::Vector{Float64} = Float64[]      # per-surface mass density ρ [kg/m³] (length msing, core→edge); Fortran rmatch `massden`
     gal_rotation::Vector{Float64} = Float64[] # per-surface rotation frequency f [Hz] (length msing, core→edge); forced eigenvalue γ_s = 2πi·n·f. Fortran rmatch `rotation`
     gal_gamma::Float64 = 5 / 3       # ratio of specific heats Γ for the resistive-layer coefficients (resist_eval G term)
-    fixed_axis::Bool = false
+    frobenius_psi_max::Float64 = 0.01
 end

--- a/src/ForceFreeStates/EulerLagrange.jl
+++ b/src/ForceFreeStates/EulerLagrange.jl
@@ -45,75 +45,49 @@ and a small set of temporary matrices and factors used to compute singular-layer
   - `numpert_total::Int` - Total number of Fourier mode combinations (m × n) used in the calculation.
 
   - `numunorms_init::Int` - Initial allocation size for the number of normalization operations recorded.
-
   - `msing::Int` - Number of singular surfaces in the equilibrium (used to size asymptotic coefficient arrays).
-
   - `numsteps_init::Int` - Initial allocation size for the number of integration steps to store.
-
   - `step::Int` - Current integration step index (1-based, like `istep` in the original Fortran).
-
   - `psi_store::Vector{Float64}` - Stored psi values at each saved integration step (length `numsteps_init`).
-
   - `q_store::Vector{Float64}` - Stored q values at each saved integration step (length `numsteps_init`).
-
   - `u_store::Array{ComplexF64,4}` - Stored solution arrays at each saved step with shape
     `(numpert_total, numpert_total, 2, numsteps_init)` (complex solution state used by the solver).
-
   - `du_store::Array{ComplexF64,3}` - dΞ_ψ/dψ (the u₁ block only) at each saved step, shape
     `(numpert_total, numpert_total, step)`. Empty until `materialize_derivative_stores!` fills it,
     except on the galerkin-matched path which supplies the analytic derivative at construction.
     du₂/dψ is never stored densely — its only consumer evaluates it on demand at bracket nodes.
-
   - `xi_s_store::Array{ComplexF64,3}` - Clebsch displacement Ξ_s at each saved step, eq. 18 of Glasser 2016,
     shape `(numpert_total, numpert_total, step)`. Empty until materialized, same as `du_store`.
-
   - `u_store_el_basis::Bool` - True when `u_store` holds the Euler-Lagrange state `(u₁, u₂)`, so the
     derivative kernel can be re-applied to it. False on the sparse parallel path, whose stored columns
     are chunk-endpoint Riccati matrices; `materialize_derivative_stores!` refuses to run there.
-
   - `du_store_populated::Bool` - True once `du_store`/`xi_s_store` hold valid data in the final
     (post-transform, post-normalization) basis. Set by `materialize_derivative_stores!` or by the
     galerkin-matched constructor; stays false where the stores cannot be materialized, e.g. the
     sparse parallel path whose solution is in the Riccati basis.
-
   - `crit_store::Vector{Float64}` - Stored crit parameter values (smallest eigenvalue of W⁻ꜝ) (length `numsteps_init`).
-
   - `ca_r::Array{ComplexF64,4}` - Asymptotic coefficients just to the right of each singular surface
     with shape `(numpert_total, numpert_total, 2, msing)`.
-
   - `ca_l::Array{ComplexF64,4}` - Asymptotic coefficients just to the left of each singular surface
     with shape `(numpert_total, numpert_total, 2, msing)`.
-
   - `ca_populated::Bool` - True once an ideal singular-surface crossing has filled `ca_l`/`ca_r`; kinetic and
     galerkin-matched runs never populate them and leave this false, and the HDF5 writer then emits zero-extent
     `ca_left`/`ca_right` datasets instead of unpopulated arrays.
-
   - `edge_scan::EdgeScanState` - Edge dW scan state and results. Initialized as a disabled sentinel (N_edge=0) and replaced by `findmax_dW_edge!` when a scan runs.
-
   - `psifac::Float64` - Current normalized flux coordinate for the integrator.
-
   - `q::Float64` - Safety factor value at `psifac` (current q during integration).
-
   - `u::Array{ComplexF64,3}` - Current working solution arrays with shape `(numpert_total, numpert_total, 2)`.
-
   - `ising_start::Int` - Index of the starting singular surface to be crossed during integration.
-
   - `psimax::Float64` - Maximum psi value for which the integrator is allowed to run in next integration region.
-
   - `needs_crossing::Bool` - Flag indicating whether a rational surface needs to be crossed after the current integration region.
-
   - `nzero::Int` - Count of detected zero crossings (used for diagnostics).
-
   - `new::Bool` - Flag indicating whether a new `unorm0` should be computed after a fixup.
 
     # Initialization parameters
-
   - `unorm::Vector{Float64}` - Current norms of the solution vectors (length `numpert_total`).
-
   - `unorm0::Vector{Float64}` - Reference/initial norms of the solution vectors (length `numpert_total`).
 
     # Saved data throughout integration
-
   - `ifix::Int` - Number of normalization operations performed (index into normalization arrays).
 
 # Total ODE solver steps taken (all steps, not just saved ones)
@@ -122,11 +96,8 @@ and a small set of temporary matrices and factors used to compute singular-layer
 
   - `sing_flag::Vector{Bool}` - Boolean flags indicating which stored normalizations correspond to singular solutions    # Edge dW scan state and results (disabled sentinel when psiedge >= psilim, i.e. no edge scan)
     (length `numunorms_init`).
-
   - `zeroed_idx::Vector{Vector{Int}}` - For each ideal rational surface jump, a vector of indices of solutions that were zeroed.    # Data for integrator
-
   - `fixfac::Array{ComplexF64,3}` - Fix-up factors for Gaussian reduction with shape `(numpert_total, numpert_total, numunorms_init)`.
-
   - `fixstep::Vector{Int64}` - Step indices (psi step positions) at which normalization/fixups were performed (length `numunorms_init`).
 """
 @kwdef mutable struct OdeState
@@ -232,9 +203,9 @@ end
 # at the interval endpoints. Coefficients are ported from STRIDE's ode_itime cost model
 # (Fortran reference) and unchanged here. Tune only after re-fitting against a per-chunk
 # step-count sweep; touching these affects parallel-chunk load balancing.
-const ODE_COST_AXIS  = (a = 39695.0, b = 212830.0)
-const ODE_COST_RAT   = (a = 17147.0, b = 470710.0)
-const ODE_COST_EDGE  = (a =  1646.0, b =   4683.0)
+const ODE_COST_AXIS = (a=39695.0, b=212830.0)
+const ODE_COST_RAT = (a=17147.0, b=470710.0)
+const ODE_COST_EDGE = (a=1646.0, b=4683.0)
 
 """
     ode_itime_cost(psi1, psi2, intr) -> Float64
@@ -267,7 +238,7 @@ never from `Threads.nthreads()` — so the chunk list, and hence every Riccati o
 identical whatever thread count `julia -t` provides.
 
 Each split finds the equal-cost midpoint ψ_mid via bisection:
-  ode_itime_cost(psi_start, psi_mid) ≈ ode_itime_cost(psi_start, psi_end) / 2
+ode_itime_cost(psi_start, psi_mid) ≈ ode_itime_cost(psi_start, psi_end) / 2
 
 Sub-chunks inherit `needs_crossing=false` and `ising=0`. Only the LAST sub-chunk of
 each original chunk retains `needs_crossing=true` and the original `ising`, so the
@@ -326,10 +297,10 @@ function balance_integration_chunks(chunks::Vector{IntegrationChunk}, ctrl::Forc
         psi_mid = (lo + hi) / 2.0
 
         left = IntegrationChunk(; psi_start=chunk.psi_start, psi_end=psi_mid,
-                                  needs_crossing=false, ising=0, direction=1)
+            needs_crossing=false, ising=0, direction=1)
         right = IntegrationChunk(; psi_start=psi_mid, psi_end=chunk.psi_end,
-                                   needs_crossing=chunk.needs_crossing, ising=chunk.ising,
-                                   direction=chunk.direction)
+            needs_crossing=chunk.needs_crossing, ising=chunk.ising,
+            direction=chunk.direction)
         splice!(result, best_idx, [left, right])
     end
 
@@ -479,20 +450,20 @@ is identified by dominant |U₁| component, giving the physically correct consta
 Frobenius solution and avoiding the spurious logarithmic irregularity.
 """
 function compute_axis_init(mats::MatrixSplines, profiles::Equilibrium.ProfileSplines,
-        intr::ForceFreeStatesInternal, psi_low::Float64)
-    N    = intr.numpert_total
+    intr::ForceFreeStatesInternal, psi_low::Float64)
+    N = intr.numpert_total
     hint = Ref(1)
 
     # Evaluate stability matrices at psi_low
     F_lower = zeros(ComplexF64, N, N)
-    kmat    = zeros(ComplexF64, N, N)
-    gmat    = zeros(ComplexF64, N, N)
+    kmat = zeros(ComplexF64, N, N)
+    gmat = zeros(ComplexF64, N, N)
     mats.ideal.F_spline_lower(vec(F_lower), psi_low; hint=hint)
-    mats.ideal.K_spline(vec(kmat),          psi_low; hint=hint)
-    mats.ideal.G_spline(vec(gmat),          psi_low; hint=hint)
+    mats.ideal.K_spline(vec(kmat), psi_low; hint=hint)
+    mats.ideal.G_spline(vec(gmat), psi_low; hint=hint)
 
     # singfac[j] = 1 / (m_j − n_j · q) for each mode j
-    q0      = profiles.q_spline(psi_low; hint=hint)
+    q0 = profiles.q_spline(psi_low; hint=hint)
     singfac = vec(1.0 ./ ((intr.mlow:intr.mhigh) .- q0 .* (intr.nlow:intr.nhigh)'))
 
     # F̄⁻¹ = (F_lower · F_lower')⁻¹ via the Cholesky factor
@@ -506,15 +477,15 @@ function compute_axis_init(mats::MatrixSplines, profiles::Equilibrium.ProfileSpl
     for j in 1:N
         sf = singfac[j]
         fi = Finv[j, j]
-        k  = kmat[j, j]
+        k = kmat[j, j]
         kd = conj(k)          # K̄†[j,j]
-        g  = gmat[j, j]
+        g = gmat[j, j]
 
         # 2×2 ODE matrix block for mode j [Glasser 2016 Eq. 22-24, diagonal approximation]
         m11 = -sf * fi * k
-        m12 =  sf^2 * fi
-        m21 =  g - kd * fi * k
-        m22 =  sf * kd * fi
+        m12 = sf^2 * fi
+        m21 = g - kd * fi * k
+        m22 = sf * kd * fi
 
         # Frobenius matrix A₀_j = ψ_low · M_j [Glasser 2016 Eq. 51]
         #! format: off
@@ -541,7 +512,7 @@ function compute_axis_init(mats::MatrixSplines, profiles::Equilibrium.ProfileSpl
         if abs(v2) > Base.sqrt(Base.eps(Float64)) * abs(v1)
             U1_init[j, j] = v1 / v2
         else
-            U1_init[j, j] =  one(ComplexF64)
+            U1_init[j, j] = one(ComplexF64)
             U2_init[j, j] = zero(ComplexF64)
         end
     end
@@ -554,13 +525,15 @@ end
 
 Initialize the OdeState struct for the case of sing_start = 0 (axis initialization).
 Formerly `ode_axis_init!`. This now only initializes `psifac`, `ising_start`, and `u`.
+The Frobenius start is used only when the starting surface lies at or below `ctrl.frobenius_psi_max`;
+an interior start (or `ctrl.frobenius_psi_max = 0`) uses U₁ = 0, U₂ = I.
 
 ### TODOs
 
 Move ising_start logic to chunk_el_integration_bounds?
 """
 function initialize_el_at_axis!(odet::OdeState, ctrl::ForceFreeStatesControl, mats::MatrixSplines,
-        profiles::Equilibrium.ProfileSplines, intr::ForceFreeStatesInternal)
+    profiles::Equilibrium.ProfileSplines, intr::ForceFreeStatesInternal)
 
     # Default psifac to minimum equilibrium psi value
     odet.psifac = profiles.xs[1]
@@ -590,10 +563,16 @@ function initialize_el_at_axis!(odet::OdeState, ctrl::ForceFreeStatesControl, ma
         odet.ising_start = searchsortedfirst(getfield.(intr.sing, :psifac), odet.psifac) - 1
     end
 
-    if ctrl.fixed_axis
+    # The Frobenius start is a series about the axis; an interior start uses the fixed start Fortran DCON always uses.
+    fixed_start = odet.psifac > ctrl.frobenius_psi_max
+    if fixed_start && ctrl.frobenius_psi_max > 0
+        @warn "Integration starts at ψ_N = $(round(odet.psifac; sigdigits=4)), above frobenius_psi_max = $(ctrl.frobenius_psi_max): " *
+              "the axis Frobenius start is only valid near the axis, so the fixed start (U₁ = 0, U₂ = I) is used, as in Fortran DCON. " *
+              "Set frobenius_psi_max = 0 to select it silently, or raise it to keep the Frobenius start."
+    end
+    if fixed_start
         # Original Glasser initialization: U₁=0, U₂=I [Glasser 2016 §VI].
-        # Constrains the axis displacement ξ^ψ=0 for all modes (fixed magnetic axis).
-        # Retained as a reference/comparison option; the default (fixed_axis=false) is Frobenius.
+        # Constrains the displacement ξ^ψ=0 for all modes at the starting surface (fixed axis or rigid core).
         for ipert in 1:intr.numpert_total
             odet.u[ipert, ipert, 2] = 1
         end
@@ -737,7 +716,7 @@ function chunk_el_integration_bounds(odet::OdeState, ctrl::ForceFreeStatesContro
                 psi_end=psi_end,
                 needs_crossing=true,
                 ising=ising_current,
-                direction = bidirectional ? -1 : 1
+                direction=bidirectional ? -1 : 1
             ))
 
             # After crossing, we jump to the other side of the singular surface
@@ -1171,7 +1150,7 @@ function transform_u!(odet::OdeState, intr::ForceFreeStatesInternal)
                     temp[ksol, jsol] = odet.fixfac[ksol, jsol, ifix]
                 end
             end
-            mul!(gauss_buffer, view(gauss,:,:,ifix), temp)
+            mul!(gauss_buffer, view(gauss, :, :, ifix), temp)
             gauss[:, :, ifix] .= gauss_buffer
         end
         # Account for zeroed indices at singular surfaces in `ode_ideal_cross`
@@ -1188,7 +1167,7 @@ function transform_u!(odet::OdeState, intr::ForceFreeStatesInternal)
     # and mfix + 1 is the for the region after the last fixup and before the edge
     transforms[:, :, end] .= identity
     for ifix in odet.ifix:-1:1
-        mul!(view(transforms,:,:,ifix), view(gauss,:,:,ifix), view(transforms,:,:,(ifix+1)))
+        mul!(view(transforms, :, :, ifix), view(gauss, :, :, ifix), view(transforms, :, :, (ifix + 1)))
     end
 
     # Now that we have the transform matrices, we can apply them to the solution vectors
@@ -1448,4 +1427,3 @@ non-Hermitian contributions and needs an LU.
     xi_s .-= tmp_mat
     return xi_s
 end
-

--- a/src/ForceFreeStates/Riccati/Driver.jl
+++ b/src/ForceFreeStates/Riccati/Driver.jl
@@ -76,8 +76,8 @@ After renormalization (at crossing or when norms exceed ucrit):
 This is compatible with downstream code (which uses U₁/U₂ ratio):
   - Free.jl:     wp = u[:,:,2] / u[:,:,1] = I · S⁻¹ = P  ✓  (post-renorm)
   - FixedBoundaryStability.jl: crit = min_eigval(u[:,:,1] / u[:,:,2]) = min_eigval(S)  ✓
-  - Axis init:   determined by `ctrl.fixed_axis`. When `true`, U₁=0, U₂=I → S(ψ₀)=0 (original
-    Glasser fixed-axis BC). When `false` (default), Frobenius eigenvalue init [Glasser 2016 Eq. 51]
+  - Axis init:   determined by `ctrl.frobenius_psi_max`. When the start lies above it (or it is 0), U₁=0, U₂=I → S(ψ₀)=0 (original
+    Glasser fixed-axis BC). Otherwise (default near the axis), Frobenius eigenvalue init [Glasser 2016 Eq. 51]
     sets U₂=I and U₁ to the regular Frobenius eigenvector per mode → S(ψ₀) = U₁_Frobenius is
     nonzero in general. Riccati S-evolution remains well-defined either way.
 
@@ -101,33 +101,34 @@ this is the only branch that produces them.
 Solves the same system as [`forward_eulerlagrange_integration`](@ref), but integrates all bulk
 chunks concurrently using `Threads.@threads`, then re-integrates the outer plasma serially:
 
-1. **Chunk generation**: calls `chunk_el_integration_bounds`, then `balance_integration_chunks`
-   to sub-divide chunks for load balancing. The chunk count depends only on `intr.msing` and
-   `ctrl.nchunks`, never on the thread count, so results are thread-independent.
-2. **Propagator phase**: `integrate_propagator_chunk!` integrates each chunk independently
-   from identity initial conditions (no accumulated state, no normalization/callback).
-   Each thread uses a private `OdeState` proxy for `sing_der!` side effects.
-3. **Serial assembly**: propagators are applied sequentially with `apply_propagator!`.
-   Rational surface crossings use `riccati_cross_ideal_singular_surf!` (no Gaussian
-   reduction).
-4. **Outer plasma re-integration**: after the last rational surface crossing, the outer
-   plasma (from last ψ_s to psilim) is re-integrated using `riccati_integrate_chunk!`.
-   FM propagation in this region is prone to precision loss for high N (exponential growth
-   without renormalization); Riccati integration keeps matrices bounded and provides dense
-   checkpoints for `findmax_dW_edge!`.
+ 1. **Chunk generation**: calls `chunk_el_integration_bounds`, then `balance_integration_chunks`
+    to sub-divide chunks for load balancing. The chunk count depends only on `intr.msing` and
+    `ctrl.nchunks`, never on the thread count, so results are thread-independent.
+ 2. **Propagator phase**: `integrate_propagator_chunk!` integrates each chunk independently
+    from identity initial conditions (no accumulated state, no normalization/callback).
+    Each thread uses a private `OdeState` proxy for `sing_der!` side effects.
+ 3. **Serial assembly**: propagators are applied sequentially with `apply_propagator!`.
+    Rational surface crossings use `riccati_cross_ideal_singular_surf!` (no Gaussian
+    reduction).
+ 4. **Outer plasma re-integration**: after the last rational surface crossing, the outer
+    plasma (from last ψ_s to psilim) is re-integrated using `riccati_integrate_chunk!`.
+    FM propagation in this region is prone to precision loss for high N (exponential growth
+    without renormalization); Riccati integration keeps matrices bounded and provides dense
+    checkpoints for `findmax_dW_edge!`.
 
 Select via `integrator = "riccati"` in `[ForceFreeStates]` of gpec.toml. Requires
 `singfac_min != 0`. Uses whatever threads `julia -t` provides; `ctrl.nchunks` is the only
 tunable.
 
 **Key differences from the forward integrator:**
-- No Gaussian reduction in the propagator BVP phase (crossings use the
-  Riccati-style algorithm, `odet.ifix` stays 0)
-- `transform_u!` is called on the odet but is a no-op (ifix=0)
-- Outer plasma uses serial Riccati integration for numerical stability
-- `odet.u_store` holds chunk-endpoint Riccati states, not dense Euler-Lagrange ξ, and
-  `odet.u_store_el_basis` stays `false`: this integrator never claims the EL basis, so
-  PerturbedEquilibrium and the HDF5 forward-integration ξ datasets require the forward path.
+
+  - No Gaussian reduction in the propagator BVP phase (crossings use the
+    Riccati-style algorithm, `odet.ifix` stays 0)
+  - `transform_u!` is called on the odet but is a no-op (ifix=0)
+  - Outer plasma uses serial Riccati integration for numerical stability
+  - `odet.u_store` holds chunk-endpoint Riccati states, not dense Euler-Lagrange ξ, and
+    `odet.u_store_el_basis` stays `false`: this integrator never claims the EL basis, so
+    PerturbedEquilibrium and the HDF5 forward-integration ξ datasets require the forward path.
 
 **Bidirectional integration for large-N accuracy:**
 The crossing chunk (nearest to each rational surface singL[j]) is integrated *backward*
@@ -174,9 +175,9 @@ end
 
 # Build odet and initialize at the magnetic axis. Same path as serial eulerlagrange_integration.
 function _initialize_parallel_odet(ctrl::ForceFreeStatesControl,
-                                   equil::Equilibrium.PlasmaEquilibrium,
-                                   mats::MatrixSplines,
-                                   intr::ForceFreeStatesInternal)
+    equil::Equilibrium.PlasmaEquilibrium,
+    mats::MatrixSplines,
+    intr::ForceFreeStatesInternal)
     odet = OdeState(intr.numpert_total, ctrl.numsteps_init, ctrl.numunorms_init, intr.msing)
     if ctrl.sing_start <= 0
         initialize_el_at_axis!(odet, ctrl, mats, equil.profiles, intr)
@@ -195,7 +196,7 @@ end
 # per-thread proxy OdeStates sized by maxthreadid() (Julia 1.9+ may report threadid
 # values above nthreads() due to the interactive thread pool).
 function _setup_parallel_chunks_and_proxies(odet::OdeState, ctrl::ForceFreeStatesControl,
-                                            intr::ForceFreeStatesInternal)
+    intr::ForceFreeStatesInternal)
     # Bidirectional chunks: crossing chunks are assigned direction=-1 so they are
     # integrated backward. The resulting Φ_bwd is well-conditioned because growing EL
     # solutions decay backward; forward propagation is recovered via LU solve in
@@ -209,8 +210,8 @@ function _setup_parallel_chunks_and_proxies(odet::OdeState, ctrl::ForceFreeState
 end
 
 function _log_parallel_start(ctrl::ForceFreeStatesControl, odet::OdeState,
-                             equil::Equilibrium.PlasmaEquilibrium,
-                             chunks::Vector{IntegrationChunk})
+    equil::Equilibrium.PlasmaEquilibrium,
+    chunks::Vector{IntegrationChunk})
     ctrl.verbose || return
     @info "   ψ = $((@sprintf "%.3f" odet.psifac)),  q = $((@sprintf "%.3f" equil.profiles.q_spline(odet.psifac)))"
     @info "   Riccati FM: $(length(chunks)) chunks over $(Threads.nthreads()) thread$(Threads.nthreads() == 1 ? "" : "s")"
@@ -221,14 +222,14 @@ end
 # Each chunk is independent (identity IC, no accumulated state), so the result does not
 # depend on how chunks are distributed across threads.
 function _run_parallel_bvp_phase!(propagators::Vector{ChunkPropagator},
-                                  chunks::Vector{IntegrationChunk},
-                                  ctrl::ForceFreeStatesControl,
-                                  equil::Equilibrium.PlasmaEquilibrium, mats::MatrixSplines,
-                                  intr::ForceFreeStatesInternal,
-                                  odet_proxies::Vector{OdeState})
+    chunks::Vector{IntegrationChunk},
+    ctrl::ForceFreeStatesControl,
+    equil::Equilibrium.PlasmaEquilibrium, mats::MatrixSplines,
+    intr::ForceFreeStatesInternal,
+    odet_proxies::Vector{OdeState})
     Threads.@threads :static for i in eachindex(chunks)
         integrate_propagator_chunk!(propagators[i], chunks[i], ctrl, equil, mats, intr,
-                                    odet_proxies[Threads.threadid()])
+            odet_proxies[Threads.threadid()])
     end
 end
 
@@ -240,10 +241,10 @@ end
 # the well-conditioned Riccati S at each surface's left boundary for use as the Δ' BVP
 # axis BC. Returns (S_at_surface_left, last_crossing_step).
 function _assemble_propagators_serially!(odet::OdeState, propagators::Vector{ChunkPropagator},
-                                         chunks::Vector{IntegrationChunk},
-                                         ctrl::ForceFreeStatesControl,
-                                         equil::Equilibrium.PlasmaEquilibrium,
-                                         mats::MatrixSplines, intr::ForceFreeStatesInternal)
+    chunks::Vector{IntegrationChunk},
+    ctrl::ForceFreeStatesControl,
+    equil::Equilibrium.PlasmaEquilibrium,
+    mats::MatrixSplines, intr::ForceFreeStatesInternal)
     N = intr.numpert_total
     S_at_surface_left = Matrix{ComplexF64}[]
     last_crossing_step = 1
@@ -290,9 +291,9 @@ end
 # entry at last_crossing_step holds (U₁_new, U₂_new) from riccati_cross_ideal_singular_surf!
 # before renormalization; we renorm here to (S_new, I) as the Riccati starting state.
 function _reintegrate_outer_plasma!(odet::OdeState, last_crossing_step::Int,
-                                    ctrl::ForceFreeStatesControl,
-                                    equil::Equilibrium.PlasmaEquilibrium, mats::MatrixSplines,
-                                    intr::ForceFreeStatesInternal)
+    ctrl::ForceFreeStatesControl,
+    equil::Equilibrium.PlasmaEquilibrium, mats::MatrixSplines,
+    intr::ForceFreeStatesInternal)
     N = intr.numpert_total
     odet.u .= odet.u_store[:, :, :, last_crossing_step]
     odet.psifac = odet.psi_store[last_crossing_step]
@@ -300,7 +301,7 @@ function _reintegrate_outer_plasma!(odet::OdeState, last_crossing_step::Int,
     odet.step = last_crossing_step + 1
     renormalize_riccati_inplace!(odet.u, N)
     outer_chunk = IntegrationChunk(; psi_start=odet.psifac, psi_end=intr.psilim * (1 - eps),
-                                   needs_crossing=false, ising=0)
+        needs_crossing=false, ising=0)
     riccati_integrate_chunk!(odet, ctrl, equil, mats, intr, outer_chunk)
     # Post: odet.u is in (S, I) form; odet.step points to next empty slot.
 end
@@ -314,10 +315,10 @@ end
 # original psilim — silently shifting the outermost rational's Δ' by tens of percent.
 # Returns the (possibly truncated) chunks and propagators arrays.
 function _handle_edge_dW_scan!(odet::OdeState, chunks::Vector{IntegrationChunk},
-                               propagators::Vector{ChunkPropagator},
-                               ctrl::ForceFreeStatesControl,
-                               equil::Equilibrium.PlasmaEquilibrium, mats::MatrixSplines,
-                               intr::ForceFreeStatesInternal)
+    propagators::Vector{ChunkPropagator},
+    ctrl::ForceFreeStatesControl,
+    equil::Equilibrium.PlasmaEquilibrium, mats::MatrixSplines,
+    intr::ForceFreeStatesInternal)
     N = intr.numpert_total
     odet.step -= 1
     trim_storage!(odet)
@@ -351,22 +352,22 @@ function _handle_edge_dW_scan!(odet::OdeState, chunks::Vector{IntegrationChunk},
     end
     straddling = chunks[last_chunk_idx]
     if straddling.psi_end > peak_psi
-        new_chunk = IntegrationChunk(
-            psi_start = straddling.psi_start,
-            psi_end   = peak_psi,
-            needs_crossing = straddling.needs_crossing,
-            ising     = straddling.ising,
-            direction = straddling.direction,
+        new_chunk = IntegrationChunk(;
+            psi_start=straddling.psi_start,
+            psi_end=peak_psi,
+            needs_crossing=straddling.needs_crossing,
+            ising=straddling.ising,
+            direction=straddling.direction
         )
         chunks[last_chunk_idx] = new_chunk
         odet_proxy = OdeState(N, 1, 1, 0)
         integrate_propagator_chunk!(propagators[last_chunk_idx], new_chunk,
-                                    ctrl, equil, mats, intr, odet_proxy)
+            ctrl, equil, mats, intr, odet_proxy)
     end
     n_dropped = 0
     if last_chunk_idx < length(chunks)
         n_dropped = length(chunks) - last_chunk_idx
-        chunks      = chunks[1:last_chunk_idx]
+        chunks = chunks[1:last_chunk_idx]
         propagators = propagators[1:last_chunk_idx]
     end
     if ctrl.verbose

--- a/test/runtests_eulerlagrange.jl
+++ b/test/runtests_eulerlagrange.jl
@@ -1,4 +1,5 @@
 using TOML
+using LinearAlgebra
 
 # TODO: this helper may belong in a shared test-utilities file rather than here.
 # TODO: come up with a Gaussian reduction test that doesn't rely on external data.
@@ -327,6 +328,49 @@ end
         @test size(odet.fixfac) == (numpert_total, numpert_total, numunorms_init)
         @test length(odet.unorm) == numpert_total
         @test length(odet.unorm0) == numpert_total
+    end
+
+    @testset "interior start falls back to the fixed initialization" begin
+        FFS = GeneralizedPerturbedEquilibrium.ForceFreeStates
+        ex = joinpath(@__DIR__, "test_data", "regression_solovev_ideal_example")
+        inputs = TOML.parsefile(joinpath(ex, "gpec.toml"))
+        inputs["ForceFreeStates"]["verbose"] = false
+        function axis_state(psilow; kwargs...)
+            eq_inputs = copy(inputs["Equilibrium"])
+            eq_inputs["psilow"] = psilow
+            eq_config = GeneralizedPerturbedEquilibrium.Equilibrium.EquilibriumConfig(eq_inputs, ex)
+            equil = GeneralizedPerturbedEquilibrium.Equilibrium.setup_equilibrium(eq_config, GeneralizedPerturbedEquilibrium.Equilibrium.SolovevConfig(inputs["SOL_INPUT"]))
+            ctrl = FFS.ForceFreeStatesControl(; (Symbol(k) => v for (k, v) in inputs["ForceFreeStates"])..., kwargs...)
+            intr = FFS.ForceFreeStatesInternal(; dir_path=ex)
+            intr.nlow = ctrl.nn_low
+            intr.nhigh = ctrl.nn_high
+            intr.npert = 1
+            FFS.sing_lim!(intr, ctrl, equil)
+            FFS.sing_find!(intr, equil)
+            intr.mlow = min(intr.nlow * equil.params.qmin, 0) - 4 - ctrl.delta_mlow
+            intr.mhigh = trunc(Int, intr.nhigh * equil.params.qmax) + ctrl.delta_mhigh
+            intr.mpert = intr.mhigh - intr.mlow + 1
+            intr.numpert_total = intr.mpert * intr.npert
+            mats = FFS.build_matrix_splines(equil, intr, FFS.make_metric(equil, intr.mpert))
+            odet = FFS.OdeState(intr.numpert_total, ctrl.numsteps_init, ctrl.numunorms_init, intr.msing)
+            return odet, ctrl, mats, equil, intr
+        end
+        # Near the axis the Frobenius start gives the regular solution: U₂ = I with a nonzero U₁.
+        odet, ctrl, mats, equil, intr = axis_state(1e-4)
+        FFS.initialize_el_at_axis!(odet, ctrl, mats, equil.profiles, intr)
+        @test odet.u[:, :, 2] ≈ I
+        @test any(!iszero, odet.u[:, :, 1])
+        # An interior start switches to the fixed start (U₁ = 0, U₂ = I) and says so.
+        odet, ctrl, mats, equil, intr = axis_state(0.3)
+        @test_logs (:warn, r"fixed start") FFS.initialize_el_at_axis!(odet, ctrl, mats, equil.profiles, intr)
+        @test iszero(odet.u[:, :, 1]) && odet.u[:, :, 2] ≈ I
+        # The threshold is a control: raising it keeps the Frobenius start, and zero selects the fixed start silently.
+        odet, ctrl, mats, equil, intr = axis_state(0.3; frobenius_psi_max=0.5)
+        @test_logs FFS.initialize_el_at_axis!(odet, ctrl, mats, equil.profiles, intr)
+        @test any(!iszero, odet.u[:, :, 1])
+        odet, ctrl, mats, equil, intr = axis_state(1e-4; frobenius_psi_max=0.0)
+        @test_logs FFS.initialize_el_at_axis!(odet, ctrl, mats, equil.profiles, intr)
+        @test iszero(odet.u[:, :, 1]) && odet.u[:, :, 2] ≈ I
     end
 
     @testset "chunk_el_integration_bounds tests" begin


### PR DESCRIPTION
Found while benchmarking the original OMFIT project's error-field case against its Fortran GPEC run. That case starts the integration well inside the plasma rather than at the axis, and with both #457 and #458 applied its innermost resonant-coupling row was still 1.34× Fortran's and the total energies 3 % apart, insensitive to every resolution and tolerance knob in either code.

**Cause.** `initialize_el_at_axis!` applies the Frobenius axis start [Glasser 2016 Eq. 51] wherever the integration begins. That start is a power series about the magnetic axis; at an interior surface it is neither the axis-regular solution nor Fortran DCON's start, which is always U₁ = 0, U₂ = I (zero displacement at the first surface). The DIII-D ideal example, which matches Fortran to four digits at `psilow = 1e-4`, shows the drift directly:

| psilow | innermost coupling row, Julia/Fortran norm | lowest W_t, Julia vs Fortran |
| --- | --- | --- |
| 1e-4 | 1.000 | 1e-4 |
| 0.01 | 1.010 | 0.03 % |
| 0.03 | 1.042 | 0.1 % |
| 0.10 | 1.243 | 2.3 % |
| 0.30 | 2.140 | 7 % |
| 0.30 with the fixed start (`frobenius_psi_max = 0`) | 0.995 | 0.4 % |

On that case the fixed start takes the coupling rows to 1.0000 correlation with Fortran and every per-coil overlap to within 1 % of OMFIT.

**Change.** One control, `frobenius_psi_max` (default 0.01), bounds where the Frobenius start is used. Above it the fixed start is used and a warning says so; `0` selects the fixed start everywhere, silently. It replaces the undocumented `fixed_axis` flag (removed; no example, test or case file set it). Every example in the repo starts at or below 0.01, so nothing tracked moves; the `!` is for the interface and for interior-start runs, whose results change.

**Verification.** `test/runtests_eulerlagrange.jl` gains a Solovev testset: axis start keeps a nonzero Frobenius U₁ with U₂ = I; a start at ψ_N = 0.3 switches to U₁ = 0, U₂ = I and logs the warning; raising `frobenius_psi_max` keeps the Frobenius start; `frobenius_psi_max = 0` selects the fixed start silently even at the axis. ODE Tests 99/99.

Not touched: which start is physically right for an interior surface. The fixed start is what DCON does and what the published numbers used; the switch reproduces that and stops an axis expansion from being applied silently far from the axis.

cc @matt-pharr

## Release note

- **Audience:** users
- **Numerical impact:** interior-start runs (`psilow` or `qlow` placing the start above ψ_N = 0.01) now begin from the fixed start and change; axis-started runs are unchanged _(harness @ e93df8f0: diiid_n1 develop vs branch: 47 unchanged; the 5 N/A rows are error-field quantities the main checkout's case TOML tracks that neither ref writes)_
- **Migration:** `fixed_axis = true` becomes `frobenius_psi_max = 0`; set `frobenius_psi_max` above the start to keep the Frobenius start for an interior start

`ForceFreeStates` uses the Frobenius axis start only when the integration begins at or below the new `frobenius_psi_max` (default 0.01); an interior start uses Fortran DCON's fixed start (U₁ = 0, U₂ = I) with a warning, and `frobenius_psi_max = 0` selects it everywhere. The `fixed_axis` flag is removed.

## Regression report

```
================================================================
Case: diiid_n1 — DIII-D-like equilibrium, n=1, ideal + perturbed equilibrium
================================================================
Regression Report: diiid_n1
======================================================================================================================================
Ref 1: develop  @ 349a0c26 (2026-09-04)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 16 threads/16 BLAS
Ref 2: bugfix/forcefreestates-interior-start-initialization  @ e93df8f0 (2026-09-12)
       env: julia 1.11.7, x86_64-linux-gnu, manifest 06e27666 (pinned), 16 threads/16 BLAS
--------------------------------------------------------------------------------------------------------------------------------------
Quantity                                      develop          bugfix/forcefreestates-interior-start-initialization  Diff       Status
--------------------------------------------------------------------------------------------------------------------------------------
total energy Re(et[1])                        8.012318e-01     8.012318e-01                                          0.0e+00    OK    
total energy Im(et[1])                        4.142529e-05     4.142529e-05                                          0.0e+00    OK    
plasma energy Re(ep[1])                       -1.348486e+00    -1.348486e+00                                         0.0e+00    OK    
vacuum energy Re(ev[1])                       2.149718e+00     2.149718e+00                                          0.0e+00    OK    
vacuum matrix min eigenvalue                  1.873976e-01     1.873976e-01                                          0.0e+00    OK    
plasma energy (all)                           [35 elem]        [35 elem]                                             0.0e+00    OK    
vacuum energy (all)                           [35 elem]        [35 elem]                                             0.0e+00    OK    
total energy (all)                            [35 elem]        [35 elem]                                             0.0e+00    OK    
ODE steps (saved)                             2576             2576                                                  0.0e+00    OK    
ODE steps (total)                             4572             4572                                                  0.0e+00    OK    
q0                                            1.204212e+00     1.204212e+00                                          0.0e+00    OK    
q95                                           4.781723e+00     4.781723e+00                                          0.0e+00    OK    
beta_t                                        1.327024e-02     1.327024e-02                                          0.0e+00    OK    
beta_n                                        1.372511e+00     1.372511e+00                                          0.0e+00    OK    
internal inductance li1                       8.842392e-01     8.842392e-01                                          0.0e+00    OK    
internal inductance li2                       7.080847e-01     7.080847e-01                                          0.0e+00    OK    
internal inductance li3                       7.304433e-01     7.304433e-01                                          0.0e+00    OK    
poloidal beta betap1                          6.680744e-01     6.680744e-01                                          0.0e+00    OK    
poloidal beta betap2                          5.349834e-01     5.349834e-01                                          0.0e+00    OK    
poloidal beta betap3                          5.518761e-01     5.518761e-01                                          0.0e+00    OK    
# singular surfaces                           5                5                                                     0.0e+00    OK    
singular psi locations                        [5 elem]         [5 elem]                                              0.0e+00    OK    
singular q values                             [5 elem]         [5 elem]                                              0.0e+00    OK    
current beta betaj                            4.236478e-01     4.236478e-01                                          0.0e+00    OK    
plasma volume                                 1.829472e+01     1.829472e+01                                          0.0e+00    OK    
plasma current                                1.152130e+00     1.152130e+00                                          0.0e+00    OK    
mpert                                         35               35                                                    0.0e+00    OK    
npert                                         1                1                                                     0.0e+00    OK    
toroidal field bt0                            2.006573e+00     2.006573e+00                                          0.0e+00    OK    
wall field bwall                              3.880145e-01     3.880145e-01                                          0.0e+00    OK    
aspect ratio                                  2.845746e+00     2.845746e+00                                          0.0e+00    OK    
elongation kappa                              1.708350e+00     1.708350e+00                                          0.0e+00    OK    
q profile (checksum)                          0cd285cea88d...  0cd285cea88d...                                       identical  OK    
pressure profile (checksum)                   a1c48b266622...  a1c48b266622...                                       identical  OK    
Mercier D_I profile (checksum)                eeb06744e795...  eeb06744e795...                                       identical  OK    
resistive interchange D_R profile (checksum)  fa37296851f6...  fa37296851f6...                                       identical  OK    
ballooning Delta' profile (checksum)          bb713caf14eb...  bb713caf14eb...                                       identical  OK    
island half-widths                            [5 elem]         [5 elem]                                              0.0e+00    OK    
Chirikov parameter                            [5 elem]         [5 elem]                                              0.0e+00    OK    
||resonant area-weighted field||              5.189179e-04     5.189179e-04                                          0.0e+00    OK    
dominant-coupling singular values             N/A              N/A                                                   N/A        N/A   
|forcing overlap with dominant mode|          N/A              N/A                                                   N/A        N/A   
|delta_nominal| of coil set 1                 N/A              N/A                                                   N/A        N/A   
||ddelta/d(shift)|| over coil sets            N/A              N/A                                                   N/A        N/A   
||ddelta/d(tilt)|| over coil sets             N/A              N/A                                                   N/A        N/A   
PE plasma energy                              3.422677e+00     3.422677e+00                                          0.0e+00    OK    
PE vacuum energy                              3.174510e+00     3.174510e+00                                          0.0e+00    OK    
PE surface energy                             5.826684e+00     5.826684e+00                                          0.0e+00    OK    
```

## Notes for reviewers

- Independent of the error-field stack and of #457/#458; branched from `develop`.
- JuliaFormatter normalized `EulerLagrange.jl` and `Riccati/Driver.jl` on first touch; the substantive diff is the block in `initialize_el_at_axis!`, the two docstrings and the control fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKDmtKYDotJWrcxWf1oJu


